### PR TITLE
music_ogg: fix sdl_seek_func() return value (SDL-1.2)

### DIFF
--- a/music_ogg.c
+++ b/music_ogg.c
@@ -56,7 +56,7 @@ static size_t sdl_read_func(void *ptr, size_t size, size_t nmemb, void *datasour
 
 static int sdl_seek_func(void *datasource, ogg_int64_t offset, int whence)
 {
-    return SDL_RWseek((SDL_RWops*)datasource, (int)offset, whence);
+    return (SDL_RWseek((SDL_RWops*)datasource, (int)offset, whence) < 0)? -1 : 0;
 }
 
 static long sdl_tell_func(void *datasource)


### PR DESCRIPTION
SDL_RWseek(), in both SDL-1.2 and SDL-2.0, returns the current offset upon
success and not NOERROR (0), therefore it behaves like `lseek`, not `fseek`
which vorbis expects. The current version seems to have worked so far by
luck.

CC: @Wohlstand
