### PR TITLE
Update Mix_Init() return value to match documentation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 2.0.5:
+Nate Houghton - Fri Dec 31 22:33:21 2021
+ * Update Mix_Init() return value to match documentation, including
+   MIXER_INIT_* flags for already-initialized modules
 Ozkan Sezer - Sun Feb 07 03:10:10 2021
  * fixed distorted MIDI playback with FluidSynth if the sample rate
    is out of library's limits

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -140,9 +140,53 @@ const SDL_version *Mix_Linked_Version(void)
     return(&linked_version);
 }
 
+/*
+ * Returns a bitmap of already loaded modules (MIX_INIT_* flags).
+ *
+ * Note that functions other than Mix_Init() may cause a module to get loaded
+ * (hence the looping over the interfaces instead of maintaining a set of flags
+ * just in Mix_Init() and Mix_Quit()).
+ */
+static int get_loaded_mix_init_flags(void)
+{
+    int i;
+    int loaded_init_flags = 0;
+
+    for (i = 0; i < get_num_music_interfaces(); ++i) {
+        Mix_MusicInterface *interface;
+
+        interface = get_music_interface(i);
+        if (interface->loaded) {
+            switch (interface->type) {
+            case MUS_FLAC:
+                loaded_init_flags |= MIX_INIT_FLAC;
+                break;
+            case MUS_MOD:
+                loaded_init_flags |= MIX_INIT_MOD;
+                break;
+            case MUS_MP3:
+                loaded_init_flags |= MIX_INIT_MP3;
+                break;
+            case MUS_OGG:
+                loaded_init_flags |= MIX_INIT_OGG;
+                break;
+            case MUS_MID:
+                loaded_init_flags |= MIX_INIT_MID;
+                break;
+            case MUS_OPUS:
+                loaded_init_flags |= MIX_INIT_OPUS;
+                break;
+            }
+        }
+    }
+
+    return loaded_init_flags;
+}
+
 int Mix_Init(int flags)
 {
     int result = 0;
+    int already_loaded = get_loaded_mix_init_flags();
 
     if (flags & MIX_INIT_FLAC) {
         if (load_music_type(MUS_FLAC)) {
@@ -192,6 +236,8 @@ int Mix_Init(int flags)
             Mix_SetError("MIDI support not available");
         }
     }
+    result |= already_loaded;
+
     return result;
 }
 


### PR DESCRIPTION
Update `Mix_Init()` to return all the initialized sample/music loaders as mentioned here:

https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_9.html

```
Returns: a bitmask of all the currently initted sample/music loaders. 
```

Note that the same page mentions:

```
You may call this multiple times, which will actually require you to call
Mix_Quit just once to clean up.
```

The above statement seems to match the implementation.

However, the `Mix_Quit()` [documentation page](https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_10.html#SEC10) seems to be conflict with the `Mix_Init()` documentation:

```
You should call this function for each time Mix_Init was called, otherwise it
may not free all the dynamic library resources until the program ends. This is
done so that multiple unrelated modules of a program may call Mix_Init and
Mix_Quit without affecting the others performance and needs.
```

As far as I can tell, `unload_music()` called by `Mix_Quit()` guarantees every loaded module is unloaded. I think this is guaranteed because `load_music_type()` will not "double load" a module (`load_music_type()` checks `interface->loaded` before calling `interface->Load`, so multiple calls to `load_music_type()` with the same music type will not cause the underlying `Load()` function to get called multiple times). I saw that the individual codecs (src/codecs/music_*.c) had a reference counting scheme inside Load() and Unload(), but due to the check mentioned earlier, I didn't think the reference count would ever go beyond 1. Am I missing any use case / scenario?

One interesting side effect of `Mix_Init(0)` not returning the already initialized flags is that a construct such as the one below (from the old docs page, and seen in a few different projects on github):

```c
// force a quit
while(Mix_Init(0))
    Mix_Quit();
```

would end up never calling `Mix_Quit()`, since if the input flags to `Mix_Init()` are 0, the result is always 0 in the current release. Probably this is not a big deal in most cases, as it just delays some resource cleanup... A large number of projects also just call `Mix_Quit()` directly a single time, which would be unaffected by this bug.

I asked @icculus on this [discussion thread](https://discourse.libsdl.org/t/wiki-libsdl-org-migration/31085) if the SDL2_image and SDL2_mixer documentation would also get added to the new wiki. If so maybe we can update the documentation for these two functions (I could help do this and get it reviewed by you all).