### PR TITLE
music_fluidsynth.c: Refactor the FLUIDSYNTH_LoadMusic() call

### DIFF
--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -128,6 +128,7 @@ static void FLUIDSYNTH_Unload()
 
 typedef struct {
     fluid_synth_t *synth;
+    fluid_settings_t *settings;
     fluid_player_t *player;
     SDL_AudioStream *stream;
     void *buffer;
@@ -171,63 +172,69 @@ static FLUIDSYNTH_Music *FLUIDSYNTH_LoadMusic(void *data)
 {
     SDL_RWops *src = (SDL_RWops *)data;
     FLUIDSYNTH_Music *music;
-    fluid_settings_t *settings;
     double samplerate; /* as set by the lib. */
+    int ret;
+    Uint8 channels = 2;
+    void *rw_mem;
+    size_t rw_size;
 
-    if ((music = SDL_calloc(1, sizeof(FLUIDSYNTH_Music)))) {
-        Uint8 channels = 2;
-        music->volume = MIX_MAX_VOLUME;
-        music->buffer_size = music_spec.samples * sizeof(Sint16) * channels;
-        if ((music->buffer = SDL_malloc((size_t)music->buffer_size))) {
-            if ((settings = fluidsynth.new_fluid_settings())) {
-                fluidsynth.fluid_settings_setnum(settings, "synth.sample-rate", (double) music_spec.freq);
-                fluidsynth.fluid_settings_getnum(settings, "synth.sample-rate", &samplerate);
-
-                if ((music->synth = fluidsynth.new_fluid_synth(settings))) {
-                    if (Mix_EachSoundFont(fluidsynth_load_soundfont, (void*) music->synth)) {
-                        if ((music->player = fluidsynth.new_fluid_player(music->synth))) {
-                            void *buffer;
-                            size_t size;
-
-                            buffer = SDL_LoadFile_RW(src, &size, SDL_FALSE);
-                            if (buffer) {
-                                if (fluidsynth.fluid_player_add_mem(music->player, buffer, size) == FLUID_OK) {
-                                    SDL_free(buffer);
-                                    if ((music->stream = SDL_NewAudioStream(AUDIO_S16SYS, channels, (int) samplerate,
-                                                          music_spec.format, music_spec.channels, music_spec.freq))) {
-                                        return music;
-                                    } else {
-                                        FLUIDSYNTH_Delete(music);
-                                        return NULL;
-                                    }
-                                } else {
-                                    Mix_SetError("FluidSynth failed to load in-memory song");
-                                }
-                                SDL_free(buffer);
-                            } else {
-                                SDL_OutOfMemory();
-                            }
-                            fluidsynth.delete_fluid_player(music->player);
-                        } else {
-                            Mix_SetError("Failed to create FluidSynth player");
-                        }
-                    }
-                    fluidsynth.delete_fluid_synth(music->synth);
-                } else {
-                    Mix_SetError("Failed to create FluidSynth synthesizer");
-                }
-                fluidsynth.delete_fluid_settings(settings);
-            } else {
-                Mix_SetError("Failed to create FluidSynth settings");
-            }
-            SDL_free(music->buffer);
-        } else {
-            SDL_OutOfMemory();
-        }
-        SDL_free(music);
-    } else {
+    if (!(music = SDL_calloc(1, sizeof(FLUIDSYNTH_Music)))) {
         SDL_OutOfMemory();
+        return NULL;
     }
+
+    music->volume = MIX_MAX_VOLUME;
+    music->buffer_size = music_spec.samples * sizeof(Sint16) * channels;
+
+    if (!(music->buffer = SDL_malloc((size_t)music->buffer_size))) {
+        SDL_OutOfMemory();
+        goto fail;
+    }
+
+    if (!(music->settings = fluidsynth.new_fluid_settings())) {
+        Mix_SetError("Failed to create FluidSynth settings");
+        goto fail;
+    }
+
+    fluidsynth.fluid_settings_setnum(music->settings, "synth.sample-rate", (double) music_spec.freq);
+    fluidsynth.fluid_settings_getnum(music->settings, "synth.sample-rate", &samplerate);
+
+    if (!(music->synth = fluidsynth.new_fluid_synth(music->settings))) {
+        Mix_SetError("Failed to create FluidSynth synthesizer");
+        goto fail;
+    }
+
+    if (!Mix_EachSoundFont(fluidsynth_load_soundfont, music->synth)) {
+        goto fail;
+    }
+
+    if (!(music->player = fluidsynth.new_fluid_player(music->synth))) {
+        Mix_SetError("Failed to create FluidSynth player");
+        goto fail;
+    }
+
+    rw_mem = SDL_LoadFile_RW(src, &rw_size, SDL_FALSE);
+    if (!rw_mem) {
+        SDL_OutOfMemory();
+        goto fail;
+    }
+
+    ret = (fluidsynth.fluid_player_add_mem(music->player, rw_mem, rw_size) == FLUID_OK);
+    SDL_free(rw_mem);
+
+    if (!ret) {
+        Mix_SetError("FluidSynth failed to load in-memory song");
+        goto fail;
+    }
+
+    if (!(music->stream = SDL_NewAudioStream(AUDIO_S16SYS, channels, (int) samplerate,
+                          music_spec.format, music_spec.channels, music_spec.freq))) {
+        goto fail;
+    }
+
+    return music;
+fail:
+    FLUIDSYNTH_Delete(music);
     return NULL;
 }
 
@@ -305,14 +312,26 @@ static void FLUIDSYNTH_Stop(void *context)
 static void FLUIDSYNTH_Delete(void *context)
 {
     FLUIDSYNTH_Music *music = (FLUIDSYNTH_Music *)context;
-    fluid_settings_t *settings = fluidsynth.fluid_synth_get_settings(music->synth);
-    fluidsynth.delete_fluid_player(music->player);
-    fluidsynth.delete_fluid_synth(music->synth);
-    fluidsynth.delete_fluid_settings(settings);
+
+    if (music->player) {
+        fluidsynth.delete_fluid_player(music->player);
+    }
+
+    if (music->synth) {
+        fluidsynth.delete_fluid_synth(music->synth);
+    }
+
+    if (music->settings) {
+        fluidsynth.delete_fluid_settings(music->settings);
+    }
+
     if (music->stream) {
         SDL_FreeAudioStream(music->stream);
     }
-    SDL_free(music->buffer);
+
+    if (music->buffer) {
+        SDL_free(music->buffer);
+    }
     SDL_free(music);
 }
 


### PR DESCRIPTION
The original code of the FLUIDSYNTH_LoadMusic() looks like the scaring lasagna with the bad visuality which is a source of various memory leak errors caused by the human factor.

I made it look better and move all clean-up into the `FLUIDSYNTH_Delete()` by adding all checks for every stage in the middle.

--- 
P.S. In addition I want to allow the FluidSynth to work with the Float32 format too (it can!) (when the Mixer was open with the AUDIO_F32-like format). This should avoid clipping when using the AUDIO_S16 as a source format. I'll make this change as a separate pull request which will depend on this.