### PR TITLE
Remove all initializers from static loader arrays

### DIFF
--- a/src/codecs/music_flac.c
+++ b/src/codecs/music_flac.c
@@ -69,9 +69,7 @@ typedef struct {
                         FLAC__MetadataType type);
 } flac_loader;
 
-static flac_loader flac = {
-    0, NULL
-};
+static flac_loader flac;
 
 #ifdef FLAC_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \

--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -62,9 +62,7 @@ typedef struct {
     fluid_synth_t* (*new_fluid_synth)(fluid_settings_t*);
 } fluidsynth_loader;
 
-static fluidsynth_loader fluidsynth = {
-    0, NULL
-};
+static fluidsynth_loader fluidsynth;
 
 #ifdef FLUIDSYNTH_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \

--- a/src/codecs/music_mikmod.c
+++ b/src/codecs/music_mikmod.c
@@ -69,9 +69,7 @@ typedef struct {
     UBYTE* md_volume;
 } mikmod_loader;
 
-static mikmod_loader mikmod = {
-    0, NULL
-};
+static mikmod_loader mikmod;
 
 #ifdef MIKMOD_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -47,10 +47,7 @@ typedef struct {
     const char* (*ModPlug_GetName)(ModPlugFile* file);
 } modplug_loader;
 
-static modplug_loader modplug = {
-    0, NULL
-};
-
+static modplug_loader modplug;
 
 static ModPlug_Settings settings;
 

--- a/src/codecs/music_mpg123.c
+++ b/src/codecs/music_mpg123.c
@@ -61,13 +61,7 @@ typedef struct {
     const char* (*mpg123_strerror)(mpg123_handle *mh);
 } mpg123_loader;
 
-static mpg123_loader mpg123 = {
-    0, NULL,
-    NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL
-};
+static mpg123_loader mpg123;
 
 #ifdef MPG123_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -61,12 +61,7 @@ typedef struct {
     ogg_int64_t (*ov_pcm_tell)(OggVorbis_File *vf);
 } vorbis_loader;
 
-static vorbis_loader vorbis = {
-    0, NULL,
-    NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL,
-    NULL
-};
+static vorbis_loader vorbis;
 
 #ifdef OGG_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \

--- a/src/codecs/music_opus.c
+++ b/src/codecs/music_opus.c
@@ -48,9 +48,7 @@ typedef struct {
     ogg_int64_t (*op_pcm_total)(const OggOpusFile *, int);
 } opus_loader;
 
-static opus_loader opus = {
-    0, NULL
-};
+static opus_loader opus;
 
 #ifdef OPUS_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \

--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -56,9 +56,7 @@ typedef struct {
     void (*xmp_free_context)(xmp_context);
 } xmp_loader;
 
-static xmp_loader libxmp = {
-    0, NULL
-};
+static xmp_loader libxmp;
 
 #ifdef XMP_DYNAMIC
 #define FUNCTION_LOADER(FUNC, SIG) \


### PR DESCRIPTION
Addition to https://github.com/libsdl-org/SDL_mixer/commit/143b0bbfd50654af667c87143c1a2d69ef80f151

EDIT: As was discussed below, I changed the entire goal of this PR:
----
C standard gives guarantee they will be NULLed by default:
https://port70.net/~nsz/c/c89/c89-draft.html#3.5.7

> If an object that has static storage duration is not initialized explicitly, it is initialized implicitly as if every member that has arithmetic type were assigned 0 and every member that has pointer type were assigned a null pointer constant. If an object that has automatic storage duration is not initialized explicitly, its value is indeterminate.