### PR TITLE
Include version.rc in Windows CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   target_compile_definitions(SDL2_mixer PRIVATE -DDLL_EXPORT)
+  target_sources(SDL2_mixer PRIVATE version.rc)
 endif()
 
 target_include_directories(SDL2_mixer PUBLIC include)


### PR DESCRIPTION
SDL2_mixer.dll doesn't have any version information when built with CMake because version.rc wasn't included as a source file.