### PR TITLE
minimp3: use SDL equivalents of standard C functions

### DIFF
--- a/src/codecs/minimp3/minimp3.h
+++ b/src/codecs/minimp3/minimp3.h
@@ -43,6 +43,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
 #if defined(MINIMP3_IMPLEMENTATION) && !defined(_MINIMP3_IMPLEMENTATION_GUARD)
 #define _MINIMP3_IMPLEMENTATION_GUARD
 
+#include "SDL_stdinc.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -469,7 +470,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
 static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
 {
     int i, k;
-    memcpy(dst + 576 + sci->stereo_bands*18, dst + sci->stereo_bands*18, (sci->total_bands - sci->stereo_bands)*18*sizeof(float));
+    SDL_memcpy(dst + 576 + sci->stereo_bands*18, dst + sci->stereo_bands*18, (sci->total_bands - sci->stereo_bands)*18*sizeof(float));
     for (i = 0; i < sci->total_bands; i++, dst += 18, scf += 6)
     {
         for (k = 0; k < 12; k++)
@@ -614,14 +615,14 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
         int cnt = scf_count[i];
         if (scfsi & 8)
         {
-            memcpy(scf, ist_pos, cnt);
+            SDL_memcpy(scf, ist_pos, cnt);
         } else
         {
             int bits = scf_size[i];
             if (!bits)
             {
-                memset(scf, 0, cnt);
-                memset(ist_pos, 0, cnt);
+                SDL_memset(scf, 0, cnt);
+                SDL_memset(ist_pos, 0, cnt);
             } else
             {
                 int max_scf = (scfsi < 0) ? (1 << bits) - 1 : -1;
@@ -1006,7 +1007,7 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
             *dst++ = src[2*len];
         }
     }
-    memcpy(grbuf, scratch, (dst - scratch)*sizeof(float));
+    SDL_memcpy(grbuf, scratch, (dst - scratch)*sizeof(float));
 }
 
 static void L3_antialias(float *grbuf, int nbands)
@@ -1175,8 +1176,8 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
     for (;nbands > 0; nbands--, overlap += 9, grbuf += 18)
     {
         float tmp[18];
-        memcpy(tmp, grbuf, sizeof(tmp));
-        memcpy(grbuf, overlap, 6*sizeof(float));
+        SDL_memcpy(tmp, grbuf, sizeof(tmp));
+        SDL_memcpy(grbuf, overlap, 6*sizeof(float));
         L3_imdct12(tmp, grbuf + 6, overlap + 6);
         L3_imdct12(tmp + 1, grbuf + 12, overlap + 6);
         L3_imdct12(tmp + 2, overlap, overlap + 6);
@@ -1220,7 +1221,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
     }
     if (remains > 0)
     {
-        memmove(h->reserv_buf, s->maindata + pos, remains);
+        SDL_memmove(h->reserv_buf, s->maindata + pos, remains);
     }
     h->reserv = remains;
 }
@@ -1229,8 +1230,8 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int 
 {
     int frame_bytes = (bs->limit - bs->pos)/8;
     int bytes_have = MINIMP3_MIN(h->reserv, main_data_begin);
-    memcpy(s->maindata, h->reserv_buf + MINIMP3_MAX(0, h->reserv - main_data_begin), MINIMP3_MIN(h->reserv, main_data_begin));
-    memcpy(s->maindata + bytes_have, bs->buf + bs->pos/8, frame_bytes);
+    SDL_memcpy(s->maindata, h->reserv_buf + MINIMP3_MAX(0, h->reserv - main_data_begin), MINIMP3_MIN(h->reserv, main_data_begin));
+    SDL_memcpy(s->maindata + bytes_have, bs->buf + bs->pos/8, frame_bytes);
     bs_init(&s->bs, s->maindata, bytes_have + frame_bytes);
     return h->reserv >= main_data_begin;
 }
@@ -1634,7 +1635,7 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
         mp3d_DCT_II(grbuf + 576*i, nbands);
     }
 
-    memcpy(lins, qmf_state, sizeof(float)*15*64);
+    SDL_memcpy(lins, qmf_state, sizeof(float)*15*64);
 
     for (i = 0; i < nbands; i += 2)
     {
@@ -1650,7 +1651,7 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
     } else
 #endif /* MINIMP3_NONSTANDARD_BUT_LOGICAL */
     {
-        memcpy(qmf_state, lins + nbands*64, sizeof(float)*15*64);
+        SDL_memcpy(qmf_state, lins + nbands*64, sizeof(float)*15*64);
     }
 }
 
@@ -1727,7 +1728,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
     }
     if (!frame_size)
     {
-        memset(dec, 0, sizeof(mp3dec_t));
+        SDL_memset(dec, 0, sizeof(mp3dec_t));
         i = mp3d_find_frame(mp3, mp3_bytes, &dec->free_format_bytes, &frame_size);
         if (!frame_size || i + frame_size > mp3_bytes)
         {
@@ -1737,7 +1738,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
     }
 
     hdr = mp3 + i;
-    memcpy(dec->header, hdr, HDR_SIZE);
+    SDL_memcpy(dec->header, hdr, HDR_SIZE);
     info->frame_bytes = i + frame_size;
     info->frame_offset = i;
     info->channels = HDR_IS_MONO(hdr) ? 1 : 2;
@@ -1769,7 +1770,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
         {
             for (igr = 0; igr < (HDR_TEST_MPEG1(hdr) ? 2 : 1); igr++, pcm += 576*info->channels)
             {
-                memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
+                SDL_memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
                 L3_decode(dec, &scratch, scratch.gr_info + igr*info->channels, info->channels);
                 mp3d_synth_granule(dec->qmf_state, scratch.grbuf[0], 18, info->channels, pcm, scratch.syn[0]);
             }
@@ -1783,7 +1784,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
         L12_scale_info sci[1];
         L12_read_scale_info(hdr, bs_frame, sci);
 
-        memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
+        SDL_memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
         for (i = 0, igr = 0; igr < 3; igr++)
         {
             if (12 == (i += L12_dequantize_granule(scratch.grbuf[0] + i, bs_frame, sci, info->layer | 1)))
@@ -1791,7 +1792,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
                 i = 0;
                 L12_apply_scf_384(sci, sci->scf + igr, scratch.grbuf[0]);
                 mp3d_synth_granule(dec->qmf_state, scratch.grbuf[0], 12, info->channels, pcm, scratch.syn[0]);
-                memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
+                SDL_memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
                 pcm += 384*info->channels;
             }
             if (bs_frame->pos > bs_frame->limit)

--- a/src/codecs/minimp3/minimp3_ex.h
+++ b/src/codecs/minimp3/minimp3_ex.h
@@ -293,8 +293,8 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
     size_t orig_buf_size = buf_size;
     int to_skip = 0;
     mp3dec_frame_info_t frame_info;
-    memset(info, 0, sizeof(*info));
-    memset(&frame_info, 0, sizeof(frame_info));
+    SDL_memset(info, 0, sizeof(*info));
+    SDL_memset(&frame_info, 0, sizeof(frame_info));
 
     /* skip id3 */
     size_t filled = 0, consumed = 0;
@@ -343,7 +343,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
         {
             if (!eof && filled - consumed < MINIMP3_BUF_SIZE)
             {   /* keep minimum 10 consecutive mp3 frames (~16KB) worst case */
-                memmove(buf, buf + consumed, filled - consumed);
+                SDL_memmove(buf, buf + consumed, filled - consumed);
                 filled -= consumed;
                 consumed = 0;
                 size_t readed = io->read(buf + filled, buf_size - filled, io->read_data);
@@ -408,7 +408,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
         allocated += detected_samples*sizeof(mp3d_sample_t);
     else
         allocated += (buf_size/frame_info.frame_bytes)*samples*sizeof(mp3d_sample_t);
-    info->buffer = (mp3d_sample_t*)malloc(allocated);
+    info->buffer = (mp3d_sample_t*)SDL_malloc(allocated);
     if (!info->buffer)
         return MP3D_E_MEMORY;
     /* save info */
@@ -422,7 +422,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
         if ((allocated - info->samples*sizeof(mp3d_sample_t)) < MINIMP3_MAX_SAMPLES_PER_FRAME*sizeof(mp3d_sample_t))
         {
             allocated *= 2;
-            mp3d_sample_t *alloc_buf = (mp3d_sample_t*)realloc(info->buffer, allocated);
+            mp3d_sample_t *alloc_buf = (mp3d_sample_t*)SDL_realloc(info->buffer, allocated);
             if (!alloc_buf)
                 return MP3D_E_MEMORY;
             info->buffer = alloc_buf;
@@ -431,7 +431,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
         {
             if (!eof && filled - consumed < MINIMP3_BUF_SIZE)
             {   /* keep minimum 10 consecutive mp3 frames (~16KB) worst case */
-                memmove(buf, buf + consumed, filled - consumed);
+                SDL_memmove(buf, buf + consumed, filled - consumed);
                 filled -= consumed;
                 consumed = 0;
                 size_t readed = io->read(buf + filled, buf_size - filled, io->read_data);
@@ -471,7 +471,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
                 size_t skip = MINIMP3_MIN(samples, to_skip);
                 to_skip -= skip;
                 samples -= skip;
-                memmove(info->buffer, info->buffer + skip, samples*sizeof(mp3d_sample_t));
+                SDL_memmove(info->buffer, info->buffer + skip, samples*sizeof(mp3d_sample_t));
             }
             info->samples += samples;
             avg_bitrate_kbps += frame_info.bitrate_kbps;
@@ -489,7 +489,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
     /* reallocate to normal buffer size */
     if (allocated != info->samples*sizeof(mp3d_sample_t))
     {
-        mp3d_sample_t *alloc_buf = (mp3d_sample_t*)realloc(info->buffer, info->samples*sizeof(mp3d_sample_t));
+        mp3d_sample_t *alloc_buf = (mp3d_sample_t*)SDL_realloc(info->buffer, info->samples*sizeof(mp3d_sample_t));
         if (!alloc_buf && info->samples)
             return MP3D_E_MEMORY;
         info->buffer = alloc_buf;
@@ -509,7 +509,7 @@ int mp3dec_iterate_buf(const uint8_t *buf, size_t buf_size, MP3D_ITERATE_CB call
     if (!buf_size)
         return 0;
     mp3dec_frame_info_t frame_info;
-    memset(&frame_info, 0, sizeof(frame_info));
+    SDL_memset(&frame_info, 0, sizeof(frame_info));
     do
     {
         int free_format_bytes = 0, frame_size = 0, ret;
@@ -546,7 +546,7 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
     uint64_t readed = 0;
     mp3dec_frame_info_t frame_info;
     int eof = 0;
-    memset(&frame_info, 0, sizeof(frame_info));
+    SDL_memset(&frame_info, 0, sizeof(frame_info));
     if (filled > MINIMP3_ID3_DETECT_SIZE)
         return MP3D_E_IOERROR;
     if (MINIMP3_ID3_DETECT_SIZE != filled)
@@ -597,7 +597,7 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
         consumed += i + frame_size;
         if (!eof && filled - consumed < MINIMP3_BUF_SIZE)
         {   /* keep minimum 10 consecutive mp3 frames (~16KB) worst case */
-            memmove(buf, buf + consumed, filled - consumed);
+            SDL_memmove(buf, buf + consumed, filled - consumed);
             filled -= consumed;
             consumed = 0;
             size_t readed = io->read(buf + filled, buf_size - filled, io->read_data);
@@ -654,7 +654,7 @@ static int mp3dec_load_index(void *user_data, const uint8_t *frame, int frame_si
             dec->index.capacity = 4096;
         else
             dec->index.capacity *= 2;
-        mp3dec_frame_t *alloc_buf = (mp3dec_frame_t *)realloc((void*)dec->index.frames, sizeof(mp3dec_frame_t)*dec->index.capacity);
+        mp3dec_frame_t *alloc_buf = (mp3dec_frame_t *)SDL_realloc((void*)dec->index.frames, sizeof(mp3dec_frame_t)*dec->index.capacity);
         if (!alloc_buf)
             return MP3D_E_MEMORY;
         dec->index.frames = alloc_buf;
@@ -676,7 +676,7 @@ int mp3dec_ex_open_buf(mp3dec_ex_t *dec, const uint8_t *buf, size_t buf_size, in
 {
     if (!dec || !buf || (size_t)-1 == buf_size || (flags & (~MP3D_FLAGS_MASK)))
         return MP3D_E_PARAM;
-    memset(dec, 0, sizeof(*dec));
+    SDL_memset(dec, 0, sizeof(*dec));
     dec->file.buffer = buf;
     dec->file.size   = buf_size;
     dec->flags       = flags;
@@ -875,7 +875,7 @@ size_t mp3dec_ex_read_frame(mp3dec_ex_t *dec, mp3d_sample_t **buf, mp3dec_frame_
         {
             if (!eof && (dec->input_filled - dec->input_consumed) < MINIMP3_BUF_SIZE)
             {   /* keep minimum 10 consecutive mp3 frames (~16KB) worst case */
-                memmove((uint8_t*)dec->file.buffer, (uint8_t*)dec->file.buffer + dec->input_consumed, dec->input_filled - dec->input_consumed);
+                SDL_memmove((uint8_t*)dec->file.buffer, (uint8_t*)dec->file.buffer + dec->input_consumed, dec->input_filled - dec->input_consumed);
                 dec->input_filled -= dec->input_consumed;
                 dec->input_consumed = 0;
                 size_t readed = dec->io->read((uint8_t*)dec->file.buffer + dec->input_filled, dec->file.size - dec->input_filled, dec->io->read_data);
@@ -956,7 +956,7 @@ size_t mp3dec_ex_read(mp3dec_ex_t *dec, mp3d_sample_t *buf, size_t samples)
         return 0;
     }
     mp3dec_frame_info_t frame_info;
-    memset(&frame_info, 0, sizeof(frame_info));
+    SDL_memset(&frame_info, 0, sizeof(frame_info));
     size_t samples_requested = samples;
     while (samples)
     {
@@ -966,7 +966,7 @@ size_t mp3dec_ex_read(mp3dec_ex_t *dec, mp3d_sample_t *buf, size_t samples)
         {
             break;
         }
-        memcpy(buf, buf_frame, read_samples * sizeof(mp3d_sample_t));
+        SDL_memcpy(buf, buf_frame, read_samples * sizeof(mp3d_sample_t));
         buf += read_samples;
         samples -= read_samples;
     }
@@ -977,14 +977,14 @@ int mp3dec_ex_open_cb(mp3dec_ex_t *dec, mp3dec_io_t *io, int flags)
 {
     if (!dec || !io || (flags & (~MP3D_FLAGS_MASK)))
         return MP3D_E_PARAM;
-    memset(dec, 0, sizeof(*dec));
+    SDL_memset(dec, 0, sizeof(*dec));
 #ifdef MINIMP3_HAVE_RING
     int ret;
     if (ret = mp3dec_open_ring(&dec->file, MINIMP3_IO_SIZE))
         return ret;
 #else
     dec->file.size = MINIMP3_IO_SIZE;
-    dec->file.buffer = (const uint8_t*)malloc(dec->file.size);
+    dec->file.buffer = (const uint8_t*)SDL_malloc(dec->file.size);
     if (!dec->file.buffer)
         return MP3D_E_MEMORY;
 #endif
@@ -1039,7 +1039,7 @@ static int mp3dec_open_file(const char *file_name, mp3dec_map_info_t *map_info)
         return MP3D_E_PARAM;
     int file;
     struct stat st;
-    memset(map_info, 0, sizeof(*map_info));
+    SDL_memset(map_info, 0, sizeof(*map_info));
 retry_open:
     file = open(file_name, O_RDONLY);
     if (file < 0 && (errno == EAGAIN || errno == EINTR))
@@ -1086,7 +1086,7 @@ static int mp3dec_open_ring(mp3dec_map_info_t *map_info, size_t size)
     void *buffer;
     int res;
 #endif
-    memset(map_info, 0, sizeof(*map_info));
+    SDL_memset(map_info, 0, sizeof(*map_info));
 
 #ifdef _SC_PAGESIZE
     page_size = sysconf(_SC_PAGESIZE);
@@ -1169,7 +1169,7 @@ static void mp3dec_close_file(mp3dec_map_info_t *map_info)
 
 static int mp3dec_open_file_h(HANDLE file, mp3dec_map_info_t *map_info)
 {
-    memset(map_info, 0, sizeof(*map_info));
+    SDL_memset(map_info, 0, sizeof(*map_info));
 
     HANDLE mapping = NULL;
     LARGE_INTEGER s;
@@ -1219,7 +1219,7 @@ static int mp3dec_open_file_w(const wchar_t *file_name, mp3dec_map_info_t *map_i
 static void mp3dec_close_file(mp3dec_map_info_t *map_info)
 {
     if (map_info->buffer)
-        free((void *)map_info->buffer);
+        SDL_free((void *)map_info->buffer);
     map_info->buffer = 0;
     map_info->size = 0;
 }
@@ -1228,7 +1228,7 @@ static int mp3dec_open_file(const char *file_name, mp3dec_map_info_t *map_info)
 {
     if (!file_name)
         return MP3D_E_PARAM;
-    memset(map_info, 0, sizeof(*map_info));
+    SDL_memset(map_info, 0, sizeof(*map_info));
     FILE *file = fopen(file_name, "rb");
     if (!file)
         return MP3D_E_IOERROR;
@@ -1242,7 +1242,7 @@ static int mp3dec_open_file(const char *file_name, mp3dec_map_info_t *map_info)
     map_info->size = (size_t)size;
     if (fseek(file, 0, SEEK_SET))
         goto error;
-    map_info->buffer = (uint8_t *)malloc(map_info->size);
+    map_info->buffer = (uint8_t *)SDL_malloc(map_info->size);
     if (!map_info->buffer)
     {
         res = MP3D_E_MEMORY;
@@ -1333,13 +1333,13 @@ void mp3dec_ex_close(mp3dec_ex_t *dec)
         mp3dec_close_ring(&dec->file);
 #else
     if (dec->io && dec->file.buffer)
-        free((void*)dec->file.buffer);
+        SDL_free((void*)dec->file.buffer);
 #endif
     if (dec->is_file)
         mp3dec_close_file(&dec->file);
     if (dec->index.frames)
-        free(dec->index.frames);
-    memset(dec, 0, sizeof(*dec));
+        SDL_free(dec->index.frames);
+    SDL_memset(dec, 0, sizeof(*dec));
 }
 
 #ifdef _WIN32
@@ -1386,11 +1386,11 @@ void mp3dec_ex_close(mp3dec_ex_t *dec)
         mp3dec_close_ring(&dec->file);
 #else
     if (dec->io && dec->file.buffer)
-        free((void*)dec->file.buffer);
+        SDL_free((void*)dec->file.buffer);
 #endif
     if (dec->index.frames)
-        free(dec->index.frames);
-    memset(dec, 0, sizeof(*dec));
+        SDL_free(dec->index.frames);
+    SDL_memset(dec, 0, sizeof(*dec));
 }
 #endif
 


### PR DESCRIPTION
On some platforms, this thing won't get built, and therefore suggested to use SDL's equivalents that will work.