### PR TITLE
native_midi_macosx.c: fixed the C90 warning

### DIFF
--- a/src/codecs/native_midi/native_midi_macosx.c
+++ b/src/codecs/native_midi/native_midi_macosx.c
@@ -154,8 +154,8 @@ macosx_load_soundfont(const char *path, void *data)
                                        kAudioUnitScope_Global, 0,
                                        &ctx->default_url, sizeof(CFURLRef));
         if (err != noErr) {
-            // uh-oh, this might leave the audio unit in an unusable state
-            // (e.g. if the soundfont was an incompatible file type)
+            /* uh-oh, this might leave the audio unit in an unusable state
+               (e.g. if the soundfont was an incompatible file type) */
         }
         return SDL_FALSE;
     }


### PR DESCRIPTION
Isn't should be the debug log print here? Right now, this makes some errors when using C90 compatibility being enforced.

Replacement for #303