### PR TITLE
Add github Action and fix CMake build fail

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,71 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - "*"
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build-cmake:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ["gcc", "clang"]
+        shared: [YES, NO]
+        build_type: [Release]
+
+    steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install ninja-build libsdl2-dev
+
+      - name: Configure CMake
+        env:
+          CC: ${{matrix.compiler}}
+        run: |
+          cmake -S . -B build -D CMAKE_BUILD_TYPE=${{matrix.build_type}} \
+                -G Ninja -D BUILD_SHARED_LIBS=${{matrix.shared}}
+
+      - name: Build CMake
+        run: ninja -C build
+  build-make:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ["gcc", "clang"]
+
+    steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install libsdl2-dev
+
+      - name: Configure make
+        env:
+          CC: ${{matrix.compiler}}
+        run: |
+          ./configure
+
+      - name: Build make
+        run: make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.0)
 project(SDL_mixer C)
 
 # FIXME: make it able build against system codec libraries, too.
@@ -14,9 +14,14 @@ option(SUPPORT_MP3_MPG123 "Support loading MP3 music via MPG123" OFF)
 option(SUPPORT_MOD_MODPLUG "Support loading MOD music via modplug" OFF)
 option(SUPPORT_MID_TIMIDITY "Support TiMidity" OFF)
 
+option(BUILD_SHARED_LIBS "Enable shared library" ON)
+
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIR})
+
 include_directories(include src src/codecs)
 
-add_library(SDL2_mixer SHARED)
+add_library(SDL2_mixer)
 
 target_sources(SDL2_mixer PRIVATE
         src/effect_position.c src/effects_internal.c src/effect_stereoreverse.c
@@ -64,5 +69,5 @@ if (SUPPORT_MID_TIMIDITY)
 endif()
 
 target_include_directories(SDL2_mixer PUBLIC include)
-target_link_libraries(SDL2_mixer PRIVATE SDL2)
+target_link_libraries(SDL2_mixer PRIVATE ${SDL2_LIBRARIES} ${SDL2_LIBRARY})
 


### PR DESCRIPTION
**Add github Action and fix CMake build fail.**

Tested with manjaro 21.1.6 and [github action](https://github.com/bensuperpc/SDL_mixer/actions/runs/1454991608) (**Ubuntu CI**) in my git repository.

Github action:
- Build with CMake (**Release** mode) and make
- Build With GCC 9 and Clang 10 (ubuntu-latest = ubuntu-20.04 now)
- Build with static or shared lib (CMake only)

Fix wrong header path with SDL2 and bump CMake to 3.0.0 (#314)

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>