### PR TITLE
music_xmp.c: Fixed the correctness of meta-tags

### DIFF
--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -219,8 +219,13 @@ void *XMP_CreateFromRW(SDL_RWops *src, int freesrc)
 
     meta_tags_init(&music->tags);
     libxmp.xmp_get_module_info(music->ctx, &music->mi);
+
+    if (music->mi.mod->name[0]) {
+        meta_tags_set(&music->tags, MIX_META_TITLE, music->mi.mod->name);
+    }
+
     if (music->mi.comment) {
-        meta_tags_set(&music->tags, MIX_META_TITLE, music->mi.comment);
+        meta_tags_set(&music->tags, MIX_META_COPYRIGHT, music->mi.comment);
     }
 
     if (freesrc) {


### PR DESCRIPTION
To get the proper title of the song, it should be taken from another place. The field was actually taken is a copyright field.