### PR TITLE
CMakeLists.txt: expose include directory as target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (ANDROID)
         target_link_libraries(SDL2_mixer PRIVATE timidity)
     endif()
 
-    target_include_directories(SDL2_mixer PUBLIC .)
+    target_include_directories(SDL2_mixer PUBLIC include)
     target_link_libraries(SDL2_mixer PRIVATE SDL2)
 else()
 


### PR DESCRIPTION
So that users of this target can write `#include <SDL_mixer.h>` instead of `#include <include/SDL_mixer.h>`.