### PR TITLE
resolve -Wmissing-field-initializers warnings

### DIFF
--- a/src/codecs/music_mpg123.c
+++ b/src/codecs/music_mpg123.c
@@ -62,7 +62,11 @@ typedef struct {
 } mpg123_loader;
 
 static mpg123_loader mpg123 = {
-    0, NULL
+    0, NULL,
+    NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL
 };
 
 #ifdef MPG123_DYNAMIC

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -62,7 +62,10 @@ typedef struct {
 } vorbis_loader;
 
 static vorbis_loader vorbis = {
-    0, NULL
+    0, NULL,
+    NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL,
+    NULL
 };
 
 #ifdef OGG_DYNAMIC


### PR DESCRIPTION
fixes:
src/codecs/music_mpg123.c:66:1: warning: missing field 'mpg123_close' initializer [-Wmissing-field-initializers]
src/codecs/music_ogg.c:66:1: warning: missing field 'ov_clear' initializer [-Wmissing-field-initializers]