### PR TITLE
Compilation fix for OS X/PowerPC

### DIFF
--- a/native_midi/native_midi_macosx.c
+++ b/native_midi/native_midi_macosx.c
@@ -201,7 +201,7 @@ NativeMidiSong *native_midi_loadsong_RW(SDL_RWops *rw, int freerw)
      * So, we use MusicSequenceLoadSMFData() for powerpc versions
      * but the *WithFlags() on intel which require 10.4 anyway. */
     # if defined(__ppc__) || defined(__POWERPC__)
-    if (MusicSequenceLoadSMFData(song->sequence, data) != noErr)
+    if (MusicSequenceLoadSMFData(retval->sequence, data) != noErr)
         goto fail;
     # else
     if (MusicSequenceLoadSMFDataWithFlags(retval->sequence, data, 0) != noErr)


### PR DESCRIPTION
This PR fixes a compilation error on OS X Tiger (PowerPC).

Based on the surrounding code, I'd say it is likely that someone refactored `song->` to `retval->` but forgot to update the PowerPC case to match, but didn't encounter the build failure because they weren't on a PowerPC machine.