### PR TITLE
mixer.c: Fixed the crash at the Mix_LoadMusic_RW

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -636,7 +636,7 @@ static SDL_AudioSpec *Mix_LoadMusic_RW(SDL_RWops *src, int freesrc, SDL_AudioSpe
     Mix_UnlockAudio();
 
     if (count > 0) {
-        *audio_len = (count - 1) * fragment_size + fragment->size;
+        *audio_len = (count - 1) * fragment_size + last->size;
         *audio_buf = (Uint8 *)SDL_malloc(*audio_len);
         if (*audio_buf) {
             Uint8 *dst = *audio_buf;


### PR DESCRIPTION
I found this crash case a while ago at MixerX. It happen because the "fragment" wasn't properly updated and left being NULL. That leads an attempt to dereferrence it while it has NULL inside.