### PR TITLE
Fix enabling external libraries with CMake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,8 @@ jobs:
           pkg-config \
           ${NULL+}
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Check that versioning is consistent
       # We only need to run this once: arbitrarily use the Linux/CMake build
       if: "runner.os == 'Linux' && matrix.platform.cmake"
@@ -70,6 +72,10 @@ jobs:
         cmake -B build \
           -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DSUPPORT_FLAC=ON \
+          -DSUPPORT_OGG=ON \
+          -DSUPPORT_MP3_MPG123=ON \
+          -DSUPPORT_MOD_MODPLUG=ON \
           ${{ matrix.platform.cmake }}
     - name: Build
       if: "matrix.platform.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,10 @@ if (SUPPORT_WAV)
     target_compile_definitions(SDL2_mixer PRIVATE -DMUSIC_WAV)
 endif()
 
+if (SUPPORT_OGG OR SUPPORT_FLAC)
+    add_subdirectory(external/ogg)
+endif()
+
 if (SUPPORT_FLAC)
     target_compile_definitions(SDL2_mixer PRIVATE -DMUSIC_FLAC)
     add_subdirectory(external/flac)
@@ -134,7 +138,6 @@ endif()
 
 if (SUPPORT_OGG)
     target_compile_definitions(SDL2_mixer PRIVATE -DMUSIC_OGG -DOGG_USE_TREMOR -DOGG_HEADER=<ivorbisfile.h>)
-    add_subdirectory(external/ogg)
     add_subdirectory(external/tremor)
     target_include_directories(SDL2_mixer PRIVATE external/tremor)
     target_link_libraries(SDL2_mixer PRIVATE vorbisidec ogg)

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -25,7 +25,11 @@
 
 #include "music_modplug.h"
 
+#ifdef MODPLUG_HEADER
+#include MODPLUG_HEADER
+#else
 #include <libmodplug/modplug.h>
+#endif
 
 typedef struct {
     int loaded;

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -29,7 +29,9 @@
 #include "utils.h"
 
 #define OV_EXCLUDE_STATIC_CALLBACKS
-#if defined(OGG_USE_TREMOR)
+#if defined(OGG_HEADER)
+#include OGG_HEADER
+#elif defined(OGG_USE_TREMOR)
 #include <tremor/ivorbisfile.h>
 #else
 #include <vorbis/vorbisfile.h>


### PR DESCRIPTION
Requires libsdl-org/tremor#1.