### PR TITLE
configure.ac: fix static linking with tremor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -530,7 +530,7 @@ if test x$enable_music_ogg = xyes; then
                 echo "-- dynamic libvorbisidec -> $ogg_lib"
                 EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
             else
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lvorbisidec -lvorbis"
+                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lvorbisidec"
             fi
         else
             AC_MSG_WARN([*** Unable to find Ogg Vorbis Tremor library (http://www.xiph.org/)])


### PR DESCRIPTION
Fix the following build failure when building statically with --enable-music-ogg-tremor:

```
libtool: link: /tmp/instance-0/output-1/host/bin/arm-linux-gcc -o build/playwave build/playwave.o -I/tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -static  -L/tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib build/.libs/libSDL_mixer.a -L/tmp/instance-0/output-1/host/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib /tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libSDL.a /tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libasound.a -lrt -ldl /tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libts.a -lpthread /tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libvorbisidec.a /tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libogg.a -lvorbis /tmp/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libmad.a -lm
/tmp/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: cannot find -lvorbis
```

Fixes:
 - http://autobuild.buildroot.org/results/9634adc433da0e25732eb98675c59d0f96ac93b2

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>