### PR TITLE
build: Fix parallel make with slibtool.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -47,7 +47,7 @@ LT_RELEASE  = @LT_RELEASE@
 LT_REVISION = @LT_REVISION@
 LT_LDFLAGS  = -no-undefined -rpath $(libdir) -release $(LT_RELEASE) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
-all: $(srcdir)/configure Makefile $(objects) $(objects)/$(TARGET) $(objects)/playwave$(EXE) $(objects)/playmus$(EXE)
+all: $(srcdir)/configure Makefile $(objects)/$(TARGET) $(objects)/playwave$(EXE) $(objects)/playmus$(EXE)
 
 $(srcdir)/configure: $(srcdir)/configure.ac
 	@echo "Warning, configure is out of date, please re-run autogen.sh"
@@ -55,8 +55,9 @@ $(srcdir)/configure: $(srcdir)/configure.ac
 Makefile: $(srcdir)/Makefile.in
 	$(SHELL) config.status $@
 
-$(objects):
-	$(SHELL) $(auxdir)/mkinstalldirs $@
+$(objects)/.created:
+	$(SHELL) $(auxdir)/mkinstalldirs $(objects)
+	touch $@
 
 .PHONY: all install install-hdrs install-lib install-bin uninstall uninstall-hdrs uninstall-lib uninstall-bin clean distclean dist
 
@@ -78,7 +79,7 @@ install-hdrs:
 	done
 	$(SHELL) $(auxdir)/mkinstalldirs $(libdir)/pkgconfig
 	$(INSTALL) -m 644 SDL_mixer.pc $(libdir)/pkgconfig/
-install-lib: $(objects) $(objects)/$(TARGET)
+install-lib: $(objects)/$(TARGET)
 	$(SHELL) $(auxdir)/mkinstalldirs $(libdir)
 	$(LIBTOOL) --mode=install $(INSTALL) $(objects)/$(TARGET) $(libdir)/$(TARGET)
 install-bin:

--- a/configure.ac
+++ b/configure.ac
@@ -626,14 +626,14 @@ OBJECTS=`echo $SOURCES`
 DEPENDS=`echo $SOURCES`
 OBJECTS=`echo "$OBJECTS" | sed 's,[[^ ]]*/\([[^ ]]*\)\.c,$(objects)/\1.lo,g'`
 DEPENDS=`echo "$DEPENDS" | sed 's,\([[^ ]]*\)/\([[^ ]]*\)\.c,\\
-$(objects)/\2.lo: \1/\2.c\\
+$(objects)/\2.lo: \1/\2.c \$(objects)/.created\\
 	\$(LIBTOOL) --mode=compile \$(CC) \$(CFLAGS) \$(EXTRA_CFLAGS) '"$DEPENDENCY_TRACKING_OPTIONS"' -c \$< -o \$@,g'`
 
 OBJECTS_CXX=`echo $SOURCES_CXX`
 DEPENDS_CXX=`echo $SOURCES_CXX`
 OBJECTS_CXX=`echo "$OBJECTS_CXX" | sed 's,[[^ ]]*/\([[^ ]]*\)\.cpp,$(objects)/\1.lo,g'`
 DEPENDS_CXX=`echo "$DEPENDS_CXX" | sed 's,\([[^ ]]*\)/\([[^ ]]*\)\.cpp,\\
-$(objects)/\2.lo: \1/\2.cpp\\
+$(objects)/\2.lo: \1/\2.cpp \$(objects)/.created\\
 	\$(LIBTOOL) --mode=compile \$(CXX) \$(CFLAGS) \$(EXTRA_CFLAGS) '"$DEPENDENCY_TRACKING_OPTIONS"' -c \$< -o \$@,g'`
 OBJECTS="$OBJECTS $OBJECTS_CXX"
 DEPENDS="$DEPENDS $DEPENDS_CXX"
@@ -643,7 +643,7 @@ VERSION_OBJECTS=`echo $VERSION_SOURCES`
 VERSION_DEPENDS=`echo $VERSION_SOURCES`
 VERSION_OBJECTS=`echo "$VERSION_OBJECTS" | sed 's,[[^ ]]*/\([[^ ]]*\)\.rc,$(objects)/\1.o,g'`
 VERSION_DEPENDS=`echo "$VERSION_DEPENDS" | sed 's,\([[^ ]]*\)/\([[^ ]]*\)\.rc,\\
-$(objects)/\2.o: \1/\2.rc\\
+$(objects)/\2.o: \1/\2.rc \$(objects)/.created\\
 	\$(WINDRES) \$< \$@,g'`
 VERSION_DEPENDS=`echo "$VERSION_DEPENDS" | sed 's,\\$,\\\\$,g'`
 
@@ -652,7 +652,7 @@ PLAYWAVE_OBJECTS=`echo $PLAYWAVE_SOURCES`
 PLAYWAVE_DEPENDS=`echo $PLAYWAVE_SOURCES`
 PLAYWAVE_OBJECTS=`echo "$PLAYWAVE_OBJECTS" | sed 's,[[^ ]]*/\([[^ ]]*\)\.c,$(objects)/\1.lo,g'`
 PLAYWAVE_DEPENDS=`echo "$PLAYWAVE_DEPENDS" | sed 's,\([[^ ]]*\)/\([[^ ]]*\)\.c,\\
-$(objects)/\2.lo: \1/\2.c\\
+$(objects)/\2.lo: \1/\2.c \$(objects)/.created\\
 	\$(LIBTOOL) --mode=compile \$(CC) \$(CFLAGS) \$(EXTRA_CFLAGS) '"$DEPENDENCY_TRACKING_OPTIONS"' -c \$< -o \$@,g'`
 PLAYWAVE_DEPENDS=`echo "$PLAYWAVE_DEPENDS" | sed 's,\\$,\\\\$,g'`
 
@@ -661,7 +661,7 @@ PLAYMUS_OBJECTS=`echo $PLAYMUS_SOURCES`
 PLAYMUS_DEPENDS=`echo $PLAYMUS_SOURCES`
 PLAYMUS_OBJECTS=`echo "$PLAYMUS_OBJECTS" | sed 's,[[^ ]]*/\([[^ ]]*\)\.c,$(objects)/\1.lo,g'`
 PLAYMUS_DEPENDS=`echo "$PLAYMUS_DEPENDS" | sed 's,\([[^ ]]*\)/\([[^ ]]*\)\.c,\\
-$(objects)/\2.lo: \1/\2.c\\
+$(objects)/\2.lo: \1/\2.c \$(objects)/.created\\
 	\$(LIBTOOL) --mode=compile \$(CC) \$(CFLAGS) \$(EXTRA_CFLAGS) '"$DEPENDENCY_TRACKING_OPTIONS"' -c \$< -o \$@,g'`
 PLAYMUS_DEPENDS=`echo "$PLAYMUS_DEPENDS" | sed 's,\\$,\\\\$,g'`
 


### PR DESCRIPTION
When building SDL1-mixer with slibtool and parallel make (`-j2` or greater) it fails when slibtool if faster than `mkinstalldirs` while GNU libtool is slower and just happens to work. This can be fixed by making an explicit dependency on a sentinel file created in the build directory. This has already been fixed in SDL2-mixer.
```
rlibtool: error logged in slbt_exec_compile(), line 158: path not found: build/.libs/.
make: *** [Makefile:137: build/effect_position.lo] Error 2
make: *** Waiting for unfinished jobs....
mkdir -p -- build
```

Also see:

https://github.com/libsdl-org/SDL_mixer/commit/b432a23ac02ef83e9114f70e81738b30c0853cf9
https://github.com/libsdl-org/SDL/commit/39e8e3951cff8a6f6c284c1dcd0e3e5d66438f81
https://github.com/libsdl-org/SDL-1.2/pull/840