### PR TITLE
Implemented the master volume feature.

### DIFF
--- a/include/SDL_mixer.h
+++ b/include/SDL_mixer.h
@@ -590,6 +590,12 @@ extern DECLSPEC int SDLCALL Mix_VolumeMusic(int volume);
 /* Get the current volume value in the range of 0-128 of a music stream */
 extern DECLSPEC int SDLCALL Mix_GetMusicVolume(Mix_Music *music);
 
+/* Set the master volume.
+   This did not affect the member variables of music, channel or chunck volume.
+   If the specified volume is -1, just return the current master volume.
+*/
+extern DECLSPEC int SDLCALL Mix_MasterVolume(int volume);
+
 /* Halt playing of a particular channel */
 extern DECLSPEC int SDLCALL Mix_HaltChannel(int channel);
 extern DECLSPEC int SDLCALL Mix_HaltGroup(int tag);

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -110,6 +110,7 @@ static void *music_data = NULL;
 static const char **chunk_decoders = NULL;
 static int num_decoders = 0;
 
+static int master_volume = MIX_MAX_VOLUME;
 
 int Mix_GetNumChunkDecoders(void)
 {
@@ -277,7 +278,7 @@ static void SDLCALL
 mix_channels(void *udata, Uint8 *stream, int len)
 {
     Uint8 *mix_input;
-    int i, mixable, volume = MIX_MAX_VOLUME;
+    int i, mixable, volume = master_volume = Mix_MasterVolume(-1);
     Uint32 sdl_ticks;
 
     (void)udata;
@@ -326,7 +327,7 @@ mix_channels(void *udata, Uint8 *stream, int len)
                 int remaining = len;
                 while (mix_channel[i].playing > 0 && index < len) {
                     remaining = len - index;
-                    volume = (mix_channel[i].volume*mix_channel[i].chunk->volume) / MIX_MAX_VOLUME;
+                    volume = (master_volume * (mix_channel[i].volume * mix_channel[i].chunk->volume)) / (MIX_MAX_VOLUME * MIX_MAX_VOLUME);
                     mixable = mix_channel[i].playing;
                     if (mixable > remaining) {
                         mixable = remaining;
@@ -1638,6 +1639,21 @@ void Mix_LockAudio(void)
 void Mix_UnlockAudio(void)
 {
     SDL_UnlockAudioDevice(audio_device);
+}
+
+int Mix_MasterVolume(int volume)
+{
+    int prev_volume;
+
+    prev_volume = master_volume;
+    if (volume < 0) {
+        return prev_volume;
+    }
+    if (volume > SDL_MIX_MAXVOLUME) {
+        volume = SDL_MIX_MAXVOLUME;
+    }
+    master_volume = volume;
+    return(prev_volume);
 }
 
 /* end of mixer.c ... */

--- a/src/music.c
+++ b/src/music.c
@@ -316,14 +316,14 @@ void SDLCALL music_mixer(void *udata, Uint8 *stream, int len)
         /* Handle fading */
         if (music_playing->fading != MIX_NO_FADING) {
             if (music_playing->fade_step++ < music_playing->fade_steps) {
-                int volume;
+                int volume = Mix_MasterVolume(-1);
                 int fade_step = music_playing->fade_step;
                 int fade_steps = music_playing->fade_steps;
 
                 if (music_playing->fading == MIX_FADING_OUT) {
-                    volume = (music_volume * (fade_steps-fade_step)) / fade_steps;
+                    volume = (volume * (music_volume * (fade_steps-fade_step))) / (fade_steps * MIX_MAX_VOLUME);
                 } else { /* Fading in */
-                    volume = (music_volume * fade_step) / fade_steps;
+                    volume = (volume * (music_volume * fade_step)) / (fade_steps * MIX_MAX_VOLUME);
                 }
                 music_internal_volume(volume);
             } else {


### PR DESCRIPTION
In some cases we need to set the overall volume level. 
For now we have only two ways:
- modify chunk's volume
- modify channel's volume

Both are bad in case when we need to modify all played now sounds and all sounds that will be played in the future.
To solve this problem I suggest new function Mix_MasterVolume(int) which works with single static variable int master_volume.
This variable is used in mix_channels/music_mixer to calculate current volume level.