### PR TITLE
Timidity: Fixed the music playing stuck after Timidity song stop

### DIFF
--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -277,7 +277,7 @@ Mix_MusicInterface Mix_MusicInterface_TIMIDITY =
     NULL,   /* GetMetaTag */
     NULL,   /* Pause */
     NULL,   /* Resume */
-    NULL,   /* Stop */
+    TIMIDITY_Stop,
     TIMIDITY_Delete,
     TIMIDITY_Close,
     NULL    /* Unload */

--- a/src/codecs/timidity/playmidi.c
+++ b/src/codecs/timidity/playmidi.c
@@ -630,6 +630,11 @@ void Timidity_Start(MidiSong *song)
   skip_to(song, 0);
 }
 
+void Timidity_Stop(MidiSong *song)
+{
+  song->playing = 0;
+}
+
 int Timidity_IsActive(MidiSong *song)
 {
   return song->playing;

--- a/src/codecs/timidity/timidity.h
+++ b/src/codecs/timidity/timidity.h
@@ -153,6 +153,7 @@ extern void Timidity_SetVolume(MidiSong *song, int volume);
 extern int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len);
 extern MidiSong *Timidity_LoadSong(SDL_RWops *rw, SDL_AudioSpec *audio);
 extern void Timidity_Start(MidiSong *song);
+extern void Timidity_Stop(MidiSong *song);
 extern void Timidity_Seek(MidiSong *song, Uint32 ms);
 extern Uint32 Timidity_GetSongLength(MidiSong *song); /* returns millseconds */
 extern Uint32 Timidity_GetSongTime(MidiSong *song);   /* returns millseconds */


### PR DESCRIPTION
When you do stop the song played by Timidity, it will still return the "is Playing = 1", which will lock the ability to start any other music playing at all. To resolve the problem I implemented the `Timidity_Stop()` call that sets the flag into zero that fixes the issue.