### PR TITLE
Add a NULL-Check to Mix_VolumeChunk()

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -1083,9 +1083,11 @@ int Mix_Volume(int which, int volume)
 /* Set volume of a particular chunk */
 int Mix_VolumeChunk(Mix_Chunk *chunk, int volume)
 {
-    int prev_volume;
-
-    prev_volume = chunk->volume;
+    if (chunk == NULL) {
+        return(-1);
+    }
+  
+    int prev_volume = chunk->volume;
     if (volume >= 0) {
         if (volume > MIX_MAX_VOLUME) {
             volume = MIX_MAX_VOLUME;


### PR DESCRIPTION
`Mix_VolumeChunk()` doesn't check if the chunk passed to it is NULL. If that happens, a crash with a segfault will follow.
Would returning `-1` as a value for the previous volume be acceptable?