### PR TITLE
Add 'Libs.private' field to pkg-config file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,7 +61,7 @@ $(objects)/.created:
 .PHONY: all install install-hdrs install-lib install-bin uninstall uninstall-hdrs uninstall-lib uninstall-bin clean distclean dist
 
 $(objects)/$(TARGET): $(OBJECTS) $(VERSION_OBJECTS)
-	$(LIBTOOL) --mode=link $(CC) -o $@ $(OBJECTS) $(VERSION_OBJECTS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
+	$(LIBTOOL) --mode=link $(CC) -o $@ $(OBJECTS) $(VERSION_OBJECTS) $(LDFLAGS) $(SDL_LIBS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
 
 $(objects)/playwave$(EXE): $(objects)/playwave.lo $(objects)/$(TARGET)
 	$(LIBTOOL) --mode=link $(CC) -o $@ $(objects)/playwave.lo $(SDL_CFLAGS) $(objects)/$(TARGET) $(SDL_LIBS) $(LDFLAGS)

--- a/SDL2_mixer.pc.in
+++ b/SDL2_mixer.pc.in
@@ -8,5 +8,6 @@ Description: mixer library for Simple DirectMedia Layer
 Version: @VERSION@
 Requires: sdl2 >= @SDL_VERSION@
 Libs: -L${libdir} -lSDL2_mixer
+Libs.private: @EXTRA_LDFLAGS@
 Cflags: -I${includedir}/SDL2
 

--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,6 @@ AM_PATH_SDL2($SDL_VERSION,
             AC_MSG_ERROR([*** SDL version $SDL_VERSION not found!])
 )
 EXTRA_CFLAGS="$EXTRA_CFLAGS $SDL_CFLAGS"
-EXTRA_LDFLAGS="$EXTRA_LDFLAGS $SDL_LIBS"
 
 dnl Check for math library
 AC_CHECK_LIB(m, pow, [LIBM="-lm"])


### PR DESCRIPTION
In order to support static linking, SDL_mixer.pc should include a
'Libs.private' field listing all the libraries that SDL_mixer requires.

This patch adds such a field and also modifies configure.ac so that
EXTRA_LDFLAGS (which is now also used as the value of 'Libs.private')
no longer includes SDL_LIBS. This is done so as to prevent libraries
required by SDL from being listed twice when 'pkg-config --libs --static
SDL_mixer' is run (they're already shown because of the 'Requires: sdl'
line in SDL_mixer.pc). Makefile.in is also adjusted accordingly.

Upstream status: submitted
https://bugzilla.libsdl.org/show_bug.cgi?id=3278

Signed-off-by: Rodrigo Rebello <rprebello@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/sdl_mixer/0001-Add-Libs.private-field-to-pkg-config-file.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>