### PR TITLE
cmake: fixed the use of SDL_mixer with disabled BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(SUPPORT_MID_TIMIDITY "Support loading MIDI music via TiMidity" ON)
 
 option(BUILD_SHARED_LIBS "Enable shared library" ON)
 
-if (NOT ANDROID AND NOT (TARGET SDL2 OR TARGET SDL2-static))
+if (NOT (TARGET SDL2::SDL2 OR TARGET SDL2::SDL2-static))
     find_package(SDL2 REQUIRED)
     if(NOT TARGET SDL2::SDL2)
         # SDL < 2.0.12
@@ -166,4 +166,9 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 target_include_directories(SDL2_mixer PUBLIC include)
-target_link_libraries(SDL2_mixer PRIVATE SDL2::SDL2)
+
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(SDL2_mixer PRIVATE SDL2::SDL2)
+else()
+  target_link_libraries(SDL2_mixer PRIVATE SDL2::SDL2-static)
+endif()


### PR DESCRIPTION
- Fixed using SDL_mixer as subproject with cmake's add_subdirectory with disabled BUILD_SHARED_LIBS
- Removed checks for ANDROID when detecting SDL2 or SDL2-static

From now we can use SDL_mixer with cmake in this way:
```
option(BUILD_SHARED_LIBS "Build the library as a shared library" OFF)
option(BUILD_SAMPLES "Build the sample program(s)" OFF)
option(SDL_STATIC_PIC "Static version of the library should be built with Position Independent Code" ON) #for x86_64 Android build

add_subdirectory(external/SDL)
add_subdirectory(external/SDL_mixer)
add_subdirectory(path_to_your_project)
```