### PR TITLE
Rebase and update stb_vorbis.h to SDL_sound's version :

### DIFF
--- a/configure
+++ b/configure
@@ -15308,7 +15308,7 @@ find_lib()
     done
 }
 
-SDL_VERSION=2.0.7
+SDL_VERSION=2.0.9
 
 # Check whether --with-sdl-prefix was given.
 if test "${with_sdl_prefix+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ find_lib()
 }
 
 dnl Check for SDL
-SDL_VERSION=2.0.7
+SDL_VERSION=2.0.9
 AM_PATH_SDL2($SDL_VERSION,
             :,
             AC_MSG_ERROR([*** SDL version $SDL_VERSION not found!])

--- a/src/codecs/music_ogg_stb.c
+++ b/src/codecs/music_ogg_stb.c
@@ -32,11 +32,11 @@
 #define STB_VORBIS_NO_CRT 1
 #define STB_VORBIS_NO_PUSHDATA_API 1
 #define STB_VORBIS_MAX_CHANNELS 6
-#define STBV_CDECL
 #define STB_FORCEINLINE SDL_FORCE_INLINE
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
 #define STB_VORBIS_BIG_ENDIAN 1
 #endif
+#define STBV_CDECL SDLCALL /* for SDL_qsort */
 
 #ifdef assert
 #undef assert
@@ -191,7 +191,7 @@ static void *OGG_CreateFromRW(SDL_RWops *src, int freesrc)
     }
 
     music->vi = stb_vorbis_get_info(music->vf);
-    if (music->vi.sample_rate <= 0) {
+    if ((int)music->vi.sample_rate <= 0) {
         Mix_SetError("Invalid sample rate value");
         OGG_Delete(music);
         return NULL;

--- a/src/codecs/music_ogg_stb.c
+++ b/src/codecs/music_ogg_stb.c
@@ -25,10 +25,46 @@
 
 #include "music_ogg.h"
 #include "utils.h"
+#include "SDL_assert.h"
 
-#define OV_EXCLUDE_STATIC_CALLBACKS
-#define STB_VORBIS_NO_STDIO
-#define STB_VORBIS_NO_CRT
+#define STB_VORBIS_SDL 1 /* for SDL_mixer-specific stuff. */
+#define STB_VORBIS_NO_STDIO 1
+#define STB_VORBIS_NO_CRT 1
+#define STB_VORBIS_NO_PUSHDATA_API 1
+#define STB_VORBIS_MAX_CHANNELS 6
+#define STBV_CDECL
+#define STB_FORCEINLINE SDL_FORCE_INLINE
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+#define STB_VORBIS_BIG_ENDIAN 1
+#endif
+
+#ifdef assert
+#undef assert
+#endif
+#ifdef memset
+#undef memset
+#endif
+#ifdef memcpy
+#undef memcpy
+#endif
+#define assert SDL_assert
+#define memset SDL_memset
+#define memcmp SDL_memcmp
+#define memcpy SDL_memcpy
+#define qsort SDL_qsort
+#define malloc SDL_malloc
+#define realloc SDL_realloc
+#define free SDL_free
+
+#define pow SDL_pow
+#define floor SDL_floor
+#define ldexp(v, e) SDL_scalbn((v), (e))
+#define abs(x) SDL_abs(x)
+#define cos(x) SDL_cos(x)
+#define sin(x) SDL_sin(x)
+#define log(x) SDL_log(x)
+#define exp(x) SDL_exp(x)
+
 #include "stb_vorbis/stb_vorbis.h"
 
 typedef struct {

--- a/src/codecs/stb_vorbis/stb_vorbis.h
+++ b/src/codecs/stb_vorbis/stb_vorbis.h
@@ -1,82 +1,80 @@
-/*  Ogg Vorbis audio decoder - v1.22 - public domain */
-/*  http://nothings.org/stb_vorbis/ */
-/*  */
-/*  Original version written by Sean Barrett in 2007. */
-/*  */
-/*  Originally sponsored by RAD Game Tools. Seeking implementation */
-/*  sponsored by Phillip Bennefall, Marc Andersen, Aaron Baker, */
-/*  Elias Software, Aras Pranckevicius, and Sean Barrett. */
-/*  */
-/*  LICENSE */
-/*  */
-/*    See end of file for license information. */
-/*  */
-/*  Limitations: */
-/*  */
-/*    - floor 0 not supported (used in old ogg vorbis files pre-2004) */
-/*    - lossless sample-truncation at beginning ignored */
-/*    - cannot concatenate multiple vorbis streams */
-/*    - sample positions are 32-bit, limiting seekable 192Khz */
-/*        files to around 6 hours (Ogg supports 64-bit) */
-/*  */
-/*  Feature contributors: */
-/*     Dougall Johnson (sample-exact seeking) */
-/*  */
-/*  Bugfix/warning contributors: */
-/*     Terje Mathisen     Niklas Frykholm     Andy Hill */
-/*     Casey Muratori     John Bolton         Gargaj */
-/*     Laurent Gomila     Marc LeBlanc        Ronny Chevalier */
-/*     Bernhard Wodo      Evan Balster        github:alxprd */
-/*     Tom Beaumont       Ingo Leitgeb        Nicolas Guillemot */
-/*     Phillip Bennefall  Rohit               Thiago Goulart */
-/*     github:manxorist   Saga Musix          github:infatum */
-/*     Timur Gagiev       Maxwell Koo         Peter Waller */
-/*     github:audinowho   Dougall Johnson     David Reid */
-/*     github:Clownacy    Pedro J. Estebanez  Remi Verschelde */
-/*     AnthoFoxo          github:morlat       Gabriel Ravier */
-/*  */
-/*  Partial history: */
-/*     1.22    - 2021-07-11 - various small fixes */
-/*     1.21    - 2021-07-02 - fix bug for files with no comments */
-/*     1.20    - 2020-07-11 - several small fixes */
-/*     1.19    - 2020-02-05 - warnings */
-/*     1.18    - 2020-02-02 - fix seek bugs; parse header comments; misc warnings etc. */
-/*     1.17    - 2019-07-08 - fix CVE-2019-13217..CVE-2019-13223 (by ForAllSecure) */
-/*     1.16    - 2019-03-04 - fix warnings */
-/*     1.15    - 2019-02-07 - explicit failure if Ogg Skeleton data is found */
-/*     1.14    - 2018-02-11 - delete bogus dealloca usage */
-/*     1.13    - 2018-01-29 - fix truncation of last frame (hopefully) */
-/*     1.12    - 2017-11-21 - limit residue begin/end to blocksize/2 to avoid large temp allocs in bad/corrupt files */
-/*     1.11    - 2017-07-23 - fix MinGW compilation */
-/*     1.10    - 2017-03-03 - more robust seeking; fix negative ilog(); clear error in open_memory */
-/*     1.09    - 2016-04-04 - back out 'truncation of last frame' fix from previous version */
-/*     1.08    - 2016-04-02 - warnings; setup memory leaks; truncation of last frame */
-/*     1.07    - 2015-01-16 - fixes for crashes on invalid files; warning fixes; const */
-/*     1.06    - 2015-08-31 - full, correct support for seeking API (Dougall Johnson) */
-/*                            some crash fixes when out of memory or with corrupt files */
-/*                            fix some inappropriately signed shifts */
-/*     1.05    - 2015-04-19 - don't define __forceinline if it's redundant */
-/*     1.04    - 2014-08-27 - fix missing const-correct case in API */
-/*     1.03    - 2014-08-07 - warning fixes */
-/*     1.02    - 2014-07-09 - declare qsort comparison as explicitly _cdecl in Windows */
-/*     1.01    - 2014-06-18 - fix stb_vorbis_get_samples_float (interleaved was correct) */
-/*     1.0     - 2014-05-26 - fix memory leaks; fix warnings; fix bugs in >2-channel; */
-/*                            (API change) report sample rate for decode-full-file funcs */
-/*  */
-/*  See end of file for full version history. */
+// Ogg Vorbis audio decoder - v1.22 - public domain
+// http://nothings.org/stb_vorbis/
+//
+// Original version written by Sean Barrett in 2007.
+//
+// Originally sponsored by RAD Game Tools. Seeking implementation
+// sponsored by Phillip Bennefall, Marc Andersen, Aaron Baker,
+// Elias Software, Aras Pranckevicius, and Sean Barrett.
+//
+// LICENSE
+//
+//   See end of file for license information.
+//
+// Limitations:
+//
+//   - floor 0 not supported (used in old ogg vorbis files pre-2004)
+//   - lossless sample-truncation at beginning ignored
+//   - cannot concatenate multiple vorbis streams
+//   - sample positions are 32-bit, limiting seekable 192Khz
+//       files to around 6 hours (Ogg supports 64-bit)
+//
+// Feature contributors:
+//    Dougall Johnson (sample-exact seeking)
+//    Vitaly Novichkov (sample-accurate tell)
+//
+// Bugfix/warning contributors:
+//    Terje Mathisen     Niklas Frykholm     Andy Hill
+//    Casey Muratori     John Bolton         Gargaj
+//    Laurent Gomila     Marc LeBlanc        Ronny Chevalier
+//    Bernhard Wodo      Evan Balster        github:alxprd
+//    Tom Beaumont       Ingo Leitgeb        Nicolas Guillemot
+//    Phillip Bennefall  Rohit               Thiago Goulart
+//    github:manxorist   Saga Musix          github:infatum
+//    Timur Gagiev       Maxwell Koo         Peter Waller
+//    github:audinowho   Dougall Johnson     David Reid
+//    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
+//    AnthoFoxo          github:morlat       Gabriel Ravier
+//    Alice Rowan
+//
+// Partial history:
+//    1.22    - 2021-07-11 - various small fixes
+//    1.21    - 2021-07-02 - fix bug for files with no comments
+//    1.20    - 2020-07-11 - several small fixes
+//    1.19    - 2020-02-05 - warnings
+//    1.18    - 2020-02-02 - fix seek bugs; parse header comments; misc warnings etc.
+//    1.17    - 2019-07-08 - fix CVE-2019-13217..CVE-2019-13223 (by ForAllSecure)
+//    1.16    - 2019-03-04 - fix warnings
+//    1.15    - 2019-02-07 - explicit failure if Ogg Skeleton data is found
+//    1.14    - 2018-02-11 - delete bogus dealloca usage
+//    1.13    - 2018-01-29 - fix truncation of last frame (hopefully)
+//    1.12    - 2017-11-21 - limit residue begin/end to blocksize/2 to avoid large temp allocs in bad/corrupt files
+//    1.11    - 2017-07-23 - fix MinGW compilation
+//    1.10    - 2017-03-03 - more robust seeking; fix negative ilog(); clear error in open_memory
+//    1.09    - 2016-04-04 - back out 'truncation of last frame' fix from previous version
+//    1.08    - 2016-04-02 - warnings; setup memory leaks; truncation of last frame
+//    1.07    - 2015-01-16 - fixes for crashes on invalid files; warning fixes; const
+//    1.06    - 2015-08-31 - full, correct support for seeking API (Dougall Johnson)
+//                           some crash fixes when out of memory or with corrupt files
+//                           fix some inappropriately signed shifts
+//    1.05    - 2015-04-19 - don't define __forceinline if it's redundant
+//    1.04    - 2014-08-27 - fix missing const-correct case in API
+//    1.03    - 2014-08-07 - warning fixes
+//    1.02    - 2014-07-09 - declare qsort comparison as explicitly _cdecl in Windows
+//    1.01    - 2014-06-18 - fix stb_vorbis_get_samples_float (interleaved was correct)
+//    1.0     - 2014-05-26 - fix memory leaks; fix warnings; fix bugs in >2-channel;
+//                           (API change) report sample rate for decode-full-file funcs
+//
+// See end of file for full version history.
 
 
-/* //////////////////////////////////////////////////////////////////////////// */
-/*  */
-/*   HEADER BEGINS HERE */
-/*  */
+//////////////////////////////////////////////////////////////////////////////
+//
+//  HEADER BEGINS HERE
+//
 
 #ifndef STB_VORBIS_INCLUDE_STB_VORBIS_H
 #define STB_VORBIS_INCLUDE_STB_VORBIS_H
-
-#include "SDL_stdinc.h"
-#include "SDL_rwops.h"
-#include "SDL_assert.h"
 
 #if defined(STB_VORBIS_NO_CRT) && !defined(STB_VORBIS_NO_STDIO)
 #define STB_VORBIS_NO_STDIO 1
@@ -90,34 +88,34 @@
 extern "C" {
 #endif
 
-/* /////////   THREAD SAFETY */
+///////////   THREAD SAFETY
 
-/*  Individual stb_vorbis* handles are not thread-safe; you cannot decode from */
-/*  them from multiple threads at the same time. However, you can have multiple */
-/*  stb_vorbis* handles and decode from them independently in multiple thrads. */
+// Individual stb_vorbis* handles are not thread-safe; you cannot decode from
+// them from multiple threads at the same time. However, you can have multiple
+// stb_vorbis* handles and decode from them independently in multiple thrads.
 
 
-/* /////////   MEMORY ALLOCATION */
+///////////   MEMORY ALLOCATION
 
-/*  normally stb_vorbis uses malloc() to allocate memory at startup, */
-/*  and alloca() to allocate temporary memory during a frame on the */
-/*  stack. (Memory consumption will depend on the amount of setup */
-/*  data in the file and how you set the compile flags for speed */
-/*  vs. size. In my test files the maximal-size usage is ~150KB.) */
-/*  */
-/*  You can modify the wrapper functions in the source (setup_malloc, */
-/*  setup_temp_malloc, temp_malloc) to change this behavior, or you */
-/*  can use a simpler allocation model: you pass in a buffer from */
-/*  which stb_vorbis will allocate _all_ its memory (including the */
-/*  temp memory). "open" may fail with a VORBIS_outofmem if you */
-/*  do not pass in enough data; there is no way to determine how */
-/*  much you do need except to succeed (at which point you can */
-/*  query get_info to find the exact amount required. yes I know */
-/*  this is lame). */
-/*  */
-/*  If you pass in a non-NULL buffer of the type below, allocation */
-/*  will occur from it as described above. Otherwise just pass NULL */
-/*  to use malloc()/alloca() */
+// normally stb_vorbis uses malloc() to allocate memory at startup,
+// and alloca() to allocate temporary memory during a frame on the
+// stack. (Memory consumption will depend on the amount of setup
+// data in the file and how you set the compile flags for speed
+// vs. size. In my test files the maximal-size usage is ~150KB.)
+//
+// You can modify the wrapper functions in the source (setup_malloc,
+// setup_temp_malloc, temp_malloc) to change this behavior, or you
+// can use a simpler allocation model: you pass in a buffer from
+// which stb_vorbis will allocate _all_ its memory (including the
+// temp memory). "open" may fail with a VORBIS_outofmem if you
+// do not pass in enough data; there is no way to determine how
+// much you do need except to succeed (at which point you can
+// query get_info to find the exact amount required. yes I know
+// this is lame).
+//
+// If you pass in a non-NULL buffer of the type below, allocation
+// will occur from it as described above. Otherwise just pass NULL
+// to use malloc()/alloca()
 
 typedef struct
 {
@@ -126,7 +124,7 @@ typedef struct
 } stb_vorbis_alloc;
 
 
-/* /////////   FUNCTIONS USEABLE WITH ALL INPUT MODES */
+///////////   FUNCTIONS USEABLE WITH ALL INPUT MODES
 
 typedef struct stb_vorbis stb_vorbis;
 
@@ -150,119 +148,119 @@ typedef struct
    char **comment_list;
 } stb_vorbis_comment;
 
-/*  get general information about the file */
+// get general information about the file
 extern stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f);
 
-/*  get ogg comments */
+// get ogg comments
 extern stb_vorbis_comment stb_vorbis_get_comment(stb_vorbis *f);
 
-/*  get the last error detected (clears it, too) */
+// get the last error detected (clears it, too)
 extern int stb_vorbis_get_error(stb_vorbis *f);
 
-/*  close an ogg vorbis file and free all memory in use */
+// close an ogg vorbis file and free all memory in use
 extern void stb_vorbis_close(stb_vorbis *f);
 
-/*  this function returns the offset (in samples) from the beginning of the */
-/*  file that will be returned by the next decode, if it is known, or -1 */
-/*  otherwise. after a flush_pushdata() call, this may take a while before */
-/*  it becomes valid again. */
-/*  NOT WORKING YET after a seek with PULLDATA API */
-extern Sint64 stb_vorbis_get_sample_offset(stb_vorbis *f);
+// this function returns the offset (in samples) from the beginning of the
+// file that will be returned by the next decode, if it is known, or -1
+// otherwise. after a flush_pushdata() call, this may take a while before
+// it becomes valid again.
+// NOT WORKING YET after a seek with PULLDATA API
+extern int stb_vorbis_get_sample_offset(stb_vorbis *f);
 
-/*  this function returns the count of returned samples from the beginning of the */
-/*  file. Functions "stb_vorbis_get_samples_*", "stb_vorbis_seek_*()" will
- *  affect the returned value. Use this call to get the accurate sample position
- *  during playback. */
-extern Sint64 stb_vorbis_get_playback_sample_offset(stb_vorbis *f);
+//  this function returns the count of returned samples from the beginning of the
+//  file. Functions "stb_vorbis_get_samples_*", "stb_vorbis_seek_*()" will
+//  affect the returned value. Use this call to get the accurate sample position
+//  during playback.
+extern int stb_vorbis_get_playback_sample_offset(stb_vorbis *f);
 
-/*  returns the current seek point within the file, or offset from the beginning */
-/*  of the memory buffer. In pushdata mode it returns 0. */
+// returns the current seek point within the file, or offset from the beginning
+// of the memory buffer. In pushdata mode it returns 0.
 extern unsigned int stb_vorbis_get_file_offset(stb_vorbis *f);
 
-/* /////////   PUSHDATA API */
+///////////   PUSHDATA API
 
 #ifndef STB_VORBIS_NO_PUSHDATA_API
 
-/*  this API allows you to get blocks of data from any source and hand */
-/*  them to stb_vorbis. you have to buffer them; stb_vorbis will tell */
-/*  you how much it used, and you have to give it the rest next time; */
-/*  and stb_vorbis may not have enough data to work with and you will */
-/*  need to give it the same data again PLUS more. Note that the Vorbis */
-/*  specification does not bound the size of an individual frame. */
+// this API allows you to get blocks of data from any source and hand
+// them to stb_vorbis. you have to buffer them; stb_vorbis will tell
+// you how much it used, and you have to give it the rest next time;
+// and stb_vorbis may not have enough data to work with and you will
+// need to give it the same data again PLUS more. Note that the Vorbis
+// specification does not bound the size of an individual frame.
 
 extern stb_vorbis *stb_vorbis_open_pushdata(
          const unsigned char * datablock, int datablock_length_in_bytes,
          int *datablock_memory_consumed_in_bytes,
          int *error,
          const stb_vorbis_alloc *alloc_buffer);
-/*  create a vorbis decoder by passing in the initial data block containing */
-/*     the ogg&vorbis headers (you don't need to do parse them, just provide */
-/*    the first N bytes of the file--you're told if it's not enough, see below) */
-/*  on success, returns an stb_vorbis *, does not set error, returns the amount of */
-/*     data parsed/consumed on this call in *datablock_memory_consumed_in_bytes; */
-/*  on failure, returns NULL on error and sets *error, does not change *datablock_memory_consumed */
-/*  if returns NULL and *error is VORBIS_need_more_data, then the input block was */
-/*        incomplete and you need to pass in a larger block from the start of the file */
+// create a vorbis decoder by passing in the initial data block containing
+//    the ogg&vorbis headers (you don't need to do parse them, just provide
+//    the first N bytes of the file--you're told if it's not enough, see below)
+// on success, returns an stb_vorbis *, does not set error, returns the amount of
+//    data parsed/consumed on this call in *datablock_memory_consumed_in_bytes;
+// on failure, returns NULL on error and sets *error, does not change *datablock_memory_consumed
+// if returns NULL and *error is VORBIS_need_more_data, then the input block was
+//       incomplete and you need to pass in a larger block from the start of the file
 
 extern int stb_vorbis_decode_frame_pushdata(
          stb_vorbis *f,
          const unsigned char *datablock, int datablock_length_in_bytes,
-         int *channels,             /*  place to write number of float * buffers */
-         float ***output,           /*  place to write float ** array of float * buffers */
-         int *samples               /*  place to write number of output samples */
+         int *channels,             // place to write number of float * buffers
+         float ***output,           // place to write float ** array of float * buffers
+         int *samples               // place to write number of output samples
      );
-/*  decode a frame of audio sample data if possible from the passed-in data block */
-/*  */
-/*  return value: number of bytes we used from datablock */
-/*  */
-/*  possible cases: */
-/*      0 bytes used, 0 samples output (need more data) */
-/*      N bytes used, 0 samples output (resynching the stream, keep going) */
-/*      N bytes used, M samples output (one frame of data) */
-/*  note that after opening a file, you will ALWAYS get one N-bytes,0-sample */
-/*  frame, because Vorbis always "discards" the first frame. */
-/*  */
-/*  Note that on resynch, stb_vorbis will rarely consume all of the buffer, */
-/*  instead only datablock_length_in_bytes-3 or less. This is because it wants */
-/*  to avoid missing parts of a page header if they cross a datablock boundary, */
-/*  without writing state-machiney code to record a partial detection. */
-/*  */
-/*  The number of channels returned are stored in *channels (which can be */
-/*  NULL--it is always the same as the number of channels reported by */
-/*  get_info). *output will contain an array of float* buffers, one per */
-/*  channel. In other words, (*output)[0][0] contains the first sample from */
-/*  the first channel, and (*output)[1][0] contains the first sample from */
-/*  the second channel. */
-/*  */
-/*  *output points into stb_vorbis's internal output buffer storage; these */
-/*  buffers are owned by stb_vorbis and application code should not free */
-/*  them or modify their contents. They are transient and will be overwritten */
-/*  once you ask for more data to get decoded, so be sure to grab any data */
-/*  you need before then. */
+// decode a frame of audio sample data if possible from the passed-in data block
+//
+// return value: number of bytes we used from datablock
+//
+// possible cases:
+//     0 bytes used, 0 samples output (need more data)
+//     N bytes used, 0 samples output (resynching the stream, keep going)
+//     N bytes used, M samples output (one frame of data)
+// note that after opening a file, you will ALWAYS get one N-bytes,0-sample
+// frame, because Vorbis always "discards" the first frame.
+//
+// Note that on resynch, stb_vorbis will rarely consume all of the buffer,
+// instead only datablock_length_in_bytes-3 or less. This is because it wants
+// to avoid missing parts of a page header if they cross a datablock boundary,
+// without writing state-machiney code to record a partial detection.
+//
+// The number of channels returned are stored in *channels (which can be
+// NULL--it is always the same as the number of channels reported by
+// get_info). *output will contain an array of float* buffers, one per
+// channel. In other words, (*output)[0][0] contains the first sample from
+// the first channel, and (*output)[1][0] contains the first sample from
+// the second channel.
+//
+// *output points into stb_vorbis's internal output buffer storage; these
+// buffers are owned by stb_vorbis and application code should not free
+// them or modify their contents. They are transient and will be overwritten
+// once you ask for more data to get decoded, so be sure to grab any data
+// you need before then.
 
 extern void stb_vorbis_flush_pushdata(stb_vorbis *f);
-/*  inform stb_vorbis that your next datablock will not be contiguous with */
-/*  previous ones (e.g. you've seeked in the data); future attempts to decode */
-/*  frames will cause stb_vorbis to resynchronize (as noted above), and */
-/*  once it sees a valid Ogg page (typically 4-8KB, as large as 64KB), it */
-/*  will begin decoding the _next_ frame. */
-/*  */
-/*  if you want to seek using pushdata, you need to seek in your file, then */
-/*  call stb_vorbis_flush_pushdata(), then start calling decoding, then once */
-/*  decoding is returning you data, call stb_vorbis_get_sample_offset, and */
-/*  if you don't like the result, seek your file again and repeat. */
+// inform stb_vorbis that your next datablock will not be contiguous with
+// previous ones (e.g. you've seeked in the data); future attempts to decode
+// frames will cause stb_vorbis to resynchronize (as noted above), and
+// once it sees a valid Ogg page (typically 4-8KB, as large as 64KB), it
+// will begin decoding the _next_ frame.
+//
+// if you want to seek using pushdata, you need to seek in your file, then
+// call stb_vorbis_flush_pushdata(), then start calling decoding, then once
+// decoding is returning you data, call stb_vorbis_get_sample_offset, and
+// if you don't like the result, seek your file again and repeat.
 #endif
 
 
-/* ////////   PULLING INPUT API */
+//////////   PULLING INPUT API
 
 #ifndef STB_VORBIS_NO_PULLDATA_API
-/*  This API assumes stb_vorbis is allowed to pull data from a source-- */
-/*  either a block of memory containing the _entire_ vorbis stream, or a */
-/*  FILE * that you or it create, or possibly some other reading mechanism */
-/*  if you go modify the source to replace the FILE * case with some kind */
-/*  of callback to your code. (But if you don't support seeking, you may */
-/*  just want to go ahead and use pushdata.) */
+// This API assumes stb_vorbis is allowed to pull data from a source--
+// either a block of memory containing the _entire_ vorbis stream, or a
+// FILE * that you or it create, or possibly some other reading mechanism
+// if you go modify the source to replace the FILE * case with some kind
+// of callback to your code. (But if you don't support seeking, you may
+// just want to go ahead and use pushdata.)
 
 #if !defined(STB_VORBIS_NO_STDIO) && !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
 extern int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output);
@@ -270,147 +268,146 @@ extern int stb_vorbis_decode_filename(const char *filename, int *channels, int *
 #if !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
 extern int stb_vorbis_decode_memory(const unsigned char *mem, int len, int *channels, int *sample_rate, short **output);
 #endif
-/*  decode an entire file and output the data interleaved into a malloc()ed */
-/*  buffer stored in *output. The return value is the number of samples */
-/*  decoded, or -1 if the file could not be opened or was not an ogg vorbis file. */
-/*  When you're done with it, just free() the pointer returned in *output. */
+// decode an entire file and output the data interleaved into a malloc()ed
+// buffer stored in *output. The return value is the number of samples
+// decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
+// When you're done with it, just free() the pointer returned in *output.
 
 extern stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
-/*  create an ogg vorbis decoder from an ogg vorbis stream in memory (note */
-/*  this must be the entire stream!). on failure, returns NULL and sets *error */
+// create an ogg vorbis decoder from an ogg vorbis stream in memory (note
+// this must be the entire stream!). on failure, returns NULL and sets *error
 
 #ifndef STB_VORBIS_NO_STDIO
 extern stb_vorbis * stb_vorbis_open_filename(const char *filename,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
-/*  create an ogg vorbis decoder from a filename via fopen(). on failure, */
-/*  returns NULL and sets *error (possibly to VORBIS_file_open_failure). */
+// create an ogg vorbis decoder from a filename via fopen(). on failure,
+// returns NULL and sets *error (possibly to VORBIS_file_open_failure).
 
 extern stb_vorbis * stb_vorbis_open_file(FILE *f, int close_handle_on_close,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
-/*  create an ogg vorbis decoder from an open FILE *, looking for a stream at */
-/*  the _current_ seek point (ftell). on failure, returns NULL and sets *error. */
-/* note that stb_vorbis must "own" this stream; if you seek it in between */
-/*  calls to stb_vorbis, it will become confused. Moreover, if you attempt to */
-/*  perform stb_vorbis_seek_*() operations on this file, it will assume it */
-/*  owns the _entire_ rest of the file after the start point. Use the next */
-/*  function, stb_vorbis_open_file_section(), to limit it. */
+// create an ogg vorbis decoder from an open FILE *, looking for a stream at
+// the _current_ seek point (ftell). on failure, returns NULL and sets *error.
+// note that stb_vorbis must "own" this stream; if you seek it in between
+// calls to stb_vorbis, it will become confused. Moreover, if you attempt to
+// perform stb_vorbis_seek_*() operations on this file, it will assume it
+// owns the _entire_ rest of the file after the start point. Use the next
+// function, stb_vorbis_open_file_section(), to limit it.
 
 extern stb_vorbis * stb_vorbis_open_file_section(FILE *f, int close_handle_on_close,
                 int *error, const stb_vorbis_alloc *alloc_buffer, unsigned int len);
-/*  create an ogg vorbis decoder from an open FILE *, looking for a stream at */
-/* the _current_ seek point (ftell); the stream will be of length 'len' bytes. */
-/* on failure, returns NULL and sets *error. note that stb_vorbis must "own" */
-/*  this stream; if you seek it in between calls to stb_vorbis, it will become */
-/*  confused. */
+// create an ogg vorbis decoder from an open FILE *, looking for a stream at
+// the _current_ seek point (ftell); the stream will be of length 'len' bytes.
+// on failure, returns NULL and sets *error. note that stb_vorbis must "own"
+// this stream; if you seek it in between calls to stb_vorbis, it will become
+// confused.
 #endif
 
-extern stb_vorbis * stb_vorbis_open_rwops(SDL_RWops *f, int close_handle_on_close,
-                        int *error, const stb_vorbis_alloc *alloc_buffer);
-
-extern stb_vorbis * stb_vorbis_open_rwops_section(SDL_RWops *file, int close_handle_on_close,
-                        int *error, const stb_vorbis_alloc *alloc_buffer, unsigned int len);
+#ifdef STB_VORBIS_SDL
+extern stb_vorbis * stb_vorbis_open_rwops_section(SDL_RWops *rwops, int close_on_free, int *error, const stb_vorbis_alloc *alloc, unsigned int length);
+extern stb_vorbis * stb_vorbis_open_rwops(SDL_RWops *rwops, int close_on_free, int *error, const stb_vorbis_alloc *alloc);
+#endif
 
 extern int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number);
-extern int stb_vorbis_seek(stb_vorbis *f, Sint64 sample_number);
-/* these functions seek in the Vorbis file to (approximately) 'sample_number'. */
-/*  after calling seek_frame(), the next call to get_frame_*() will include */
-/*  the specified sample. after calling stb_vorbis_seek(), the next call to */
-/*  stb_vorbis_get_samples_* will start with the specified sample. If you */
-/*  do not need to seek to EXACTLY the target sample when using get_samples_*, */
-/*  you can also use seek_frame(). */
+extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
+// these functions seek in the Vorbis file to (approximately) 'sample_number'.
+// after calling seek_frame(), the next call to get_frame_*() will include
+// the specified sample. after calling stb_vorbis_seek(), the next call to
+// stb_vorbis_get_samples_* will start with the specified sample. If you
+// do not need to seek to EXACTLY the target sample when using get_samples_*,
+// you can also use seek_frame().
 
 extern int stb_vorbis_seek_start(stb_vorbis *f);
-/*  this function is equivalent to stb_vorbis_seek(f,0) */
+// this function is equivalent to stb_vorbis_seek(f,0)
 
-extern Sint64       stb_vorbis_stream_length_in_samples(stb_vorbis *f);
+extern unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f);
 extern float        stb_vorbis_stream_length_in_seconds(stb_vorbis *f);
-/*  these functions return the total length of the vorbis stream */
+// these functions return the total length of the vorbis stream
 
 extern int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output);
-/*  decode the next frame and return the number of samples. the number of */
-/*  channels returned are stored in *channels (which can be NULL--it is always */
-/*  the same as the number of channels reported by get_info). *output will */
-/*  contain an array of float* buffers, one per channel. These outputs will */
-/*  be overwritten on the next call to stb_vorbis_get_frame_*. */
-/*  */
-/*  You generally should not intermix calls to stb_vorbis_get_frame_*() */
-/*  and stb_vorbis_get_samples_*(), since the latter calls the former. */
+// decode the next frame and return the number of samples. the number of
+// channels returned are stored in *channels (which can be NULL--it is always
+// the same as the number of channels reported by get_info). *output will
+// contain an array of float* buffers, one per channel. These outputs will
+// be overwritten on the next call to stb_vorbis_get_frame_*.
+//
+// You generally should not intermix calls to stb_vorbis_get_frame_*()
+// and stb_vorbis_get_samples_*(), since the latter calls the former.
 
 #ifndef STB_VORBIS_NO_INTEGER_CONVERSION
 extern int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts);
 extern int stb_vorbis_get_frame_short            (stb_vorbis *f, int num_c, short **buffer, int num_samples);
 #endif
-/*  decode the next frame and return the number of *samples* per channel. */
-/*  Note that for interleaved data, you pass in the number of shorts (the */
-/*  size of your array), but the return value is the number of samples per */
-/*  channel, not the total number of samples. */
-/*  */
-/*  The data is coerced to the number of channels you request according to the */
-/*  channel coercion rules (see below). You must pass in the size of your */
-/*  buffer(s) so that stb_vorbis will not overwrite the end of the buffer. */
-/*  The maximum buffer size needed can be gotten from get_info(); however, */
-/*  the Vorbis I specification implies an absolute maximum of 4096 samples */
-/*  per channel. */
+// decode the next frame and return the number of *samples* per channel.
+// Note that for interleaved data, you pass in the number of shorts (the
+// size of your array), but the return value is the number of samples per
+// channel, not the total number of samples.
+//
+// The data is coerced to the number of channels you request according to the
+// channel coercion rules (see below). You must pass in the size of your
+// buffer(s) so that stb_vorbis will not overwrite the end of the buffer.
+// The maximum buffer size needed can be gotten from get_info(); however,
+// the Vorbis I specification implies an absolute maximum of 4096 samples
+// per channel.
 
-/*  Channel coercion rules: */
-/*     Let M be the number of channels requested, and N the number of channels present, */
-/*     and Cn be the nth channel; let stereo L be the sum of all L and center channels, */
-/*     and stereo R be the sum of all R and center channels (channel assignment from the */
-/*     vorbis spec). */
-/*         M    N       output */
-/*         1    k      sum(Ck) for all k */
-/*         2    *      stereo L, stereo R */
-/*         k    l      k > l, the first l channels, then 0s */
-/*         k    l      k <= l, the first k channels */
-/*     Note that this is not _good_ surround etc. mixing at all! It's just so */
-/*     you get something useful. */
+// Channel coercion rules:
+//    Let M be the number of channels requested, and N the number of channels present,
+//    and Cn be the nth channel; let stereo L be the sum of all L and center channels,
+//    and stereo R be the sum of all R and center channels (channel assignment from the
+//    vorbis spec).
+//        M    N       output
+//        1    k      sum(Ck) for all k
+//        2    *      stereo L, stereo R
+//        k    l      k > l, the first l channels, then 0s
+//        k    l      k <= l, the first k channels
+//    Note that this is not _good_ surround etc. mixing at all! It's just so
+//    you get something useful.
 
 extern int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats);
 extern int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples);
-/*  gets num_samples samples, not necessarily on a frame boundary--this requires */
-/*  buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES. */
-/*  Returns the number of samples stored per channel; it may be less than requested */
-/*  at the end of the file. If there are no more samples in the file, returns 0. */
+// gets num_samples samples, not necessarily on a frame boundary--this requires
+// buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES.
+// Returns the number of samples stored per channel; it may be less than requested
+// at the end of the file. If there are no more samples in the file, returns 0.
 
 #ifndef STB_VORBIS_NO_INTEGER_CONVERSION
 extern int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts);
 extern int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int num_samples);
 #endif
-/*  gets num_samples samples, not necessarily on a frame boundary--this requires */
-/*  buffering so you have to supply the buffers. Applies the coercion rules above */
-/* to produce 'channels' channels. Returns the number of samples stored per channel;  */
-/*  it may be less than requested at the end of the file. If there are no more */
-/*  samples in the file, returns 0. */
+// gets num_samples samples, not necessarily on a frame boundary--this requires
+// buffering so you have to supply the buffers. Applies the coercion rules above
+// to produce 'channels' channels. Returns the number of samples stored per channel;
+// it may be less than requested at the end of the file. If there are no more
+// samples in the file, returns 0.
 
 #endif
 
-/* //////   ERROR CODES */
+////////   ERROR CODES
 
 enum STBVorbisError
 {
    VORBIS__no_error,
 
-   VORBIS_need_more_data=1,             /*  not a real error */
+   VORBIS_need_more_data=1,             // not a real error
 
-   VORBIS_invalid_api_mixing,           /*  can't mix API modes */
-   VORBIS_outofmem,                     /*  not enough memory */
-   VORBIS_feature_not_supported,        /*  uses floor 0 */
-   VORBIS_too_many_channels,            /*  STB_VORBIS_MAX_CHANNELS is too small */
-   VORBIS_file_open_failure,            /*  fopen() failed */
-   VORBIS_seek_without_length,          /*  can't seek in unknown-length file */
+   VORBIS_invalid_api_mixing,           // can't mix API modes
+   VORBIS_outofmem,                     // not enough memory
+   VORBIS_feature_not_supported,        // uses floor 0
+   VORBIS_too_many_channels,            // STB_VORBIS_MAX_CHANNELS is too small
+   VORBIS_file_open_failure,            // fopen() failed
+   VORBIS_seek_without_length,          // can't seek in unknown-length file
 
-   VORBIS_unexpected_eof=10,            /*  file is truncated? */
-   VORBIS_seek_invalid,                 /*  seek past EOF */
+   VORBIS_unexpected_eof=10,            // file is truncated?
+   VORBIS_seek_invalid,                 // seek past EOF
 
-   /*  decoding errors (corrupt/invalid stream) -- you probably */
-   /*  don't care about the exact details of these */
+   // decoding errors (corrupt/invalid stream) -- you probably
+   // don't care about the exact details of these
 
-   /*  vorbis errors: */
+   // vorbis errors:
    VORBIS_invalid_setup=20,
    VORBIS_invalid_stream,
 
-   /*  ogg errors: */
+   // ogg errors:
    VORBIS_missing_capture_pattern=30,
    VORBIS_invalid_stream_structure_version,
    VORBIS_continued_packet_flag_invalid,
@@ -427,141 +424,141 @@ enum STBVorbisError
 }
 #endif
 
-#endif /*  STB_VORBIS_INCLUDE_STB_VORBIS_H */
-/*  */
-/*   HEADER ENDS HERE */
-/*  */
-/* //////////////////////////////////////////////////////////////////////////// */
+#endif // STB_VORBIS_INCLUDE_STB_VORBIS_H
+//
+//  HEADER ENDS HERE
+//
+//////////////////////////////////////////////////////////////////////////////
 
 #ifndef STB_VORBIS_HEADER_ONLY
 
-/*  global configuration settings (e.g. set these in the project/makefile), */
-/*  or just set them in this file at the top (although ideally the first few */
-/*  should be visible when the header file is compiled too, although it's not */
-/*  crucial) */
+// global configuration settings (e.g. set these in the project/makefile),
+// or just set them in this file at the top (although ideally the first few
+// should be visible when the header file is compiled too, although it's not
+// crucial)
 
-/*  STB_VORBIS_NO_PUSHDATA_API */
-/*      does not compile the code for the various stb_vorbis_*_pushdata() */
-/*      functions */
-/*  #define STB_VORBIS_NO_PUSHDATA_API */
+// STB_VORBIS_NO_PUSHDATA_API
+//     does not compile the code for the various stb_vorbis_*_pushdata()
+//     functions
+// #define STB_VORBIS_NO_PUSHDATA_API
 
-/*  STB_VORBIS_NO_PULLDATA_API */
-/*      does not compile the code for the non-pushdata APIs */
-/*  #define STB_VORBIS_NO_PULLDATA_API */
+// STB_VORBIS_NO_PULLDATA_API
+//     does not compile the code for the non-pushdata APIs
+// #define STB_VORBIS_NO_PULLDATA_API
 
-/*  STB_VORBIS_NO_STDIO */
-/*      does not compile the code for the APIs that use FILE *s internally */
-/*      or externally (implied by STB_VORBIS_NO_PULLDATA_API) */
-/*  #define STB_VORBIS_NO_STDIO */
+// STB_VORBIS_NO_STDIO
+//     does not compile the code for the APIs that use FILE *s internally
+//     or externally (implied by STB_VORBIS_NO_PULLDATA_API)
+// #define STB_VORBIS_NO_STDIO
 
-/*  STB_VORBIS_NO_INTEGER_CONVERSION */
-/*      does not compile the code for converting audio sample data from */
-/*      float to integer (implied by STB_VORBIS_NO_PULLDATA_API) */
-/*  #define STB_VORBIS_NO_INTEGER_CONVERSION */
+// STB_VORBIS_NO_INTEGER_CONVERSION
+//     does not compile the code for converting audio sample data from
+//     float to integer (implied by STB_VORBIS_NO_PULLDATA_API)
+// #define STB_VORBIS_NO_INTEGER_CONVERSION
 
-/*  STB_VORBIS_NO_FAST_SCALED_FLOAT */
-/*       does not use a fast float-to-int trick to accelerate float-to-int on */
-/*       most platforms which requires endianness be defined correctly. */
-/* #define STB_VORBIS_NO_FAST_SCALED_FLOAT */
+// STB_VORBIS_NO_FAST_SCALED_FLOAT
+//      does not use a fast float-to-int trick to accelerate float-to-int on
+//      most platforms which requires endianness be defined correctly.
+//#define STB_VORBIS_NO_FAST_SCALED_FLOAT
 
 
-/*  STB_VORBIS_MAX_CHANNELS [number] */
-/*      globally define this to the maximum number of channels you need. */
-/*      The spec does not put a restriction on channels except that */
-/*      the count is stored in a byte, so 255 is the hard limit. */
-/*      Reducing this saves about 16 bytes per value, so using 16 saves */
-/*      (255-16)*16 or around 4KB. Plus anything other memory usage */
-/*      I forgot to account for. Can probably go as low as 8 (7.1 audio), */
-/*      6 (5.1 audio), or 2 (stereo only). */
+// STB_VORBIS_MAX_CHANNELS [number]
+//     globally define this to the maximum number of channels you need.
+//     The spec does not put a restriction on channels except that
+//     the count is stored in a byte, so 255 is the hard limit.
+//     Reducing this saves about 16 bytes per value, so using 16 saves
+//     (255-16)*16 or around 4KB. Plus anything other memory usage
+//     I forgot to account for. Can probably go as low as 8 (7.1 audio),
+//     6 (5.1 audio), or 2 (stereo only).
 #ifndef STB_VORBIS_MAX_CHANNELS
-#define STB_VORBIS_MAX_CHANNELS    16  /*  enough for anyone? */
+#define STB_VORBIS_MAX_CHANNELS    16  // enough for anyone?
 #endif
 
-/*  STB_VORBIS_PUSHDATA_CRC_COUNT [number] */
-/*      after a flush_pushdata(), stb_vorbis begins scanning for the */
-/*      next valid page, without backtracking. when it finds something */
-/*      that looks like a page, it streams through it and verifies its */
-/*      CRC32. Should that validation fail, it keeps scanning. But it's */
-/*      possible that _while_ streaming through to check the CRC32 of */
-/*      one candidate page, it sees another candidate page. This #define */
-/*     determines how many "overlapping" candidate pages it can search */
-/*     at once. Note that "real" pages are typically ~4KB to ~8KB, whereas */
-/*      garbage pages could be as big as 64KB, but probably average ~16KB. */
-/*      So don't hose ourselves by scanning an apparent 64KB page and */
-/*      missing a ton of real ones in the interim; so minimum of 2 */
+// STB_VORBIS_PUSHDATA_CRC_COUNT [number]
+//     after a flush_pushdata(), stb_vorbis begins scanning for the
+//     next valid page, without backtracking. when it finds something
+//     that looks like a page, it streams through it and verifies its
+//     CRC32. Should that validation fail, it keeps scanning. But it's
+//     possible that _while_ streaming through to check the CRC32 of
+//     one candidate page, it sees another candidate page. This #define
+//     determines how many "overlapping" candidate pages it can search
+//     at once. Note that "real" pages are typically ~4KB to ~8KB, whereas
+//     garbage pages could be as big as 64KB, but probably average ~16KB.
+//     So don't hose ourselves by scanning an apparent 64KB page and
+//     missing a ton of real ones in the interim; so minimum of 2
 #ifndef STB_VORBIS_PUSHDATA_CRC_COUNT
 #define STB_VORBIS_PUSHDATA_CRC_COUNT  4
 #endif
 
-/*  STB_VORBIS_FAST_HUFFMAN_LENGTH [number] */
-/*      sets the log size of the huffman-acceleration table.  Maximum */
-/*      supported value is 24. with larger numbers, more decodings are O(1), */
-/*      but the table size is larger so worse cache missing, so you'll have */
-/*      to probe (and try multiple ogg vorbis files) to find the sweet spot. */
+// STB_VORBIS_FAST_HUFFMAN_LENGTH [number]
+//     sets the log size of the huffman-acceleration table.  Maximum
+//     supported value is 24. with larger numbers, more decodings are O(1),
+//     but the table size is larger so worse cache missing, so you'll have
+//     to probe (and try multiple ogg vorbis files) to find the sweet spot.
 #ifndef STB_VORBIS_FAST_HUFFMAN_LENGTH
 #define STB_VORBIS_FAST_HUFFMAN_LENGTH   10
 #endif
 
-/*  STB_VORBIS_FAST_BINARY_LENGTH [number] */
-/*      sets the log size of the binary-search acceleration table. this */
-/*      is used in similar fashion to the fast-huffman size to set initial */
-/*      parameters for the binary search */
+// STB_VORBIS_FAST_BINARY_LENGTH [number]
+//     sets the log size of the binary-search acceleration table. this
+//     is used in similar fashion to the fast-huffman size to set initial
+//     parameters for the binary search
 
-/*  STB_VORBIS_FAST_HUFFMAN_INT */
-/*      The fast huffman tables are much more efficient if they can be */
-/*      stored as 16-bit results instead of 32-bit results. This restricts */
-/*      the codebooks to having only 65535 possible outcomes, though. */
-/*      (At least, accelerated by the huffman table.) */
+// STB_VORBIS_FAST_HUFFMAN_INT
+//     The fast huffman tables are much more efficient if they can be
+//     stored as 16-bit results instead of 32-bit results. This restricts
+//     the codebooks to having only 65535 possible outcomes, though.
+//     (At least, accelerated by the huffman table.)
 #ifndef STB_VORBIS_FAST_HUFFMAN_INT
 #define STB_VORBIS_FAST_HUFFMAN_SHORT
 #endif
 
-/*  STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH */
-/*     If the 'fast huffman' search doesn't succeed, then stb_vorbis falls */
-/*      back on binary searching for the correct one. This requires storing */
-/*      extra tables with the huffman codes in sorted order. Defining this */
-/*      symbol trades off space for speed by forcing a linear search in the */
-/*     non-fast case, except for "sparse" codebooks. */
-/*  #define STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH */
+// STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH
+//     If the 'fast huffman' search doesn't succeed, then stb_vorbis falls
+//     back on binary searching for the correct one. This requires storing
+//     extra tables with the huffman codes in sorted order. Defining this
+//     symbol trades off space for speed by forcing a linear search in the
+//     non-fast case, except for "sparse" codebooks.
+// #define STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH
 
-/*  STB_VORBIS_DIVIDES_IN_RESIDUE */
-/*      stb_vorbis precomputes the result of the scalar residue decoding */
-/*      that would otherwise require a divide per chunk. you can trade off */
-/*      space for time by defining this symbol. */
-/*  #define STB_VORBIS_DIVIDES_IN_RESIDUE */
+// STB_VORBIS_DIVIDES_IN_RESIDUE
+//     stb_vorbis precomputes the result of the scalar residue decoding
+//     that would otherwise require a divide per chunk. you can trade off
+//     space for time by defining this symbol.
+// #define STB_VORBIS_DIVIDES_IN_RESIDUE
 
-/*  STB_VORBIS_DIVIDES_IN_CODEBOOK */
-/*      vorbis VQ codebooks can be encoded two ways: with every case explicitly */
-/*      stored, or with all elements being chosen from a small range of values, */
-/*      and all values possible in all elements. By default, stb_vorbis expands */
-/*      this latter kind out to look like the former kind for ease of decoding, */
-/*      because otherwise an integer divide-per-vector-element is required to */
-/*      unpack the index. If you define STB_VORBIS_DIVIDES_IN_CODEBOOK, you can */
-/*      trade off storage for speed. */
-/* #define STB_VORBIS_DIVIDES_IN_CODEBOOK */
+// STB_VORBIS_DIVIDES_IN_CODEBOOK
+//     vorbis VQ codebooks can be encoded two ways: with every case explicitly
+//     stored, or with all elements being chosen from a small range of values,
+//     and all values possible in all elements. By default, stb_vorbis expands
+//     this latter kind out to look like the former kind for ease of decoding,
+//     because otherwise an integer divide-per-vector-element is required to
+//     unpack the index. If you define STB_VORBIS_DIVIDES_IN_CODEBOOK, you can
+//     trade off storage for speed.
+//#define STB_VORBIS_DIVIDES_IN_CODEBOOK
 
 #ifdef STB_VORBIS_CODEBOOK_SHORTS
 #error "STB_VORBIS_CODEBOOK_SHORTS is no longer supported as it produced incorrect results for some input formats"
 #endif
 
-/*  STB_VORBIS_DIVIDE_TABLE */
-/*      this replaces small integer divides in the floor decode loop with */
-/*      table lookups. made less than 1% difference, so disabled by default. */
+// STB_VORBIS_DIVIDE_TABLE
+//     this replaces small integer divides in the floor decode loop with
+//     table lookups. made less than 1% difference, so disabled by default.
 
-/*  STB_VORBIS_NO_INLINE_DECODE */
-/*      disables the inlining of the scalar codebook fast-huffman decode. */
-/*      might save a little codespace; useful for debugging */
-/*  #define STB_VORBIS_NO_INLINE_DECODE */
+// STB_VORBIS_NO_INLINE_DECODE
+//     disables the inlining of the scalar codebook fast-huffman decode.
+//     might save a little codespace; useful for debugging
+// #define STB_VORBIS_NO_INLINE_DECODE
 
-/*  STB_VORBIS_NO_DEFER_FLOOR */
-/*      Normally we only decode the floor without synthesizing the actual */
-/*      full curve. We can instead synthesize the curve immediately. This */
-/*      requires more memory and is very likely slower, so I don't think */
-/*      you'd ever want to do it except for debugging. */
-/*  #define STB_VORBIS_NO_DEFER_FLOOR */
+// STB_VORBIS_NO_DEFER_FLOOR
+//     Normally we only decode the floor without synthesizing the actual
+//     full curve. We can instead synthesize the curve immediately. This
+//     requires more memory and is very likely slower, so I don't think
+//     you'd ever want to do it except for debugging.
+// #define STB_VORBIS_NO_DEFER_FLOOR
 
 
-/* //////////////////////////////////////////////////////////////////////////// */
+//////////////////////////////////////////////////////////////////////////////
 
 #ifdef STB_VORBIS_NO_PULLDATA_API
    #define STB_VORBIS_NO_INTEGER_CONVERSION
@@ -575,8 +572,8 @@ enum STBVorbisError
 #ifndef STB_VORBIS_NO_INTEGER_CONVERSION
 #ifndef STB_VORBIS_NO_FAST_SCALED_FLOAT
 
-   /*  only need endianness for fast-float-to-int, which we don't */
-   /*  use for pushdata */
+   // only need endianness for fast-float-to-int, which we don't
+   // use for pushdata
 
    #ifndef STB_VORBIS_BIG_ENDIAN
      #define STB_VORBIS_ENDIAN  0
@@ -597,45 +594,31 @@ enum STBVorbisError
    #include <string.h>
    #include <assert.h>
    #include <math.h>
-
-   /*  find definition of alloca if it's not in stdlib.h: */
-   #if defined(_MSC_VER) || defined(__MINGW32__)
-      #include <malloc.h>
+#else // STB_VORBIS_NO_CRT
+   #ifndef NULL
+   #define NULL 0
    #endif
-   #if defined(__linux__) || defined(__linux) || defined(__sun__) || defined(__EMSCRIPTEN__) || defined(__NEWLIB__)
-      #include <alloca.h>
-   #endif
-#else /*  STB_VORBIS_NO_CRT */
-   /* #define NULL 0 */
+   #ifndef malloc
    #define malloc(s)   0
-   #define free(s)     ((void) 0)
-   #define realloc(s)  0
-#endif /*  STB_VORBIS_NO_CRT */
+   #endif
+   #ifndef free
+   #define free(p)     ((void) 0)
+   #endif
+   #ifndef realloc
+   #define realloc(p, s)  0
+   #endif
+#endif // STB_VORBIS_NO_CRT
 
 #include <limits.h>
 
-/*Prefer the SDL_stdinc.h*/
-#if 0
-#ifdef __MINGW32__
-   /*  eff you mingw: */
-   /*     //      : */
-   /*          http://sourceforge.net/p/mingw-w64/mailman/message/32882927/ */
-   /*     "no that broke the build, reverted, who cares a//      : */
-   /*          http://sourceforge.net/p/mingw-w64/mailman/message/32890381/ */
-   #ifdef __forceinline
-   #undef __forceinline
-   #endif
-   #define __forceinline
-   #ifndef alloca
-   #define alloca __builtin_alloca
-   #endif
-#elif !defined(_MSC_VER)
-   #if __GNUC__
-      #define __forceinline inline
-   #else
-      #define __forceinline
-   #endif
-#endif
+#ifndef STB_FORCEINLINE
+    #if defined(_MSC_VER)
+        #define STB_FORCEINLINE __forceinline
+    #elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
+        #define STB_FORCEINLINE static __inline __attribute__((always_inline))
+    #else
+        #define STB_FORCEINLINE static inline
+    #endif
 #endif
 
 #if STB_VORBIS_MAX_CHANNELS > 256
@@ -651,12 +634,43 @@ enum STBVorbisError
 #include <crtdbg.h>
 #define CHECK(f)   _CrtIsValidHeapPointer(f->channel_buffers[1])
 #else
-#define CHECK(f)   ((void) 0)
+#define CHECK(f)   do {} while(0)
 #endif
 
-#define MAX_BLOCKSIZE_LOG  13   /*  from specification */
+#define MAX_BLOCKSIZE_LOG  13   // from specification
 #define MAX_BLOCKSIZE      (1 << MAX_BLOCKSIZE_LOG)
 
+#ifdef STB_VORBIS_SDL
+typedef Uint8 uint8;
+typedef Sint8 int8;
+typedef Uint16 uint16;
+typedef Sint16 int16;
+typedef Uint32 uint32;
+typedef Sint32 int32;
+#else
+typedef unsigned char  uint8;
+typedef   signed char   int8;
+typedef unsigned short uint16;
+typedef   signed short  int16;
+typedef unsigned int   uint32;
+typedef   signed int    int32;
+#endif
+
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+#define HAS_UBSAN
+#endif
+#endif
+#ifdef HAS_UBSAN
+#define STB_NO_SANITIZE(s) __attribute__((no_sanitize(s)))
+#else
+#define STB_NO_SANITIZE(s)
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#define FALSE 0
+#endif
 
 typedef float codetype;
 
@@ -666,18 +680,18 @@ typedef float codetype;
 #define STBV_NOTUSED(v)  (void)sizeof(v)
 #endif
 
-/*  @NOTE */
-/*  */
-/* Some arrays below are tagged "//varies", which means it's actually */
-/*  a variable-sized piece of data, but rather than malloc I assume it's */
-/*  small enough it's better to just allocate it all together with the */
-/*  main thing */
-/*  */
-/*  Most of the variables are specified with the smallest size I could pack */
-/*  them into. It might give better performance to make them all full-sized */
-/*  integers. It should be safe to freely rearrange the structures or change */
-/*  the sizes larger--nothing relies on silently truncating etc., nor the */
-/*  order of variables. */
+// @NOTE
+//
+// Some arrays below are tagged "//varies", which means it's actually
+// a variable-sized piece of data, but rather than malloc I assume it's
+// small enough it's better to just allocate it all together with the
+// main thing
+//
+// Most of the variables are specified with the smallest size I could pack
+// them into. It might give better performance to make them all full-sized
+// integers. It should be safe to freely rearrange the structures or change
+// the sizes larger--nothing relies on silently truncating etc., nor the
+// order of variables.
 
 #define FAST_HUFFMAN_TABLE_SIZE   (1 << STB_VORBIS_FAST_HUFFMAN_LENGTH)
 #define FAST_HUFFMAN_TABLE_MASK   (FAST_HUFFMAN_TABLE_SIZE - 1)
@@ -685,50 +699,50 @@ typedef float codetype;
 typedef struct
 {
    int dimensions, entries;
-   Uint8 *codeword_lengths;
+   uint8 *codeword_lengths;
    float  minimum_value;
    float  delta_value;
-   Uint8  value_bits;
-   Uint8  lookup_type;
-   Uint8  sequence_p;
-   Uint8  sparse;
-   Uint32 lookup_values;
+   uint8  value_bits;
+   uint8  lookup_type;
+   uint8  sequence_p;
+   uint8  sparse;
+   uint32 lookup_values;
    codetype *multiplicands;
-   Uint32 *codewords;
+   uint32 *codewords;
    #ifdef STB_VORBIS_FAST_HUFFMAN_SHORT
-    Sint16  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
+    int16  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
    #else
-    Sint32  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
+    int32  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
    #endif
-   Uint32 *sorted_codewords;
+   uint32 *sorted_codewords;
    int    *sorted_values;
    int     sorted_entries;
 } Codebook;
 
 typedef struct
 {
-   Uint8 order;
-   Uint16 rate;
-   Uint16 bark_map_size;
-   Uint8 amplitude_bits;
-   Uint8 amplitude_offset;
-   Uint8 number_of_books;
-   Uint8 book_list[16]; /*  varies */
+   uint8 order;
+   uint16 rate;
+   uint16 bark_map_size;
+   uint8 amplitude_bits;
+   uint8 amplitude_offset;
+   uint8 number_of_books;
+   uint8 book_list[16]; // varies
 } Floor0;
 
 typedef struct
 {
-   Uint8 partitions;
-   Uint8 partition_class_list[32]; /*  varies */
-   Uint8 class_dimensions[16]; /*  varies */
-   Uint8 class_subclasses[16]; /*  varies */
-   Uint8 class_masterbooks[16]; /*  varies */
-   Sint16 subclass_books[16][8]; /*  varies */
-   Uint16 Xlist[31*8+2]; /*  varies */
-   Uint8 sorted_order[31*8+2];
-   Uint8 neighbors[31*8+2][2];
-   Uint8 floor1_multiplier;
-   Uint8 rangebits;
+   uint8 partitions;
+   uint8 partition_class_list[32]; // varies
+   uint8 class_dimensions[16]; // varies
+   uint8 class_subclasses[16]; // varies
+   uint8 class_masterbooks[16]; // varies
+   int16 subclass_books[16][8]; // varies
+   uint16 Xlist[31*8+2]; // varies
+   uint8 sorted_order[31*8+2];
+   uint8 neighbors[31*8+2][2];
+   uint8 floor1_multiplier;
+   uint8 rangebits;
    int values;
 } Floor1;
 
@@ -740,56 +754,57 @@ typedef union
 
 typedef struct
 {
-   Uint32 begin, end;
-   Uint32 part_size;
-   Uint8 classifications;
-   Uint8 classbook;
-   Uint8 **classdata;
-   Sint16 (*residue_books)[8];
+   uint32 begin, end;
+   uint32 part_size;
+   uint8 classifications;
+   uint8 classbook;
+   uint8 **classdata;
+   int16 (*residue_books)[8];
 } Residue;
 
 typedef struct
 {
-   Uint8 magnitude;
-   Uint8 angle;
-   Uint8 mux;
+   uint8 magnitude;
+   uint8 angle;
+   uint8 mux;
 } MappingChannel;
 
 typedef struct
 {
-   Uint16 coupling_steps;
+  // https://github.com/nothings/stb/pull/1312
    MappingChannel *chan;
-   Uint8  submaps;
-   Uint8  submap_floor[15]; /*  varies */
-   Uint8  submap_residue[15]; /*  varies */
+   uint16 coupling_steps;
+   uint8  submaps;
+   uint8  submap_floor[16]; // varies
+   uint8  submap_residue[16]; // varies
 } Mapping;
 
 typedef struct
 {
-   Uint8 blockflag;
-   Uint8 mapping;
-   Uint16 windowtype;
-   Uint16 transformtype;
+   uint8 blockflag;
+   uint8 mapping;
+   uint16 windowtype;
+   uint16 transformtype;
 } Mode;
 
 typedef struct
 {
-   Uint32  goal_crc;    /*  expected crc if match */
-   int     bytes_left;  /*  bytes left in packet */
-   Uint32  crc_so_far;  /*  running crc */
-   int     bytes_done;  /*  bytes processed in _current_ chunk */
-   Uint32  sample_loc;  /*  granule pos encoded in page */
+   uint32  goal_crc;    // expected crc if match
+   int     bytes_left;  // bytes left in packet
+   uint32  crc_so_far;  // running crc
+   int     bytes_done;  // bytes processed in _current_ chunk
+   uint32  sample_loc;  // granule pos encoded in page
 } CRCscan;
 
 typedef struct
 {
-   Uint32 page_start, page_end;
-   Uint32 last_decoded_sample;
+   uint32 page_start, page_end;
+   uint32 last_decoded_sample;
 } ProbedPage;
 
 struct stb_vorbis
 {
-  /*  user-accessible info */
+  // user-accessible info
    unsigned int sample_rate;
    int channels;
 
@@ -801,59 +816,63 @@ struct stb_vorbis
    int comment_list_length;
    char **comment_list;
 
-  /*  input config */
+  // input config
 #ifndef STB_VORBIS_NO_STDIO
    FILE *f;
-#endif
-   Uint32 f_start;
+   uint32 f_start;
    int close_on_free;
-   SDL_RWops *rw;
+#endif
+#ifdef STB_VORBIS_SDL
+   SDL_RWops *rwops;
+   uint32 rwops_start;
+   int close_on_free;
+#endif
 
-   Uint8 *stream;
-   Uint8 *stream_start;
-   Uint8 *stream_end;
+   uint8 *stream;
+   uint8 *stream_start;
+   uint8 *stream_end;
 
-   Uint32 stream_len;
+   uint32 stream_len;
 
-   Uint8  push_mode;
+   uint8  push_mode;
 
-   /*  the page to seek to when seeking to start, may be zero */
-   Uint32 first_audio_page_offset;
+   // the page to seek to when seeking to start, may be zero
+   uint32 first_audio_page_offset;
 
-   /*  p_first is the page on which the first audio packet ends */
-   /*  (but not necessarily the page on which it starts) */
+   // p_first is the page on which the first audio packet ends
+   // (but not necessarily the page on which it starts)
    ProbedPage p_first, p_last;
 
-  /*  memory management */
+  // memory management
    stb_vorbis_alloc alloc;
    int setup_offset;
    int temp_offset;
 
-  /*  run-time results */
+  // run-time results
    int eof;
    enum STBVorbisError error;
 
-  /*  user-useful data */
+  // user-useful data
 
-  /*  header info */
+  // header info
    int blocksize[2];
    int blocksize_0, blocksize_1;
    int codebook_count;
    Codebook *codebooks;
    int floor_count;
-   Uint16 floor_types[64]; /*  varies */
+   uint16 floor_types[64]; // varies
    Floor *floor_config;
    int residue_count;
-   Uint16 residue_types[64]; /*  varies */
+   uint16 residue_types[64]; // varies
    Residue *residue_config;
    int mapping_count;
    Mapping *mapping;
    int mode_count;
-   Mode mode_config[64];  /*  varies */
+   Mode mode_config[64];  // varies
 
-   Sint64 total_samples;
+   uint32 total_samples;
 
-  /*  decode buffer */
+  // decode buffer
    float *channel_buffers[STB_VORBIS_MAX_CHANNELS];
    float *outputs        [STB_VORBIS_MAX_CHANNELS];
 
@@ -861,58 +880,67 @@ struct stb_vorbis
    int previous_length;
 
    #ifndef STB_VORBIS_NO_DEFER_FLOOR
-   Sint16 *finalY[STB_VORBIS_MAX_CHANNELS];
+   int16 *finalY[STB_VORBIS_MAX_CHANNELS];
    #else
    float *floor_buffers[STB_VORBIS_MAX_CHANNELS];
    #endif
 
-   Uint32 current_loc; /*  sample location of next frame to decode */
+   uint32 current_loc; // sample location of next frame to decode
    int    current_loc_valid;
 
-   Sint64 current_playback_loc; /*  sample location of played samples*/
+   int32  current_playback_loc; // sample location of played samples
    int    current_playback_loc_valid;
 
-  /*  per-blocksize precomputed data */
+  // per-blocksize precomputed data
 
-   /*  twiddle factors */
+   // twiddle factors
    float *A[2],*B[2],*C[2];
    float *window[2];
-   Uint16 *bit_reverse[2];
+   uint16 *bit_reverse[2];
 
-  /*  current page/packet/segment streaming info */
-   Uint32 serial; /*  stream serial number for verification */
+  // current page/packet/segment streaming info
+   uint32 serial; // stream serial number for verification
    int last_page;
    int segment_count;
-   Uint8 segments[255];
-   Uint8 page_flag;
-   Uint8 bytes_in_seg;
-   Uint8 first_decode;
+   uint8 segments[255];
+   uint8 page_flag;
+   uint8 bytes_in_seg;
+   uint8 first_decode;
    int next_seg;
-   int last_seg;  /*  flag that we're on the last segment */
-   int last_seg_which; /*  what was the segment number of the last seg? */
-   Uint32 acc;
+   int last_seg;  // flag that we're on the last segment
+   int last_seg_which; // what was the segment number of the last seg?
+   uint32 acc;
    int valid_bits;
    int packet_bytes;
    int end_seg_with_known_loc;
-   Uint32 known_loc_for_packet;
+   uint32 known_loc_for_packet;
    int discard_samples_deferred;
-   Uint32 samples_output;
+   uint32 samples_output;
 
-  /*  push mode scanning */
-   int page_crc_tests; /*  only in push_mode: number of tests active; -1 if not searching */
+  // push mode scanning
+   int page_crc_tests; // only in push_mode: number of tests active; -1 if not searching
 #ifndef STB_VORBIS_NO_PUSHDATA_API
    CRCscan scan[STB_VORBIS_PUSHDATA_CRC_COUNT];
 #endif
 
-  /*  sample-access */
+  // sample-access
    int channel_buffer_start;
    int channel_buffer_end;
+
+  // hack: decode work buffer (used in inverse_mdct and decode_residues)
+   void *work_buffer;
+
+  // temporary buffers
+   void *temp_lengths;
+   void *temp_codewords;
+   void *temp_values;
+   void *temp_mults;
 };
 
 #if defined(STB_VORBIS_NO_PUSHDATA_API)
-   #define IS_PUSH_MODE(f)   SDL_FALSE
+   #define IS_PUSH_MODE(f)   FALSE
 #elif defined(STB_VORBIS_NO_PULLDATA_API)
-   #define IS_PUSH_MODE(f)   SDL_TRUE
+   #define IS_PUSH_MODE(f)   TRUE
 #else
    #define IS_PUSH_MODE(f)   ((f)->push_mode)
 #endif
@@ -923,34 +951,27 @@ static int error(vorb *f, enum STBVorbisError e)
 {
    f->error = e;
    if (!f->eof && e != VORBIS_need_more_data) {
-      f->error=e; /*  breakpoint for debugging */
+      f->error=e; // breakpoint for debugging
    }
    return 0;
 }
 
 
-/*  these functions are used for allocating temporary memory */
-/*  while decoding. if you can afford the stack space, use */
-/*  alloca(); otherwise, provide a temp buffer and it will */
-/*  allocate out of those. */
+// these functions are used for allocating temporary memory
+// while decoding. if you can afford the stack space, use
+// alloca(); otherwise, provide a temp buffer and it will
+// allocate out of those.
 
 #define array_size_required(count,size)  (count*(sizeof(void *)+(size)))
-#if defined(HAVE_ALLOCA)
-#   define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : alloca(size))
-#   define temp_free(f,p)                  (void)0
-#   define temp_buffer
-#else
-#   define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : \
-                                           (size > 20480 ? SDL_malloc(size) : (void*)temp_buffer_fixed))
-#   define temp_free(f,p)                  if(temp_buffer_fixed != (Uint8*)p) SDL_free(p);
-#   define temp_buffer                     Uint8 temp_buffer_fixed[20480];
-#endif
+
+#define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : f->work_buffer)
+#define temp_free(f,p)                  do {} while (0)
 #define temp_alloc_save(f)              ((f)->temp_offset)
 #define temp_alloc_restore(f,p)         ((f)->temp_offset = (p))
 
 #define temp_block_array(f,count,size)  make_block_array(temp_alloc(f,array_size_required(count,size)), count, size)
 
-/*  given a sufficiently large block of memory, make an array of pointers to subblocks of it */
+// given a sufficiently large block of memory, make an array of pointers to subblocks of it
 static void *make_block_array(void *mem, int count, int size)
 {
    int i;
@@ -965,7 +986,7 @@ static void *make_block_array(void *mem, int count, int size)
 
 static void *setup_malloc(vorb *f, int sz)
 {
-   sz = (sz+7) & ~7; /*  round up to nearest 8 for alignment of future allocs. */
+   sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    f->setup_memory_required += sz;
    if (f->alloc.alloc_buffer) {
       void *p = (char *) f->alloc.alloc_buffer + f->setup_offset;
@@ -973,56 +994,58 @@ static void *setup_malloc(vorb *f, int sz)
       f->setup_offset += sz;
       return p;
    }
-   return sz ? SDL_malloc(sz) : NULL;
+   return sz ? malloc(sz) : NULL;
 }
 
 static void setup_free(vorb *f, void *p)
 {
-   if (f->alloc.alloc_buffer) return; /*  do nothing; setup mem is a stack */
-   SDL_free(p);
+   if (f->alloc.alloc_buffer) return; // do nothing; setup mem is a stack
+   free(p);
 }
 
 static void *setup_temp_malloc(vorb *f, int sz)
 {
-   sz = (sz+7) & ~7; /*  round up to nearest 8 for alignment of future allocs. */
+   sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    if (f->alloc.alloc_buffer) {
       if (f->temp_offset - sz < f->setup_offset) return NULL;
       f->temp_offset -= sz;
       return (char *) f->alloc.alloc_buffer + f->temp_offset;
    }
-   return SDL_malloc(sz);
+   return malloc(sz);
 }
 
-static void setup_temp_free(vorb *f, void *p, int sz)
+static void setup_temp_free(vorb *f, void **_p, int sz)
 {
+   void *p = *_p;
+   *_p = NULL;
    if (f->alloc.alloc_buffer) {
       f->temp_offset += (sz+7)&~7;
       return;
    }
-   SDL_free(p);
+   free(p);
 }
 
-#define CRC32_POLY    0x04c11db7   /*  from spec */
+#define CRC32_POLY    0x04c11db7   // from spec
 
-static Uint32 crc_table[256];
+static uint32 crc_table[256];
 static void crc32_init(void)
 {
    int i,j;
-   Uint32 s;
+   uint32 s;
    for(i=0; i < 256; i++) {
-      for (s=(Uint32) i << 24, j=0; j < 8; ++j)
+      for (s=(uint32) i << 24, j=0; j < 8; ++j)
          s = (s << 1) ^ (s >= (1U<<31) ? CRC32_POLY : 0);
       crc_table[i] = s;
    }
 }
 
-SDL_FORCE_INLINE Uint32 crc32_update(Uint32 crc, Uint8 byte)
+STB_FORCEINLINE uint32 crc32_update(uint32 crc, uint8 byte)
 {
    return (crc << 8) ^ crc_table[byte ^ (crc >> 24)];
 }
 
 
-/*  used in setup, and for huffman that doesn't go fast path */
+// used in setup, and for huffman that doesn't go fast path
 static unsigned int bit_reverse(unsigned int n)
 {
   n = ((n & 0xAAAAAAAA) >>  1) | ((n & 0x55555555) << 1);
@@ -1037,16 +1060,16 @@ static float square(float x)
    return x*x;
 }
 
-/*  this is a weird definition of log2() for which log2(1) = 1, log2(2) = 2, log2(4) = 3 */
-/*  as required by the specification. fast(?) implementation from stb.h */
-/* @OPTIMIZE: called multiple times per-packet with "constants"; move to setup */
-static int ilog(Sint32 n)
+// this is a weird definition of log2() for which log2(1) = 1, log2(2) = 2, log2(4) = 3
+// as required by the specification. fast(?) implementation from stb.h
+// @OPTIMIZE: called multiple times per-packet with "constants"; move to setup
+static int ilog(int32 n)
 {
    static signed char log2_4[16] = { 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4 };
 
-   if (n < 0) return 0; /*  signed n returns 0 */
+   if (n < 0) return 0; // signed n returns 0
 
-   /*  2 compares if n < 16, 3 compares otherwise (4 if signed or n > 1<<29) */
+   // 2 compares if n < 16, 3 compares otherwise (4 if signed or n > 1<<29)
    if (n < (1 << 14))
         if (n < (1 <<  4))            return  0 + log2_4[n      ];
         else if (n < (1 <<  9))       return  5 + log2_4[n >>  5];
@@ -1059,36 +1082,36 @@ static int ilog(Sint32 n)
 }
 
 #ifndef M_PI
-  #define M_PI  3.14159265358979323846264f  /*  from CRC */
+  #define M_PI  3.14159265358979323846264f  // from CRC
 #endif
 
-/*  code length assigned to a value with no huffman encoding */
+// code length assigned to a value with no huffman encoding
 #define NO_CODE   255
 
-/* ///////////////////// LEAF SETUP FUNCTIONS ////////////////////////// */
-/*  */
-/*  these functions are only called at setup, and only a few times */
-/*  per file */
+/////////////////////// LEAF SETUP FUNCTIONS //////////////////////////
+//
+// these functions are only called at setup, and only a few times
+// per file
 
-static float float32_unpack(Uint32 x)
+static float float32_unpack(uint32 x)
 {
-   /*  from the specification */
-   Uint32 mantissa = x & 0x1fffff;
-   Uint32 sign = x & 0x80000000;
-   Uint32 exp = (x & 0x7fe00000) >> 21;
+   // from the specification
+   uint32 mantissa = x & 0x1fffff;
+   uint32 sign = x & 0x80000000;
+   uint32 exp = (x & 0x7fe00000) >> 21;
    double res = sign ? -(double)mantissa : (double)mantissa;
    return (float) ldexp((float)res, (int)exp-788);
 }
 
 
-/*  zlib & jpeg huffman tables assume that the output symbols */
-/*  can either be arbitrarily arranged, or have monotonically */
-/*  increasing frequencies--they rely on the lengths being sorted; */
-/*  this makes for a very simple generation algorithm. */
-/*  vorbis allows a huffman table with non-sorted lengths. This */
-/*  requires a more sophisticated construction, since symbols in */
-/* order do not map to huffman codes "in order". */
-static void add_entry(Codebook *c, Uint32 huff_code, int symbol, int count, int len, Uint32 *values)
+// zlib & jpeg huffman tables assume that the output symbols
+// can either be arbitrarily arranged, or have monotonically
+// increasing frequencies--they rely on the lengths being sorted;
+// this makes for a very simple generation algorithm.
+// vorbis allows a huffman table with non-sorted lengths. This
+// requires a more sophisticated construction, since symbols in
+// order do not map to huffman codes "in order".
+static void add_entry(Codebook *c, uint32 huff_code, int symbol, int count, int len, uint32 *values)
 {
    if (!c->sparse) {
       c->codewords      [symbol] = huff_code;
@@ -1099,54 +1122,54 @@ static void add_entry(Codebook *c, Uint32 huff_code, int symbol, int count, int 
    }
 }
 
-static int compute_codewords(Codebook *c, Uint8 *len, int n, Uint32 *values)
+static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
 {
    int i,k,m=0;
-   Uint32 available[32];
+   uint32 available[32];
 
-   SDL_memset(available, 0, sizeof(available));
-   /*  find the first entry */
+   memset(available, 0, sizeof(available));
+   // find the first entry
    for (k=0; k < n; ++k) if (len[k] < NO_CODE) break;
-   if (k == n) { SDL_assert(c->sorted_entries == 0); return SDL_TRUE; }
-   SDL_assert(len[k] < 32); /*  no error return required, code reading lens checks this */
-   /*  add to the list */
+   if (k == n) { assert(c->sorted_entries == 0); return TRUE; }
+   assert(len[k] < 32); // no error return required, code reading lens checks this
+   // add to the list
    add_entry(c, 0, k, m++, len[k], values);
-   /*  add all available leaves */
+   // add all available leaves
    for (i=1; i <= len[k]; ++i)
       available[i] = 1U << (32-i);
-   /*  note that the above code treats the first case specially, */
-   /*  but it's really the same as the following code, so they */
-   /*  could probably be combined (except the initial code is 0, */
-   /* and I use 0 in available[] to mean 'empty') */
+   // note that the above code treats the first case specially,
+   // but it's really the same as the following code, so they
+   // could probably be combined (except the initial code is 0,
+   // and I use 0 in available[] to mean 'empty')
    for (i=k+1; i < n; ++i) {
-      Uint32 res;
+      uint32 res;
       int z = len[i], y;
       if (z == NO_CODE) continue;
-      SDL_assert(z < 32); /*  no error return required, code reading lens checks this */
-      /*  find lowest available leaf (should always be earliest, */
-      /*  which is what the specification calls for) */
-      /*  note that this property, and the fact we can never have */
-      /*  more than one free leaf at a given level, isn't totally */
-      /*  trivial to prove, but it seems true and the assert never */
-      /*  fires, so! */
+      assert(z < 32); // no error return required, code reading lens checks this
+      // find lowest available leaf (should always be earliest,
+      // which is what the specification calls for)
+      // note that this property, and the fact we can never have
+      // more than one free leaf at a given level, isn't totally
+      // trivial to prove, but it seems true and the assert never
+      // fires, so!
       while (z > 0 && !available[z]) --z;
-      if (z == 0) { return SDL_FALSE; }
+      if (z == 0) { return FALSE; }
       res = available[z];
       available[z] = 0;
       add_entry(c, bit_reverse(res), i, m++, len[i], values);
-      /*  propagate availability up the tree */
+      // propagate availability up the tree
       if (z != len[i]) {
          for (y=len[i]; y > z; --y) {
-            SDL_assert(available[y] == 0);
+            assert(available[y] == 0);
             available[y] = res + (1 << (32-y));
          }
       }
    }
-   return SDL_TRUE;
+   return TRUE;
 }
 
-/*  accelerated huffman table allows fast O(1) match of all symbols */
-/*  of length <= STB_VORBIS_FAST_HUFFMAN_LENGTH */
+// accelerated huffman table allows fast O(1) match of all symbols
+// of length <= STB_VORBIS_FAST_HUFFMAN_LENGTH
 static void compute_accelerated_huffman(Codebook *c)
 {
    int i, len;
@@ -1155,12 +1178,12 @@ static void compute_accelerated_huffman(Codebook *c)
 
    len = c->sparse ? c->sorted_entries : c->entries;
    #ifdef STB_VORBIS_FAST_HUFFMAN_SHORT
-   if (len > 32767) len = 32767; /*  largest possible value we can encode! */
+   if (len > 32767) len = 32767; // largest possible value we can encode!
    #endif
    for (i=0; i < len; ++i) {
       if (c->codeword_lengths[i] <= STB_VORBIS_FAST_HUFFMAN_LENGTH) {
-         Uint32 z = c->sparse ? bit_reverse(c->sorted_codewords[i]) : c->codewords[i];
-         /*  set table entries for all bit combinations in the higher bits */
+         uint32 z = c->sparse ? bit_reverse(c->sorted_codewords[i]) : c->codewords[i];
+         // set table entries for all bit combinations in the higher bits
          while (z < FAST_HUFFMAN_TABLE_SIZE) {
              c->fast_huffman[z] = i;
              z += 1 << c->codeword_lengths[i];
@@ -1169,63 +1192,65 @@ static void compute_accelerated_huffman(Codebook *c)
    }
 }
 
+#ifndef STBV_CDECL
 #ifdef _MSC_VER
 #define STBV_CDECL __cdecl
 #else
 #define STBV_CDECL
 #endif
+#endif
 
-static int STBV_CDECL Uint32_compare(const void *p, const void *q)
+static int STBV_CDECL uint32_compare(const void *p, const void *q)
 {
-   Uint32 x = * (Uint32 *) p;
-   Uint32 y = * (Uint32 *) q;
+   uint32 x = * (uint32 *) p;
+   uint32 y = * (uint32 *) q;
    return x < y ? -1 : x > y;
 }
 
-static int include_in_sort(Codebook *c, Uint8 len)
+static int include_in_sort(Codebook *c, uint8 len)
 {
-   if (c->sparse) { SDL_assert(len != NO_CODE); return SDL_TRUE; }
-   if (len == NO_CODE) return SDL_FALSE;
-   if (len > STB_VORBIS_FAST_HUFFMAN_LENGTH) return SDL_TRUE;
-   return SDL_FALSE;
+   if (c->sparse) { assert(len != NO_CODE); return TRUE; }
+   if (len == NO_CODE) return FALSE;
+   if (len > STB_VORBIS_FAST_HUFFMAN_LENGTH) return TRUE;
+   return FALSE;
 }
 
-/*  if the fast table above doesn't work, we want to binary */
-/*  search them... need to reverse the bits */
-static void compute_sorted_huffman(Codebook *c, Uint8 *lengths, Uint32 *values)
+// if the fast table above doesn't work, we want to binary
+// search them... need to reverse the bits
+static void compute_sorted_huffman(Codebook *c, uint8 *lengths, uint32 *values)
 {
    int i, len;
-   /*  build a list of all the entries */
-   /* OPTIMIZATION: don't include the short ones, since they'll be caught by FAST_HUFFMAN. */
-   /*  this is kind of a frivolous optimization--I don't see any performance improvement, */
-   /*  but it's like 4 extra lines of code, so. */
+   // build a list of all the entries
+   // OPTIMIZATION: don't include the short ones, since they'll be caught by FAST_HUFFMAN.
+   // this is kind of a frivolous optimization--I don't see any performance improvement,
+   // but it's like 4 extra lines of code, so.
    if (!c->sparse) {
       int k = 0;
       for (i=0; i < c->entries; ++i)
          if (include_in_sort(c, lengths[i]))
             c->sorted_codewords[k++] = bit_reverse(c->codewords[i]);
-      SDL_assert(k == c->sorted_entries);
+      assert(k == c->sorted_entries);
    } else {
       for (i=0; i < c->sorted_entries; ++i)
          c->sorted_codewords[i] = bit_reverse(c->codewords[i]);
    }
 
-   SDL_qsort(c->sorted_codewords, c->sorted_entries, sizeof(c->sorted_codewords[0]), Uint32_compare);
+   qsort(c->sorted_codewords, c->sorted_entries, sizeof(c->sorted_codewords[0]), uint32_compare);
    c->sorted_codewords[c->sorted_entries] = 0xffffffff;
 
    len = c->sparse ? c->sorted_entries : c->entries;
-   /*  now we need to indicate how they correspond; we could either */
-   /*    #1: sort a different data structure that says who they correspond to */
-   /*    #2: for each sorted entry, search the original list to find who corresponds */
-   /*    #3: for each original entry, find the sorted entry */
-   /*  #1 requires extra storage, #2 is slow, #3 can use binary search! */
+   // now we need to indicate how they correspond; we could either
+   //   #1: sort a different data structure that says who they correspond to
+   //   #2: for each sorted entry, search the original list to find who corresponds
+   //   #3: for each original entry, find the sorted entry
+   // #1 requires extra storage, #2 is slow, #3 can use binary search!
    for (i=0; i < len; ++i) {
       int huff_len = c->sparse ? lengths[values[i]] : lengths[i];
       if (include_in_sort(c,huff_len)) {
-         Uint32 code = bit_reverse(c->codewords[i]);
+         uint32 code = bit_reverse(c->codewords[i]);
          int x=0, n=c->sorted_entries;
          while (n > 1) {
-            /*  invariant: sc[x] <= code < sc[x+n] */
+            // invariant: sc[x] <= code < sc[x+n]
             int m = x + (n >> 1);
             if (c->sorted_codewords[m] <= code) {
                x = m;
@@ -1234,7 +1259,7 @@ static void compute_sorted_huffman(Codebook *c, Uint8 *lengths, Uint32 *values)
                n >>= 1;
             }
          }
-         SDL_assert(c->sorted_codewords[x] == code);
+         assert(c->sorted_codewords[x] == code);
          if (c->sparse) {
             c->sorted_values[x] = values[i];
             c->codeword_lengths[x] = huff_len;
@@ -1245,28 +1270,32 @@ static void compute_sorted_huffman(Codebook *c, Uint8 *lengths, Uint32 *values)
    }
 }
 
-/*  only run while parsing the header (3 times) */
-static int vorbis_validate(Uint8 *data)
+// only run while parsing the header (3 times)
+static int vorbis_validate(uint8 *data)
 {
-   static Uint8 vorbis[6] = { 'v', 'o', 'r', 'b', 'i', 's' };
-   return SDL_memcmp(data, vorbis, 6) == 0;
+   static uint8 vorbis[6] = { 'v', 'o', 'r', 'b', 'i', 's' };
+   return memcmp(data, vorbis, 6) == 0;
 }
 
-/*  called from setup only, once per code book */
-/*  (formula implied by specification) */
+// called from setup only, once per code book
+// (formula implied by specification)
+//
+// suppress an UBSan error caused by invalid input data.
+// upstream:  https://github.com/nothings/stb/issues/1168.
+STB_NO_SANITIZE("float-cast-overflow")
 static int lookup1_values(int entries, int dim)
 {
-   int r = (int) SDL_floor(exp((float) log((float) entries) / dim));
-   if ((int) SDL_floor(pow((float) r+1, dim)) <= entries)   /*  (int) cast for MinGW warning; */
-      ++r;                                              /*  floor() to avoid _ftol() when non-CRT */
-   if (SDL_pow((float) r+1, dim) <= entries)
+   int r = (int) floor(exp((float) log((float) entries) / dim));
+   if ((int) floor(pow((float) r+1, dim)) <= entries)   // (int) cast for MinGW warning;
+      ++r;                                              // floor() to avoid _ftol() when non-CRT
+   if (pow((float) r+1, dim) <= entries)
       return -1;
-   if ((int) SDL_floor(SDL_pow((float) r, dim)) > entries)
+   if ((int) floor(pow((float) r, dim)) > entries)
       return -1;
    return r;
 }
 
-/*  called twice per file */
+// called twice per file
 static void compute_twiddle_factors(int n, float *A, float *B, float *C)
 {
    int n4 = n >> 2, n8 = n >> 3;
@@ -1288,12 +1317,12 @@ static void compute_window(int n, float *window)
 {
    int n2 = n >> 1, i;
    for (i=0; i < n2; ++i)
-      window[i] = (float) sin(0.5 * M_PI * square((float) SDL_sin((i - 0 + 0.5) / n2 * 0.5 * M_PI)));
+      window[i] = (float) sin(0.5 * M_PI * square((float) sin((i - 0 + 0.5) / n2 * 0.5 * M_PI)));
 }
 
-static void compute_bitreverse(int n, Uint16 *rev)
+static void compute_bitreverse(int n, uint16 *rev)
 {
-   int ld = ilog(n) - 1; /*  ilog is off-by-one from normal definitions */
+   int ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
    int i, n8 = n >> 3;
    for (i=0; i < n8; ++i)
       rev[i] = (bit_reverse(i) >> (32-ld+3)) << 2;
@@ -1310,13 +1339,13 @@ static int init_blocksize(vorb *f, int b, int n)
    f->window[b] = (float *) setup_malloc(f, sizeof(float) * n2);
    if (!f->window[b]) return error(f, VORBIS_outofmem);
    compute_window(n, f->window[b]);
-   f->bit_reverse[b] = (Uint16 *) setup_malloc(f, sizeof(Uint16) * n8);
+   f->bit_reverse[b] = (uint16 *) setup_malloc(f, sizeof(uint16) * n8);
    if (!f->bit_reverse[b]) return error(f, VORBIS_outofmem);
    compute_bitreverse(n, f->bit_reverse[b]);
-   return SDL_TRUE;
+   return TRUE;
 }
 
-static void neighbors(Uint16 *x, int n, int *plow, int *phigh)
+static void neighbors(uint16 *x, int n, int *plow, int *phigh)
 {
    int low = -1;
    int high = 65536;
@@ -1327,10 +1356,10 @@ static void neighbors(Uint16 *x, int n, int *plow, int *phigh)
    }
 }
 
-/*  this has been repurposed so y is now the original index instead of y */
+// this has been repurposed so y is now the original index instead of y
 typedef struct
 {
-   Uint16 x,id;
+   uint16 x,id;
 } stbv__floor_ordering;
 
 static int STBV_CDECL point_compare(const void *p, const void *q)
@@ -1340,72 +1369,66 @@ static int STBV_CDECL point_compare(const void *p, const void *q)
    return a->x < b->x ? -1 : a->x > b->x;
 }
 
-/*  */
-/* ///////////////////// END LEAF SETUP FUNCTIONS ////////////////////////// */
+//
+/////////////////////// END LEAF SETUP FUNCTIONS //////////////////////////
 
 
-#if defined(STB_VORBIS_NO_STDIO)
-   #define USE_MEMORY(z)    SDL_TRUE
+#ifdef STB_VORBIS_SDL
+   #define USE_MEMORY(z)    FALSE
+#elif defined(STB_VORBIS_NO_STDIO)
+   #define USE_MEMORY(z)    TRUE
 #else
    #define USE_MEMORY(z)    ((z)->stream)
 #endif
 
-#define USE_RWOPS(z)    ((z)->rw)
-
-static Uint8 get8(vorb *z)
+static uint8 get8(vorb *z)
 {
-   if (USE_RWOPS(z))
-   {
-       Uint8 c;
-       int l = SDL_RWread(z->rw, &c, 1, 1);
-       if (l < 1) { z->eof = SDL_TRUE; return 0; }
-       return c;
-   }
+   #ifdef STB_VORBIS_SDL
+   uint8 c;
+   if (SDL_RWread(z->rwops, &c, 1, 1) != 1) { z->eof = TRUE; return 0; }
+   return c;
 
+   #else
    if (USE_MEMORY(z)) {
-      if (z->stream >= z->stream_end) { z->eof = SDL_TRUE; return 0; }
+      if (z->stream >= z->stream_end) { z->eof = TRUE; return 0; }
       return *z->stream++;
    }
+   #endif
 
    #ifndef STB_VORBIS_NO_STDIO
    {
    int c = fgetc(z->f);
-   if (c == EOF) { z->eof = SDL_TRUE; return 0; }
+   if (c == EOF) { z->eof = TRUE; return 0; }
    return c;
    }
-   #else
-   z->eof = SDL_TRUE;
-   return 0;
    #endif
 }
 
-static Uint32 get32(vorb *f)
+static uint32 get32(vorb *f)
 {
-   Uint32 x;
+   uint32 x;
    x = get8(f);
    x += get8(f) << 8;
    x += get8(f) << 16;
-   x += (Uint32) get8(f) << 24;
+   x += (uint32) get8(f) << 24;
    return x;
 }
 
-static int getn(vorb *z, Uint8 *data, int n)
+static int getn(vorb *z, uint8 *data, int n)
 {
-   if (USE_RWOPS(z)) {
-      if (SDL_RWread(z->rw, data, n, 1) == 1)
-         return 1;
-      else {
-         z->eof = 1;
-         return 0;
-      }
-   }
+   #ifdef STB_VORBIS_SDL
+   if (SDL_RWread(z->rwops, data, n, 1) == 1) return 1;
+   z->eof = 1;
+   return 0;
 
+   #else
    if (USE_MEMORY(z)) {
       if (z->stream+n > z->stream_end) { z->eof = 1; return 0; }
-      SDL_memcpy(data, z->stream, n);
+      memcpy(data, z->stream, n);
       z->stream += n;
       return 1;
    }
+   #endif
 
    #ifndef STB_VORBIS_NO_STDIO
    if (fread(data, n, 1, z->f) == 1)
@@ -1419,16 +1442,17 @@ static int getn(vorb *z, Uint8 *data, int n)
 
 static void skip(vorb *z, int n)
 {
-   if (USE_RWOPS(z)) {
-      long x = SDL_RWtell(z->rw);
-      SDL_RWseek(z->rw, x+n, RW_SEEK_SET);
-      return;
-   }
+   #ifdef STB_VORBIS_SDL
+   SDL_RWseek(z->rwops, n, RW_SEEK_CUR);
+
+   #else
    if (USE_MEMORY(z)) {
       z->stream += n;
       if (z->stream >= z->stream_end) z->eof = 1;
       return;
    }
+   #endif
+
    #ifndef STB_VORBIS_NO_STDIO
    {
       long x = ftell(z->f);
@@ -1444,20 +1468,20 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
    #endif
    f->eof = 0;
 
-   if (USE_RWOPS(f)) {
-      if (loc + f->f_start < loc || loc >= 0x80000000) {
-         loc = 0x7fffffff;
-         f->eof = 1;
-      } else {
-         loc += f->f_start;
-      }
-      if (SDL_RWseek(f->rw, loc, RW_SEEK_SET) == loc)
-         return 1;
+   #ifdef STB_VORBIS_SDL
+   if (loc + f->rwops_start < loc || loc >= 0x80000000) {
+      loc = 0x7fffffff;
       f->eof = 1;
-      SDL_RWseek(f->rw, f->f_start, RW_SEEK_END);
-      return 0;
+   } else {
+      loc += f->rwops_start;
    }
+   if (SDL_RWseek(f->rwops, loc, RW_SEEK_SET) != -1)
+      return 1;
+   f->eof = 1;
+   SDL_RWseek(f->rwops, f->rwops_start, RW_SEEK_END);
+   return 0;
 
+   #else
    if (USE_MEMORY(f)) {
       if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
          f->stream = f->stream_end;
@@ -1468,6 +1492,7 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
          return 1;
       }
    }
+   #endif
 
    #ifndef STB_VORBIS_NO_STDIO
    if (loc + f->f_start < loc || loc >= 0x80000000) {
@@ -1485,15 +1510,15 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
 }
 
 
-static Uint8 ogg_page_header[4] = { 0x4f, 0x67, 0x67, 0x53 };
+static uint8 ogg_page_header[4] = { 0x4f, 0x67, 0x67, 0x53 };
 
 static int capture_pattern(vorb *f)
 {
-   if (0x4f != get8(f)) return SDL_FALSE;
-   if (0x67 != get8(f)) return SDL_FALSE;
-   if (0x67 != get8(f)) return SDL_FALSE;
-   if (0x53 != get8(f)) return SDL_FALSE;
-   return SDL_TRUE;
+   if (0x4f != get8(f)) return FALSE;
+   if (0x67 != get8(f)) return FALSE;
+   if (0x67 != get8(f)) return FALSE;
+   if (0x53 != get8(f)) return FALSE;
+   return TRUE;
 }
 
 #define PAGEFLAG_continued_packet   1
@@ -1502,39 +1527,39 @@ static int capture_pattern(vorb *f)
 
 static int start_page_no_capturepattern(vorb *f)
 {
-   Uint32 loc0,loc1,n;
+   uint32 loc0,loc1,n;
    if (f->first_decode && !IS_PUSH_MODE(f)) {
       f->p_first.page_start = stb_vorbis_get_file_offset(f) - 4;
    }
-   /*  stream structure version */
+   // stream structure version
    if (0 != get8(f)) return error(f, VORBIS_invalid_stream_structure_version);
-   /*  header flag */
+   // header flag
    f->page_flag = get8(f);
-   /*  absolute granule position */
+   // absolute granule position
    loc0 = get32(f);
    loc1 = get32(f);
-   /*  @TODO: validate loc0,loc1 as valid positions? */
-   /*  stream serial number -- vorbis doesn't interleave, so discard */
+   // @TODO: validate loc0,loc1 as valid positions?
+   // stream serial number -- vorbis doesn't interleave, so discard
    get32(f);
-   /* if (f->serial != get32(f)) return error(f, VORBIS_incorrect_stream_serial_number); */
-   /*  page sequence number */
+   //if (f->serial != get32(f)) return error(f, VORBIS_incorrect_stream_serial_number);
+   // page sequence number
    n = get32(f);
    f->last_page = n;
-   /*  CRC32 */
+   // CRC32
    get32(f);
-   /*  page_segments */
+   // page_segments
    f->segment_count = get8(f);
    if (!getn(f, f->segments, f->segment_count))
       return error(f, VORBIS_unexpected_eof);
-   /*  assume we _don't_ know any the sample position of any segments */
+   // assume we _don't_ know any the sample position of any segments
    f->end_seg_with_known_loc = -2;
    if (loc0 != ~0U || loc1 != ~0U) {
       int i;
-      /*  determine which packet is the last one that will complete */
+      // determine which packet is the last one that will complete
       for (i=f->segment_count-1; i >= 0; --i)
          if (f->segments[i] < 255)
             break;
-      /* 'i' is now the index of the _last_ segment of a packet that ends */
+      // 'i' is now the index of the _last_ segment of a packet that ends
       if (i >= 0) {
          f->end_seg_with_known_loc = i;
          f->known_loc_for_packet   = loc0;
@@ -1550,7 +1575,7 @@ static int start_page_no_capturepattern(vorb *f)
       f->p_first.last_decoded_sample = loc0;
    }
    f->next_seg = 0;
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static int start_page(vorb *f)
@@ -1562,32 +1587,32 @@ static int start_page(vorb *f)
 static int start_packet(vorb *f)
 {
    while (f->next_seg == -1) {
-      if (!start_page(f)) return SDL_FALSE;
+      if (!start_page(f)) return FALSE;
       if (f->page_flag & PAGEFLAG_continued_packet)
          return error(f, VORBIS_continued_packet_flag_invalid);
    }
-   f->last_seg = SDL_FALSE;
+   f->last_seg = FALSE;
    f->valid_bits = 0;
    f->packet_bytes = 0;
    f->bytes_in_seg = 0;
-   /*  f->next_seg is now valid */
-   return SDL_TRUE;
+   // f->next_seg is now valid
+   return TRUE;
 }
 
 static int maybe_start_packet(vorb *f)
 {
    if (f->next_seg == -1) {
       int x = get8(f);
-      if (f->eof) return SDL_FALSE; /*  EOF at page boundary is not an error! */
+      if (f->eof) return FALSE; // EOF at page boundary is not an error!
       if (0x4f != x      ) return error(f, VORBIS_missing_capture_pattern);
       if (0x67 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
       if (0x67 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
       if (0x53 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
-      if (!start_page_no_capturepattern(f)) return SDL_FALSE;
+      if (!start_page_no_capturepattern(f)) return FALSE;
       if (f->page_flag & PAGEFLAG_continued_packet) {
-         /*  set up enough state that we can read this packet if we want, */
-         /*  e.g. during recovery */
-         f->last_seg = SDL_FALSE;
+         // set up enough state that we can read this packet if we want,
+         // e.g. during recovery
+         f->last_seg = FALSE;
          f->bytes_in_seg = 0;
          return error(f, VORBIS_continued_packet_flag_invalid);
       }
@@ -1600,18 +1625,18 @@ static int next_segment(vorb *f)
    int len;
    if (f->last_seg) return 0;
    if (f->next_seg == -1) {
-      f->last_seg_which = f->segment_count-1; /*  in case start_page fails */
+      f->last_seg_which = f->segment_count-1; // in case start_page fails
       if (!start_page(f)) { f->last_seg = 1; return 0; }
       if (!(f->page_flag & PAGEFLAG_continued_packet)) return error(f, VORBIS_continued_packet_flag_invalid);
    }
    len = f->segments[f->next_seg++];
    if (len < 255) {
-      f->last_seg = SDL_TRUE;
+      f->last_seg = TRUE;
       f->last_seg_which = f->next_seg-1;
    }
    if (f->next_seg >= f->segment_count)
       f->next_seg = -1;
-   SDL_assert(f->bytes_in_seg == 0);
+   assert(f->bytes_in_seg == 0);
    f->bytes_in_seg = len;
    return len;
 }
@@ -1621,11 +1646,11 @@ static int next_segment(vorb *f)
 
 static int get8_packet_raw(vorb *f)
 {
-   if (!f->bytes_in_seg) {  /*  CLANG! */
+   if (!f->bytes_in_seg) {  // CLANG!
       if (f->last_seg) return EOP;
       else if (!next_segment(f)) return EOP;
    }
-   SDL_assert(f->bytes_in_seg > 0);
+   assert(f->bytes_in_seg > 0);
    --f->bytes_in_seg;
    ++f->packet_bytes;
    return get8(f);
@@ -1640,11 +1665,11 @@ static int get8_packet(vorb *f)
 
 static int get32_packet(vorb *f)
 {
-   Uint32 x;
+   uint32 x;
    x = get8_packet(f);
    x += get8_packet(f) << 8;
    x += get8_packet(f) << 16;
-   x += (Uint32) get8_packet(f) << 24;
+   x += (uint32) get8_packet(f) << 24;
    return x;
 }
 
@@ -1653,16 +1678,16 @@ static void flush_packet(vorb *f)
    while (get8_packet_raw(f) != EOP);
 }
 
-/*  @OPTIMIZE: this is the secondary bit decoder, so it's probably not as important */
-/*  as the huffman decoder? */
-static Uint32 get_bits(vorb *f, int n)
+// @OPTIMIZE: this is the secondary bit decoder, so it's probably not as important
+// as the huffman decoder?
+static uint32 get_bits(vorb *f, int n)
 {
-   Uint32 z;
+   uint32 z;
 
    if (f->valid_bits < 0) return 0;
    if (f->valid_bits < n) {
       if (n > 24) {
-         /*  the accumulator technique below would not work correctly in this case */
+         // the accumulator technique below would not work correctly in this case
          z = get_bits(f, 24);
          z += get_bits(f, n-24) << 24;
          return z;
@@ -1679,18 +1704,18 @@ static Uint32 get_bits(vorb *f, int n)
       }
    }
 
-   SDL_assert(f->valid_bits >= n);
+   assert(f->valid_bits >= n);
    z = f->acc & ((1 << n)-1);
    f->acc >>= n;
    f->valid_bits -= n;
    return z;
 }
 
-/*  @OPTIMIZE: primary accumulator for huffman */
-/*  expand the buffer to as many bits as possible without reading off end of packet */
-/*  it might be nice to allow f->valid_bits and f->acc to be stored in registers, */
-/*  e.g. cache them locally and decode locally */
-SDL_FORCE_INLINE void prep_huffman(vorb *f)
+// @OPTIMIZE: primary accumulator for huffman
+// expand the buffer to as many bits as possible without reading off end of packet
+// it might be nice to allow f->valid_bits and f->acc to be stored in registers,
+// e.g. cache them locally and decode locally
+STB_FORCEINLINE void prep_huffman(vorb *f)
 {
    if (f->valid_bits <= 24) {
       if (f->valid_bits == 0) f->acc = 0;
@@ -1720,15 +1745,15 @@ static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
    if (c->codewords == NULL && c->sorted_codewords == NULL)
       return -1;
 
-   /*  cases to use binary search: sorted_codewords && !c->codewords */
-   /*                              sorted_codewords && c->entries > 8 */
+   // cases to use binary search: sorted_codewords && !c->codewords
+   //                             sorted_codewords && c->entries > 8
    if (c->entries > 8 ? c->sorted_codewords!=NULL : !c->codewords) {
-      /*  binary search */
-      Uint32 code = bit_reverse(f->acc);
+      // binary search
+      uint32 code = bit_reverse(f->acc);
       int x=0, n=c->sorted_entries, len;
 
       while (n > 1) {
-         /*  invariant: sc[x] <= code < sc[x+n] */
+         // invariant: sc[x] <= code < sc[x+n]
          int m = x + (n >> 1);
          if (c->sorted_codewords[m] <= code) {
             x = m;
@@ -1737,9 +1762,9 @@ static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
             n >>= 1;
          }
       }
-      /*  x is now the sorted index */
+      // x is now the sorted index
       if (!c->sparse) x = c->sorted_values[x];
-      /*  x is now sorted index if sparse, or symbol otherwise */
+      // x is now sorted index if sparse, or symbol otherwise
       len = c->codeword_lengths[x];
       if (f->valid_bits >= len) {
          f->acc >>= len;
@@ -1751,11 +1776,13 @@ static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
       return -1;
    }
 
-   /*  if small, linear search */
-   SDL_assert(!c->sparse);
+   // if small, linear search
+   assert(!c->sparse);
    for (i=0; i < c->entries; ++i) {
       if (c->codeword_lengths[i] == NO_CODE) continue;
-      if (c->codewords[i] == (f->acc & ((1 << c->codeword_lengths[i])-1))) {
+      /* unsigned left shift for 32-bit codewords.
+       * https://github.com/nothings/stb/issues/1168 */
+      if (c->codewords[i] == (f->acc & ((1U << c->codeword_lengths[i])-1))) {
          if (f->valid_bits >= c->codeword_lengths[i]) {
             f->acc >>= c->codeword_lengths[i];
             f->valid_bits -= c->codeword_lengths[i];
@@ -1794,7 +1821,7 @@ static int codebook_decode_scalar(vorb *f, Codebook *c)
    int i;
    if (f->valid_bits < STB_VORBIS_FAST_HUFFMAN_LENGTH)
       prep_huffman(f);
-   /*  fast huffman table lookup */
+   // fast huffman table lookup
    i = f->acc & FAST_HUFFMAN_TABLE_MASK;
    i = c->fast_huffman[i];
    if (i >= 0) {
@@ -1825,8 +1852,8 @@ static int codebook_decode_scalar(vorb *f, Codebook *c)
 
 
 
-/*  CODEBOOK_ELEMENT_FAST is an optimization for the CODEBOOK_FLOATS case */
-/*  where we avoid one addition */
+// CODEBOOK_ELEMENT_FAST is an optimization for the CODEBOOK_FLOATS case
+// where we avoid one addition
 #define CODEBOOK_ELEMENT(c,off)          (c->multiplicands[off])
 #define CODEBOOK_ELEMENT_FAST(c,off)     (c->multiplicands[off])
 #define CODEBOOK_ELEMENT_BASE(c)         (0)
@@ -1835,13 +1862,13 @@ static int codebook_decode_start(vorb *f, Codebook *c)
 {
    int z = -1;
 
-   /*  type 0 is only legal in a scalar context */
+   // type 0 is only legal in a scalar context
    if (c->lookup_type == 0)
       error(f, VORBIS_invalid_stream);
    else {
       DECODE_VQ(z,f,c);
-      if (c->sparse) SDL_assert(z < c->sorted_entries);
-      if (z < 0) {  /*  check for EOP */
+      if (c->sparse) assert(z < c->sorted_entries);
+      if (z < 0) {  // check for EOP
          if (!f->bytes_in_seg)
             if (f->last_seg)
                return z;
@@ -1854,7 +1881,7 @@ static int codebook_decode_start(vorb *f, Codebook *c)
 static int codebook_decode(vorb *f, Codebook *c, float *output, int len)
 {
    int i,z = codebook_decode_start(f,c);
-   if (z < 0) return SDL_FALSE;
+   if (z < 0) return FALSE;
    if (len > c->dimensions) len = c->dimensions;
 
 #ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
@@ -1868,7 +1895,7 @@ static int codebook_decode(vorb *f, Codebook *c, float *output, int len)
          if (c->sequence_p) last = val + c->minimum_value;
          div *= c->lookup_values;
       }
-      return SDL_TRUE;
+      return TRUE;
    }
 #endif
 
@@ -1887,14 +1914,14 @@ static int codebook_decode(vorb *f, Codebook *c, float *output, int len)
       }
    }
 
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, int step)
 {
    int i,z = codebook_decode_start(f,c);
    float last = CODEBOOK_ELEMENT_BASE(c);
-   if (z < 0) return SDL_FALSE;
+   if (z < 0) return FALSE;
    if (len > c->dimensions) len = c->dimensions;
 
 #ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
@@ -1907,7 +1934,7 @@ static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, in
          if (c->sequence_p) last = val;
          div *= c->lookup_values;
       }
-      return SDL_TRUE;
+      return TRUE;
    }
 #endif
 
@@ -1918,7 +1945,7 @@ static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, in
       if (c->sequence_p) last = val;
    }
 
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **outputs, int ch, int *c_inter_p, int *p_inter_p, int len, int total_decode)
@@ -1927,25 +1954,25 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
    int p_inter = *p_inter_p;
    int i,z, effective = c->dimensions;
 
-   /*  type 0 is only legal in a scalar context */
+   // type 0 is only legal in a scalar context
    if (c->lookup_type == 0)   return error(f, VORBIS_invalid_stream);
 
    while (total_decode > 0) {
       float last = CODEBOOK_ELEMENT_BASE(c);
       DECODE_VQ(z,f,c);
       #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
-      SDL_assert(!c->sparse || z < c->sorted_entries);
+      assert(!c->sparse || z < c->sorted_entries);
       #endif
       if (z < 0) {
          if (!f->bytes_in_seg)
-            if (f->last_seg) return SDL_FALSE;
+            if (f->last_seg) return FALSE;
          return error(f, VORBIS_invalid_stream);
       }
 
-      /*  if this will take us off the end of the buffers, stop short! */
-      /*  we check by computing the length of the virtual interleaved */
-      /*  buffer (len*ch), our current offset within it (p_inter*ch)+(c_inter), */
-      /*  and the length we'll be using (effective) */
+      // if this will take us off the end of the buffers, stop short!
+      // we check by computing the length of the virtual interleaved
+      // buffer (len*ch), our current offset within it (p_inter*ch)+(c_inter),
+      // and the length we'll be using (effective)
       if (c_inter + p_inter*ch + effective > len * ch) {
          effective = len*ch - (p_inter*ch - c_inter);
       }
@@ -1988,20 +2015,20 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
    }
    *c_inter_p = c_inter;
    *p_inter_p = p_inter;
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static int predict_point(int x, int x0, int x1, int y0, int y1)
 {
    int dy = y1 - y0;
    int adx = x1 - x0;
-   /*  @OPTIMIZE: force int division to round in the right direction... is this necessary on x86? */
+   // @OPTIMIZE: force int division to round in the right direction... is this necessary on x86?
    int err = abs(dy) * (x - x0);
    int off = err / adx;
    return dy < 0 ? y0 - off : y0 + off;
 }
 
-/*  the following table is block-copied from the specification */
+// the following table is block-copied from the specification
 static float inverse_db_table[256] =
 {
   1.0649863e-07f, 1.1341951e-07f, 1.2079015e-07f, 1.2863978e-07f,
@@ -2071,13 +2098,13 @@ static float inverse_db_table[256] =
 };
 
 
-/*  @OPTIMIZE: if you want to replace this bresenham line-drawing routine, */
-/*  note that you must produce bit-identical output to decode correctly; */
-/*  this specific sequence of operations is specified in the spec (it's */
-/*  drawing integer-quantized frequency-space lines that the encoder */
-/*  expects to be exactly the same) */
-/*     ... also, isn't the whole point of Bresenham's algorithm to NOT */
-/*  have to divide in the setup? sigh. */
+// @OPTIMIZE: if you want to replace this bresenham line-drawing routine,
+// note that you must produce bit-identical output to decode correctly;
+// this specific sequence of operations is specified in the spec (it's
+// drawing integer-quantized frequency-space lines that the encoder
+// expects to be exactly the same)
+//     ... also, isn't the whole point of Bresenham's algorithm to NOT
+// have to divide in the setup? sigh.
 #ifndef STB_VORBIS_NO_DEFER_FLOOR
 #define LINE_OP(a,b)   a *= b
 #else
@@ -2087,10 +2114,10 @@ static float inverse_db_table[256] =
 #ifdef STB_VORBIS_DIVIDE_TABLE
 #define DIVTAB_NUMER   32
 #define DIVTAB_DENOM   64
-Sint8 integer_divide_table[DIVTAB_NUMER][DIVTAB_DENOM]; /*  2KB */
+int8 integer_divide_table[DIVTAB_NUMER][DIVTAB_DENOM]; // 2KB
 #endif
 
-SDL_FORCE_INLINE void draw_line(float *output, int x0, int y0, int x1, int y1, int n)
+STB_FORCEINLINE void draw_line(float *output, int x0, int y0, int x1, int y1, int n)
 {
    int dy = y1 - y0;
    int adx = x1 - x0;
@@ -2146,23 +2173,22 @@ static int residue_decode(vorb *f, Codebook *book, float *target, int offset, in
       int step = n / book->dimensions;
       for (k=0; k < step; ++k)
          if (!codebook_decode_step(f, book, target+offset+k, n-offset-k, step))
-            return SDL_FALSE;
+            return FALSE;
    } else {
       for (k=0; k < n; ) {
          if (!codebook_decode(f, book, target+offset, n-k))
-            return SDL_FALSE;
+            return FALSE;
          k += book->dimensions;
          offset += book->dimensions;
       }
    }
-   return SDL_TRUE;
+   return TRUE;
 }
 
-/*  n is 1/2 of the blocksize -- */
-/* specification: "Correct per-vector decode length is [n]/2" */
-static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int rn, Uint8 *do_not_decode)
+// n is 1/2 of the blocksize --
+// specification: "Correct per-vector decode length is [n]/2"
+static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int rn, uint8 *do_not_decode)
 {
-   temp_buffer;
    int i,j,pass;
    Residue *r = f->residue_config + rn;
    int rtype = f->residue_types[rn];
@@ -2175,7 +2201,7 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
    int part_read = n_read / r->part_size;
    int temp_alloc_point = temp_alloc_save(f);
    #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-   Uint8 ***part_classdata = (Uint8 ***) temp_block_array(f,f->channels, part_read * sizeof(**part_classdata));
+   uint8 ***part_classdata = (uint8 ***) temp_block_array(f,f->channels, part_read * sizeof(**part_classdata));
    #else
    int **classifications = (int **) temp_block_array(f,f->channels, part_read * sizeof(**classifications));
    #endif
@@ -2184,7 +2210,7 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
 
    for (i=0; i < ch; ++i)
       if (!do_not_decode[i])
-         SDL_memset(residue_buffers[i], 0, sizeof(float) * n);
+         memset(residue_buffers[i], 0, sizeof(float) * n);
 
    if (rtype == 2 && ch != 1) {
       for (j=0; j < ch; ++j)
@@ -2227,7 +2253,7 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                      if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
                         goto done;
                      #else
-                     /*  saves 1% */
+                     // saves 1%
                      if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
                         goto done;
                      #endif
@@ -2345,37 +2371,37 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
 
 
 #if 0
-/*  slow way for debugging */
+// slow way for debugging
 void inverse_mdct_slow(float *buffer, int n)
 {
    int i,j;
    int n2 = n >> 1;
    float *x = (float *) malloc(sizeof(*x) * n2);
-   SDL_memcpy(x, buffer, sizeof(*x) * n2);
+   memcpy(x, buffer, sizeof(*x) * n2);
    for (i=0; i < n; ++i) {
       float acc = 0;
       for (j=0; j < n2; ++j)
-         /*  formula from paper: */
-         /* acc += n/4.0f * x[j] * (float) cos(M_PI / 2 / n * (2 * i + 1 + n/2.0)*(2*j+1)); */
-         /*  formula from wikipedia */
-         /* acc += 2.0f / n2 * x[j] * (float) cos(M_PI/n2 * (i + 0.5 + n2/2)*(j + 0.5)); */
-         /*  these are equivalent, except the formula from the paper inverts the multiplier! */
-         /*  however, what actually works is NO MULTIPLIER!?! */
-         /* acc += 64 * 2.0f / n2 * x[j] * (float) cos(M_PI/n2 * (i + 0.5 + n2/2)*(j + 0.5)); */
+         // formula from paper:
+         //acc += n/4.0f * x[j] * (float) cos(M_PI / 2 / n * (2 * i + 1 + n/2.0)*(2*j+1));
+         // formula from wikipedia
+         //acc += 2.0f / n2 * x[j] * (float) cos(M_PI/n2 * (i + 0.5 + n2/2)*(j + 0.5));
+         // these are equivalent, except the formula from the paper inverts the multiplier!
+         // however, what actually works is NO MULTIPLIER!?!
+         //acc += 64 * 2.0f / n2 * x[j] * (float) cos(M_PI/n2 * (i + 0.5 + n2/2)*(j + 0.5));
          acc += x[j] * (float) cos(M_PI / 2 / n * (2 * i + 1 + n/2.0)*(2*j+1));
       buffer[i] = acc;
    }
    free(x);
 }
 #elif 0
-/*  same as above, but just barely able to run in real time on modern machines */
+// same as above, but just barely able to run in real time on modern machines
 void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
 {
    float mcos[16384];
    int i,j;
    int n2 = n >> 1, nmask = (n << 2) -1;
    float *x = (float *) malloc(sizeof(*x) * n2);
-   SDL_memcpy(x, buffer, sizeof(*x) * n2);
+   memcpy(x, buffer, sizeof(*x) * n2);
    for (i=0; i < 4*n; ++i)
       mcos[i] = (float) cos(M_PI / 2 * i / n);
 
@@ -2388,15 +2414,15 @@ void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
    free(x);
 }
 #elif 0
-/*  transform to use a slow dct-iv; this is STILL basically trivial, */
-/*  but only requires half as many ops */
+// transform to use a slow dct-iv; this is STILL basically trivial,
+// but only requires half as many ops
 void dct_iv_slow(float *buffer, int n)
 {
    float mcos[16384];
    float x[2048];
    int i,j;
    int n2 = n >> 1, nmask = (n << 3) - 1;
-   SDL_memcpy(x, buffer, sizeof(*x) * n);
+   memcpy(x, buffer, sizeof(*x) * n);
    for (i=0; i < 8*n; ++i)
       mcos[i] = (float) cos(M_PI / 4 * i / n);
    for (i=0; i < n; ++i) {
@@ -2412,12 +2438,12 @@ void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
    int i, n4 = n >> 2, n2 = n >> 1, n3_4 = n - n4;
    float temp[4096];
 
-   SDL_memcpy(temp, buffer, n2 * sizeof(float));
-   dct_iv_slow(temp, n2);  /* returns -c'-d, a-b' */
+   memcpy(temp, buffer, n2 * sizeof(float));
+   dct_iv_slow(temp, n2);  // returns -c'-d, a-b'
 
-   for (i=0; i < n4  ; ++i) buffer[i] = temp[i+n4];            /*  a-b' */
-   for (   ; i < n3_4; ++i) buffer[i] = -temp[n3_4 - i - 1];   /* b-a', c+d' */
-   for (   ; i < n   ; ++i) buffer[i] = -temp[i - n3_4];       /*  c'+d */
+   for (i=0; i < n4  ; ++i) buffer[i] = temp[i+n4];            // a-b'
+   for (   ; i < n3_4; ++i) buffer[i] = -temp[n3_4 - i - 1];   // b-a', c+d'
+   for (   ; i < n   ; ++i) buffer[i] = -temp[i - n3_4];       // c'+d
 }
 #endif
 
@@ -2426,8 +2452,8 @@ void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
 #endif
 
 #if LIBVORBIS_MDCT
-/*  directly call the vorbis MDCT using an interface documented */
-/*  by Jeff Roberts... useful for performance comparison */
+// directly call the vorbis MDCT using an interface documented
+// by Jeff Roberts... useful for performance comparison
 typedef struct
 {
   int n;
@@ -2462,46 +2488,46 @@ void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
 #endif
 
 
-/*  the following were split out into separate functions while optimizing; */
-/*  they could be pushed back up but eh. __forceinline showed no change; */
-/*  they're probably already being inlined. */
+// the following were split out into separate functions while optimizing;
+// they could be pushed back up but eh. __forceinline showed no change;
+// they're probably already being inlined.
 static void imdct_step3_iter0_loop(int n, float *e, int i_off, int k_off, float *A)
 {
    float *ee0 = e + i_off;
    float *ee2 = ee0 + k_off;
    int i;
 
-   SDL_assert((n & 3) == 0);
+   assert((n & 3) == 0);
    for (i=(n>>2); i > 0; --i) {
       float k00_20, k01_21;
       k00_20  = ee0[ 0] - ee2[ 0];
       k01_21  = ee0[-1] - ee2[-1];
-      ee0[ 0] += ee2[ 0];/* ee0[ 0] = ee0[ 0] + ee2[ 0]; */
-      ee0[-1] += ee2[-1];/* ee0[-1] = ee0[-1] + ee2[-1]; */
+      ee0[ 0] += ee2[ 0];//ee0[ 0] = ee0[ 0] + ee2[ 0];
+      ee0[-1] += ee2[-1];//ee0[-1] = ee0[-1] + ee2[-1];
       ee2[ 0] = k00_20 * A[0] - k01_21 * A[1];
       ee2[-1] = k01_21 * A[0] + k00_20 * A[1];
       A += 8;
 
       k00_20  = ee0[-2] - ee2[-2];
       k01_21  = ee0[-3] - ee2[-3];
-      ee0[-2] += ee2[-2];/* ee0[-2] = ee0[-2] + ee2[-2]; */
-      ee0[-3] += ee2[-3];/* ee0[-3] = ee0[-3] + ee2[-3]; */
+      ee0[-2] += ee2[-2];//ee0[-2] = ee0[-2] + ee2[-2];
+      ee0[-3] += ee2[-3];//ee0[-3] = ee0[-3] + ee2[-3];
       ee2[-2] = k00_20 * A[0] - k01_21 * A[1];
       ee2[-3] = k01_21 * A[0] + k00_20 * A[1];
       A += 8;
 
       k00_20  = ee0[-4] - ee2[-4];
       k01_21  = ee0[-5] - ee2[-5];
-      ee0[-4] += ee2[-4];/* ee0[-4] = ee0[-4] + ee2[-4]; */
-      ee0[-5] += ee2[-5];/* ee0[-5] = ee0[-5] + ee2[-5]; */
+      ee0[-4] += ee2[-4];//ee0[-4] = ee0[-4] + ee2[-4];
+      ee0[-5] += ee2[-5];//ee0[-5] = ee0[-5] + ee2[-5];
       ee2[-4] = k00_20 * A[0] - k01_21 * A[1];
       ee2[-5] = k01_21 * A[0] + k00_20 * A[1];
       A += 8;
 
       k00_20  = ee0[-6] - ee2[-6];
       k01_21  = ee0[-7] - ee2[-7];
-      ee0[-6] += ee2[-6];/* ee0[-6] = ee0[-6] + ee2[-6]; */
-      ee0[-7] += ee2[-7];/* ee0[-7] = ee0[-7] + ee2[-7]; */
+      ee0[-6] += ee2[-6];//ee0[-6] = ee0[-6] + ee2[-6];
+      ee0[-7] += ee2[-7];//ee0[-7] = ee0[-7] + ee2[-7];
       ee2[-6] = k00_20 * A[0] - k01_21 * A[1];
       ee2[-7] = k01_21 * A[0] + k00_20 * A[1];
       A += 8;
@@ -2521,8 +2547,8 @@ static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float
    for (i=lim >> 2; i > 0; --i) {
       k00_20 = e0[-0] - e2[-0];
       k01_21 = e0[-1] - e2[-1];
-      e0[-0] += e2[-0];/* e0[-0] = e0[-0] + e2[-0]; */
-      e0[-1] += e2[-1];/* e0[-1] = e0[-1] + e2[-1]; */
+      e0[-0] += e2[-0];//e0[-0] = e0[-0] + e2[-0];
+      e0[-1] += e2[-1];//e0[-1] = e0[-1] + e2[-1];
       e2[-0] = (k00_20)*A[0] - (k01_21) * A[1];
       e2[-1] = (k01_21)*A[0] + (k00_20) * A[1];
 
@@ -2530,8 +2556,8 @@ static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float
 
       k00_20 = e0[-2] - e2[-2];
       k01_21 = e0[-3] - e2[-3];
-      e0[-2] += e2[-2];/* e0[-2] = e0[-2] + e2[-2]; */
-      e0[-3] += e2[-3];/* e0[-3] = e0[-3] + e2[-3]; */
+      e0[-2] += e2[-2];//e0[-2] = e0[-2] + e2[-2];
+      e0[-3] += e2[-3];//e0[-3] = e0[-3] + e2[-3];
       e2[-2] = (k00_20)*A[0] - (k01_21) * A[1];
       e2[-3] = (k01_21)*A[0] + (k00_20) * A[1];
 
@@ -2539,8 +2565,8 @@ static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float
 
       k00_20 = e0[-4] - e2[-4];
       k01_21 = e0[-5] - e2[-5];
-      e0[-4] += e2[-4];/* e0[-4] = e0[-4] + e2[-4]; */
-      e0[-5] += e2[-5];/* e0[-5] = e0[-5] + e2[-5]; */
+      e0[-4] += e2[-4];//e0[-4] = e0[-4] + e2[-4];
+      e0[-5] += e2[-5];//e0[-5] = e0[-5] + e2[-5];
       e2[-4] = (k00_20)*A[0] - (k01_21) * A[1];
       e2[-5] = (k01_21)*A[0] + (k00_20) * A[1];
 
@@ -2548,8 +2574,8 @@ static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float
 
       k00_20 = e0[-6] - e2[-6];
       k01_21 = e0[-7] - e2[-7];
-      e0[-6] += e2[-6];/* e0[-6] = e0[-6] + e2[-6]; */
-      e0[-7] += e2[-7];/* e0[-7] = e0[-7] + e2[-7]; */
+      e0[-6] += e2[-6];//e0[-6] = e0[-6] + e2[-6];
+      e0[-7] += e2[-7];//e0[-7] = e0[-7] + e2[-7];
       e2[-6] = (k00_20)*A[0] - (k01_21) * A[1];
       e2[-7] = (k01_21)*A[0] + (k00_20) * A[1];
 
@@ -2611,7 +2637,7 @@ static void imdct_step3_inner_s_loop(int n, float *e, int i_off, int k_off, floa
    }
 }
 
-SDL_FORCE_INLINE void iter_54(float *z)
+STB_FORCEINLINE void iter_54(float *z)
 {
    float k00,k11,k22,k33;
    float y0,y1,y2,y3;
@@ -2621,26 +2647,26 @@ SDL_FORCE_INLINE void iter_54(float *z)
    y2   = z[-2] + z[-6];
    k22  = z[-2] - z[-6];
 
-   z[-0] = y0 + y2;      /*  z0 + z4 + z2 + z6 */
-   z[-2] = y0 - y2;      /*  z0 + z4 - z2 - z6 */
+   z[-0] = y0 + y2;      // z0 + z4 + z2 + z6
+   z[-2] = y0 - y2;      // z0 + z4 - z2 - z6
 
-   /*  done with y0,y2 */
+   // done with y0,y2
 
    k33  = z[-3] - z[-7];
 
-   z[-4] = k00 + k33;    /*  z0 - z4 + z3 - z7 */
-   z[-6] = k00 - k33;    /*  z0 - z4 - z3 + z7 */
+   z[-4] = k00 + k33;    // z0 - z4 + z3 - z7
+   z[-6] = k00 - k33;    // z0 - z4 - z3 + z7
 
-   /*  done with k33 */
+   // done with k33
 
    k11  = z[-1] - z[-5];
    y1   = z[-1] + z[-5];
    y3   = z[-3] + z[-7];
 
-   z[-1] = y1 + y3;      /*  z1 + z5 + z3 + z7 */
-   z[-3] = y1 - y3;      /*  z1 + z5 - z3 - z7 */
-   z[-5] = k11 - k22;    /*  z1 - z5 + z2 - z6 */
-   z[-7] = k11 + k22;    /*  z1 - z5 - z2 + z6 */
+   z[-1] = y1 + y3;      // z1 + z5 + z3 + z7
+   z[-3] = y1 - y3;      // z1 + z5 - z3 - z7
+   z[-5] = k11 - k22;    // z1 - z5 + z2 - z6
+   z[-7] = k11 + k22;    // z1 - z5 - z2 + z6
 }
 
 static void imdct_step3_inner_s_loop_ld654(int n, float *e, int i_off, float *A, int base_n)
@@ -2688,34 +2714,33 @@ static void imdct_step3_inner_s_loop_ld654(int n, float *e, int i_off, float *A,
 
 static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
 {
-   temp_buffer;
    int n2 = n >> 1, n4 = n >> 2, n8 = n >> 3, l;
    int ld;
-   /*  @OPTIMIZE: reduce register pressure by using fewer variables? */
+   // @OPTIMIZE: reduce register pressure by using fewer variables?
    int save_point = temp_alloc_save(f);
    float *buf2 = (float *) temp_alloc(f, n2 * sizeof(*buf2));
    float *u=NULL,*v=NULL;
-   /*  twiddle factors */
+   // twiddle factors
    float *A = f->A[blocktype];
 
-   /* IMDCT algorithm from "The use of multirate filter banks for coding of high quality digital audio" */
-   /* See notes about bugs in that paper in less-optimal implementation 'inverse_mdct_old' after this function. */
+   // IMDCT algorithm from "The use of multirate filter banks for coding of high quality digital audio"
+   // See notes about bugs in that paper in less-optimal implementation 'inverse_mdct_old' after this function.
 
-   /*  kernel from paper */
+   // kernel from paper
 
 
-   /*  merged: */
-   /*    copy and reflect spectral data */
-   /*    step 0 */
+   // merged:
+   //   copy and reflect spectral data
+   //   step 0
 
-   /*  note that it turns out that the items added together during */
-   /*  this step are, in fact, being added to themselves (as reflected */
-   /*  by step 0). inexplicable inefficiency! this became obvious */
-   /*  once I combined the passes. */
+   // note that it turns out that the items added together during
+   // this step are, in fact, being added to themselves (as reflected
+   // by step 0). inexplicable inefficiency! this became obvious
+   // once I combined the passes.
 
-   /*  so there's a missing 'times 2' here (for adding X to itself). */
-   /*  this propagates through linearly to the end, where the numbers */
-   /*  are 1/2 too small, and need to be compensated for. */
+   // so there's a missing 'times 2' here (for adding X to itself).
+   // this propagates through linearly to the end, where the numbers
+   // are 1/2 too small, and need to be compensated for.
 
    {
       float *d,*e, *AA, *e_stop;
@@ -2741,16 +2766,16 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       }
    }
 
-   /*  now we use symbolic names for these, so that we can */
-   /*  possibly swap their meaning as we change which operations */
-   /*  are in place */
+   // now we use symbolic names for these, so that we can
+   // possibly swap their meaning as we change which operations
+   // are in place
 
    u = buffer;
    v = buf2;
 
-   /*  step 2    (paper output is w, now u) */
-   /*  this could be in place, but the data ends up in the wrong */
-   /*  place... _somebody_'s got to swap it, so this is nominated */
+   // step 2    (paper output is w, now u)
+   // this could be in place, but the data ends up in the wrong
+   // place... _somebody_'s got to swap it, so this is nominated
    {
       float *AA = &A[n2-8];
       float *d0,*d1, *e0, *e1;
@@ -2787,21 +2812,21 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       }
    }
 
-   /*  step 3 */
-   ld = ilog(n) - 1; /*  ilog is off-by-one from normal definitions */
+   // step 3
+   ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
 
-   /*  optimized step 3: */
+   // optimized step 3:
 
-   /*  the original step3 loop can be nested r inside s or s inside r; */
-   /*  it's written originally as s inside r, but this is dumb when r */
-   /*  iterates many times, and s few. So I have two copies of it and */
-   /*  switch between them halfway. */
+   // the original step3 loop can be nested r inside s or s inside r;
+   // it's written originally as s inside r, but this is dumb when r
+   // iterates many times, and s few. So I have two copies of it and
+   // switch between them halfway.
 
-   /*  this is iteration 0 of step 3 */
+   // this is iteration 0 of step 3
    imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*0, -(n >> 3), A);
    imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*1, -(n >> 3), A);
 
-   /*  this is iteration 1 of step 3 */
+   // this is iteration 1 of step 3
    imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*0, -(n >> 4), A, 16);
    imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*1, -(n >> 4), A, 16);
    imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*2, -(n >> 4), A, 16);
@@ -2830,23 +2855,23 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       }
    }
 
-   /*  iterations with count: */
-   /*    ld-6,-5,-4 all interleaved together */
-   /*        the big win comes from getting rid of needless flops */
-   /*          due to the constants on pass 5 & 4 being all 1 and 0; */
-   /*        combining them to be simultaneous to improve cache made little difference */
+   // iterations with count:
+   //   ld-6,-5,-4 all interleaved together
+   //       the big win comes from getting rid of needless flops
+   //         due to the constants on pass 5 & 4 being all 1 and 0;
+   //       combining them to be simultaneous to improve cache made little difference
    imdct_step3_inner_s_loop_ld654(n >> 5, u, n2-1, A, n);
 
-   /*  output is u */
+   // output is u
 
-   /*  step 4, 5, and 6 */
-   /*  cannot be in-place because of step 5 */
+   // step 4, 5, and 6
+   // cannot be in-place because of step 5
    {
-      Uint16 *bitrev = f->bit_reverse[blocktype];
-      /*  weirdly, I'd have thought reading sequentially and writing */
-      /*  erratically would have been better than vice-versa, but in */
-      /*  fact that's not what my testing showed. (That is, with */
-      /*  j = bitreverse(i), do you read i and write j, or read j and write i.) */
+      uint16 *bitrev = f->bit_reverse[blocktype];
+      // weirdly, I'd have thought reading sequentially and writing
+      // erratically would have been better than vice-versa, but in
+      // fact that's not what my testing showed. (That is, with
+      // j = bitreverse(i), do you read i and write j, or read j and write i.)
 
       float *d0 = &v[n4-4];
       float *d1 = &v[n2-4];
@@ -2870,14 +2895,14 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
          bitrev += 2;
       }
    }
-   /*  (paper output is u, now v) */
+   // (paper output is u, now v)
 
 
-   /*  data must be in buf2 */
-   SDL_assert(v == buf2);
+   // data must be in buf2
+   assert(v == buf2);
 
-   /*  step 7   (paper output is v, now v) */
-   /*  this is now in place */
+   // step 7   (paper output is v, now v)
+   // this is now in place
    {
       float *C = f->C[blocktype];
       float *d, *e;
@@ -2922,15 +2947,15 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       }
    }
 
-   /*  data must be in buf2 */
+   // data must be in buf2
 
 
-   /*  step 8+decode   (paper output is X, now buffer) */
-   /*  this generates pairs of data a la 8 and pushes them directly through */
-   /*  the decode kernel (pushing rather than pulling) to avoid having */
-   /*  to make another pass later */
+   // step 8+decode   (paper output is X, now buffer)
+   // this generates pairs of data a la 8 and pushes them directly through
+   // the decode kernel (pushing rather than pulling) to avoid having
+   // to make another pass later
 
-   /*  this cannot POSSIBLY be in place, so we refer to the buffers directly */
+   // this cannot POSSIBLY be in place, so we refer to the buffers directly
 
    {
       float *d0,*d1,*d2,*d3;
@@ -2990,17 +3015,17 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
 }
 
 #if 0
-/*  this is the original version of the above code, if you want to optimize it from scratch */
+// this is the original version of the above code, if you want to optimize it from scratch
 void inverse_mdct_naive(float *buffer, int n)
 {
    float s;
    float A[1 << 12], B[1 << 12], C[1 << 11];
    int i,k,k2,k4, n2 = n >> 1, n4 = n >> 2, n8 = n >> 3, l;
    int n3_4 = n - n4, ld;
-   /*  how can they claim this only uses N words?! */
-   /*  oh, because they're only used sparsely, whoops */
+   // how can they claim this only uses N words?!
+   // oh, because they're only used sparsely, whoops
    float u[1 << 13], X[1 << 13], v[1 << 13], w[1 << 13];
-   /*  set up twiddle factors */
+   // set up twiddle factors
 
    for (k=k2=0; k < n4; ++k,k2+=2) {
       A[k2  ] = (float)  cos(4*k*M_PI/n);
@@ -3013,31 +3038,31 @@ void inverse_mdct_naive(float *buffer, int n)
       C[k2+1] = (float) -sin(2*(k2+1)*M_PI/n);
    }
 
-   /* IMDCT algorithm from "The use of multirate filter banks for coding of high quality digital audio" */
-   /*  Note there are bugs in that pseudocode, presumably due to them attempting */
-   /*  to rename the arrays nicely rather than representing the way their actual */
-   /*  implementation bounces buffers back and forth. As a result, even in the */
-   /* "some formulars corrected" version, a direct implementation fails. These */
-   /* are noted below as "paper bug". */
+   // IMDCT algorithm from "The use of multirate filter banks for coding of high quality digital audio"
+   // Note there are bugs in that pseudocode, presumably due to them attempting
+   // to rename the arrays nicely rather than representing the way their actual
+   // implementation bounces buffers back and forth. As a result, even in the
+   // "some formulars corrected" version, a direct implementation fails. These
+   // are noted below as "paper bug".
 
-   /*  copy and reflect spectral data */
+   // copy and reflect spectral data
    for (k=0; k < n2; ++k) u[k] = buffer[k];
    for (   ; k < n ; ++k) u[k] = -buffer[n - k - 1];
-   /*  kernel from paper */
-   /*  step 1 */
+   // kernel from paper
+   // step 1
    for (k=k2=k4=0; k < n4; k+=1, k2+=2, k4+=4) {
       v[n-k4-1] = (u[k4] - u[n-k4-1]) * A[k2]   - (u[k4+2] - u[n-k4-3])*A[k2+1];
       v[n-k4-3] = (u[k4] - u[n-k4-1]) * A[k2+1] + (u[k4+2] - u[n-k4-3])*A[k2];
    }
-   /*  step 2 */
+   // step 2
    for (k=k4=0; k < n8; k+=1, k4+=4) {
       w[n2+3+k4] = v[n2+3+k4] + v[k4+3];
       w[n2+1+k4] = v[n2+1+k4] + v[k4+1];
       w[k4+3]    = (v[n2+3+k4] - v[k4+3])*A[n2-4-k4] - (v[n2+1+k4]-v[k4+1])*A[n2-3-k4];
       w[k4+1]    = (v[n2+1+k4] - v[k4+1])*A[n2-4-k4] + (v[n2+3+k4]-v[k4+3])*A[n2-3-k4];
    }
-   /*  step 3 */
-   ld = ilog(n) - 1; /*  ilog is off-by-one from normal definitions */
+   // step 3
+   ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
    for (l=0; l < ld-3; ++l) {
       int k0 = n >> (l+2), k1 = 1 << (l+3);
       int rlim = n >> (l+4), r4, r;
@@ -3053,18 +3078,18 @@ void inverse_mdct_naive(float *buffer, int n)
          }
       }
       if (l+1 < ld-3) {
-         /*  paper bug: ping-ponging of u&w here is omitted */
-         SDL_memcpy(w, u, sizeof(u));
+         // paper bug: ping-ponging of u&w here is omitted
+         memcpy(w, u, sizeof(u));
       }
    }
 
-   /*  step 4 */
+   // step 4
    for (i=0; i < n8; ++i) {
       int j = bit_reverse(i) >> (32-ld+3);
-      SDL_assert(j < n8);
+      assert(j < n8);
       if (i == j) {
-         /*  paper bug: original code probably swapped in place; if copying, */
-         /*             need to directly copy in this case */
+         // paper bug: original code probably swapped in place; if copying,
+         //            need to directly copy in this case
          int i8 = i << 3;
          v[i8+1] = u[i8+1];
          v[i8+3] = u[i8+3];
@@ -3078,39 +3103,39 @@ void inverse_mdct_naive(float *buffer, int n)
          v[j8+7] = u[i8+7], v[i8+7] = u[j8 + 7];
       }
    }
-   /*  step 5 */
+   // step 5
    for (k=0; k < n2; ++k) {
       w[k] = v[k*2+1];
    }
-   /*  step 6 */
+   // step 6
    for (k=k2=k4=0; k < n8; ++k, k2 += 2, k4 += 4) {
       u[n-1-k2] = w[k4];
       u[n-2-k2] = w[k4+1];
       u[n3_4 - 1 - k2] = w[k4+2];
       u[n3_4 - 2 - k2] = w[k4+3];
    }
-   /*  step 7 */
+   // step 7
    for (k=k2=0; k < n8; ++k, k2 += 2) {
       v[n2 + k2 ] = ( u[n2 + k2] + u[n-2-k2] + C[k2+1]*(u[n2+k2]-u[n-2-k2]) + C[k2]*(u[n2+k2+1]+u[n-2-k2+1]))/2;
       v[n-2 - k2] = ( u[n2 + k2] + u[n-2-k2] - C[k2+1]*(u[n2+k2]-u[n-2-k2]) - C[k2]*(u[n2+k2+1]+u[n-2-k2+1]))/2;
       v[n2+1+ k2] = ( u[n2+1+k2] - u[n-1-k2] + C[k2+1]*(u[n2+1+k2]+u[n-1-k2]) - C[k2]*(u[n2+k2]-u[n-2-k2]))/2;
       v[n-1 - k2] = (-u[n2+1+k2] + u[n-1-k2] + C[k2+1]*(u[n2+1+k2]+u[n-1-k2]) - C[k2]*(u[n2+k2]-u[n-2-k2]))/2;
    }
-   /*  step 8 */
+   // step 8
    for (k=k2=0; k < n4; ++k,k2 += 2) {
       X[k]      = v[k2+n2]*B[k2  ] + v[k2+1+n2]*B[k2+1];
       X[n2-1-k] = v[k2+n2]*B[k2+1] - v[k2+1+n2]*B[k2  ];
    }
 
-   /*  decode kernel to output */
-   /*  determined the following value experimentally */
-   /*  (by first figuring out what made inverse_mdct_slow work); then matching that here */
-   /*  (probably vorbis encoder premultiplies by n or n/2, to save it on the decoder?) */
-   s = 0.5; /*  theoretically would be n4 */
+   // decode kernel to output
+   // determined the following value experimentally
+   // (by first figuring out what made inverse_mdct_slow work); then matching that here
+   // (probably vorbis encoder premultiplies by n or n/2, to save it on the decoder?)
+   s = 0.5; // theoretically would be n4
 
-   /*  [[[ note! the s value of 0.5 is compensated for by the B[] in the current code, */
-   /*      so it needs to use the "old" B values to behave correctly, or else */
-   /*      set s to 1.0 ]]] */
+   // [[[ note! the s value of 0.5 is compensated for by the B[] in the current code,
+   //     so it needs to use the "old" B values to behave correctly, or else
+   //     set s to 1.0 ]]]
    for (i=0; i < n4  ; ++i) buffer[i] = s * X[i+n4];
    for (   ; i < n3_4; ++i) buffer[i] = -s * X[n3_4 - i - 1];
    for (   ; i < n   ; ++i) buffer[i] = -s * X[i - n3_4];
@@ -3126,11 +3151,11 @@ static float *get_window(vorb *f, int len)
 }
 
 #ifndef STB_VORBIS_NO_DEFER_FLOOR
-typedef Sint16 YTYPE;
+typedef int16 YTYPE;
 #else
 typedef int YTYPE;
 #endif
-static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *finalY, Uint8 *step2_flag)
+static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *finalY, uint8 *step2_flag)
 {
    int n2 = n >> 1;
    int s = map->chan[i].mux, floor;
@@ -3159,28 +3184,28 @@ static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *f
          }
       }
       if (lx < n2) {
-         /*  optimization of: draw_line(target, lx,ly, n,ly, n2); */
+         // optimization of: draw_line(target, lx,ly, n,ly, n2);
          for (j=lx; j < n2; ++j)
             LINE_OP(target[j], inverse_db_table[ly]);
          CHECK(f);
       }
    }
-   return SDL_TRUE;
+   return TRUE;
 }
 
-/* The meaning of //  The meaning of  */
-/*  */
-/*  For a given frame: */
-/*      we compute samples from 0..n */
-/*      window_center is n/2 */
-/*      we'll window and mix the samples from left_start to left_end with data from the previous frame */
-/*      all of the samples from left_end to right_start can be output without mixing; however, */
-/*         this interval is 0-length except when transitioning between short and long frames */
-/*      all of the samples from right_start to right_end need to be mixed with the next frame, */
-/*         which we don't have, so those get saved in a buffer */
-/*      frame N's right_end-right_start, the number of samples to mix with the next frame, */
-/*         has to be the same as frame N+1's left_end-left_start (which they are by */
-/*         construction) */
+// The meaning of "left" and "right"
+//
+// For a given frame:
+//     we compute samples from 0..n
+//     window_center is n/2
+//     we'll window and mix the samples from left_start to left_end with data from the previous frame
+//     all of the samples from left_end to right_start can be output without mixing; however,
+//        this interval is 0-length except when transitioning between short and long frames
+//     all of the samples from right_start to right_end need to be mixed with the next frame,
+//        which we don't have, so those get saved in a buffer
+//     frame N's right_end-right_start, the number of samples to mix with the next frame,
+//        has to be the same as frame N+1's left_end-left_start (which they are by
+//        construction)
 
 static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
 {
@@ -3189,10 +3214,10 @@ static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, in
    f->channel_buffer_start = f->channel_buffer_end = 0;
 
   retry:
-   if (f->eof) return SDL_FALSE;
+   if (f->eof) return FALSE;
    if (!maybe_start_packet(f))
-      return SDL_FALSE;
-   /*  check packet type */
+      return FALSE;
+   // check packet type
    if (get_bits(f,1) != 0) {
       if (IS_PUSH_MODE(f))
          return error(f,VORBIS_bad_packet_type);
@@ -3201,11 +3226,11 @@ static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, in
    }
 
    if (f->alloc.alloc_buffer)
-      SDL_assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
 
    i = get_bits(f, ilog(f->mode_count-1));
-   if (i == EOP) return SDL_FALSE;
-   if (i >= f->mode_count) return SDL_FALSE;
+   if (i == EOP) return FALSE;
+   if (i >= f->mode_count) return FALSE;
    *mode = i;
    m = f->mode_config + i;
    if (m->blockflag) {
@@ -3217,7 +3242,7 @@ static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, in
       n = f->blocksize_0;
    }
 
-/*  WINDOWING */
+// WINDOWING
 
    window_center = n >> 1;
    if (m->blockflag && !prev) {
@@ -3235,7 +3260,7 @@ static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, in
       *p_right_end   = n;
    }
 
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start, int left_end, int right_start, int right_end, int *p_left)
@@ -3245,20 +3270,20 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    int zero_channel[256];
    int really_zero_channel[256];
 
-/*  WINDOWING */
+// WINDOWING
 
    STBV_NOTUSED(left_end);
    n = f->blocksize[m->blockflag];
    map = &f->mapping[m->mapping];
 
-/*  FLOORS */
+// FLOORS
    n2 = n >> 1;
 
    CHECK(f);
 
    for (i=0; i < f->channels; ++i) {
       int s = map->chan[i].mux, floor;
-      zero_channel[i] = SDL_FALSE;
+      zero_channel[i] = FALSE;
       floor = map->submap_floor[s];
       if (f->floor_types[floor] == 0) {
          return error(f, VORBIS_invalid_stream);
@@ -3266,7 +3291,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
          Floor1 *g = &f->floor_config[floor].floor1;
          if (get_bits(f, 1)) {
             short *finalY;
-            Uint8 step2_flag[256];
+            uint8 step2_flag[256];
             static int range_list[4] = { 256, 128, 86, 64 };
             int range = range_list[g->floor1_multiplier-1];
             int offset = 2;
@@ -3295,13 +3320,13 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
                      finalY[offset++] = 0;
                }
             }
-            if (f->valid_bits == INVALID_BITS) goto error; /*  behavior according to spec */
+            if (f->valid_bits == INVALID_BITS) goto error; // behavior according to spec
             step2_flag[0] = step2_flag[1] = 1;
             for (j=2; j < g->values; ++j) {
                int low, high, pred, highroom, lowroom, room, val;
                low = g->neighbors[j][0];
                high = g->neighbors[j][1];
-               /* neighbors(g->Xlist, j, &low, &high); */
+               //neighbors(g->Xlist, j, &low, &high);
                pred = predict_point(g->Xlist[j], g->Xlist[low], g->Xlist[high], finalY[low], finalY[high]);
                val = finalY[j];
                highroom = range - pred;
@@ -3332,7 +3357,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
 #ifdef STB_VORBIS_NO_DEFER_FLOOR
             do_floor(f, map, i, n, f->floor_buffers[i], finalY, step2_flag);
 #else
-            /*  defer final floor computation until _after_ residue */
+            // defer final floor computation until _after_ residue
             for (j=0; j < g->values; ++j) {
                if (!step2_flag[j])
                   finalY[j] = -1;
@@ -3340,40 +3365,40 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
 #endif
          } else {
            error:
-            zero_channel[i] = SDL_TRUE;
+            zero_channel[i] = TRUE;
          }
-         /*  So we just defer everything else to later */
+         // So we just defer everything else to later
 
-         /*  at this point we've decoded the floor into buffer */
+         // at this point we've decoded the floor into buffer
       }
    }
    CHECK(f);
-   /*  at this point we've decoded all floors */
+   // at this point we've decoded all floors
 
    if (f->alloc.alloc_buffer)
-      SDL_assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
 
-   /*  re-enable coupled channels if necessary */
-   SDL_memcpy(really_zero_channel, zero_channel, sizeof(really_zero_channel[0]) * f->channels);
+   // re-enable coupled channels if necessary
+   memcpy(really_zero_channel, zero_channel, sizeof(really_zero_channel[0]) * f->channels);
    for (i=0; i < map->coupling_steps; ++i)
       if (!zero_channel[map->chan[i].magnitude] || !zero_channel[map->chan[i].angle]) {
-         zero_channel[map->chan[i].magnitude] = zero_channel[map->chan[i].angle] = SDL_FALSE;
+         zero_channel[map->chan[i].magnitude] = zero_channel[map->chan[i].angle] = FALSE;
       }
 
    CHECK(f);
-/*  RESIDUE DECODE */
+// RESIDUE DECODE
    for (i=0; i < map->submaps; ++i) {
       float *residue_buffers[STB_VORBIS_MAX_CHANNELS];
       int r;
-      Uint8 do_not_decode[256];
+      uint8 do_not_decode[256];
       int ch = 0;
       for (j=0; j < f->channels; ++j) {
          if (map->chan[j].mux == i) {
             if (zero_channel[j]) {
-               do_not_decode[ch] = SDL_TRUE;
+               do_not_decode[ch] = TRUE;
                residue_buffers[ch] = NULL;
             } else {
-               do_not_decode[ch] = SDL_FALSE;
+               do_not_decode[ch] = FALSE;
                residue_buffers[ch] = f->channel_buffers[j];
             }
             ++ch;
@@ -3384,10 +3409,10 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    }
 
    if (f->alloc.alloc_buffer)
-      SDL_assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
    CHECK(f);
 
-/*  INVERSE COUPLING */
+// INVERSE COUPLING
    for (i = map->coupling_steps-1; i >= 0; --i) {
       int n2 = n >> 1;
       float *m = f->channel_buffers[map->chan[i].magnitude];
@@ -3410,11 +3435,11 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    }
    CHECK(f);
 
-   /*  finish decoding the floors */
+   // finish decoding the floors
 #ifndef STB_VORBIS_NO_DEFER_FLOOR
    for (i=0; i < f->channels; ++i) {
       if (really_zero_channel[i]) {
-         SDL_memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
+         memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
       } else {
          do_floor(f, map, i, n, f->channel_buffers[i], f->finalY[i], NULL);
       }
@@ -3422,7 +3447,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
 #else
    for (i=0; i < f->channels; ++i) {
       if (really_zero_channel[i]) {
-         SDL_memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
+         memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
       } else {
          for (j=0; j < n2; ++j)
             f->channel_buffers[i][j] *= f->floor_buffers[i][j];
@@ -3430,27 +3455,27 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    }
 #endif
 
-/*  INVERSE MDCT */
+// INVERSE MDCT
    CHECK(f);
    for (i=0; i < f->channels; ++i)
       inverse_mdct(f->channel_buffers[i], n, f, m->blockflag);
    CHECK(f);
 
-   /*  this shouldn't be necessary, unless we exited on an error */
-   /*  and want to flush to get to the next packet */
+   // this shouldn't be necessary, unless we exited on an error
+   // and want to flush to get to the next packet
    flush_packet(f);
 
    if (f->first_decode) {
-      /*  assume we start so first non-discarded sample is sample 0 */
-      /*  this isn't to spec, but spec would require us to read ahead */
-      /*  and decode the size of all current frames--could be done, */
-      /*  but presumably it's not a commonly used feature */
-      f->current_loc = 0u - n2; /*  start of first frame is positioned for discard (NB this is an intentional unsigned overflow/wrap-around) */
-      /*  we might have to discard samples "from" the next frame too, */
-      /*  if we're lapping a large block then a small at the start? */
+      // assume we start so first non-discarded sample is sample 0
+      // this isn't to spec, but spec would require us to read ahead
+      // and decode the size of all current frames--could be done,
+      // but presumably it's not a commonly used feature
+      f->current_loc = 0u - n2; // start of first frame is positioned for discard (NB this is an intentional unsigned overflow/wrap-around)
+      // we might have to discard samples "from" the next frame too,
+      // if we're lapping a large block then a small at the start?
       f->discard_samples_deferred = n - right_end;
-      f->current_loc_valid = SDL_TRUE;
-      f->first_decode = SDL_FALSE;
+      f->current_loc_valid = TRUE;
+      f->first_decode = FALSE;
    } else if (f->discard_samples_deferred) {
       if (f->discard_samples_deferred >= right_start - left_start) {
          f->discard_samples_deferred -= (right_start - left_start);
@@ -3462,49 +3487,49 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
          f->discard_samples_deferred = 0;
       }
    } else if (f->previous_length == 0 && f->current_loc_valid) {
-      /* we're recovering from a seek... that means we're going to discard */
-      /*  the samples from this packet even though we know our position from */
-      /*  the last page header, so we need to update the position based on */
-      /*  the discarded samples here */
-      /*  but wait, the code below is going to add this in itself even */
-      /*  on a discard, so we don't need to do it here... */
+      // we're recovering from a seek... that means we're going to discard
+      // the samples from this packet even though we know our position from
+      // the last page header, so we need to update the position based on
+      // the discarded samples here
+      // but wait, the code below is going to add this in itself even
+      // on a discard, so we don't need to do it here...
    }
 
-   /*  check if we have ogg information about the sample # for this packet */
+   // check if we have ogg information about the sample # for this packet
    if (f->last_seg_which == f->end_seg_with_known_loc) {
-      /*  if we have a valid current loc, and this is final: */
+      // if we have a valid current loc, and this is final:
       if (f->current_loc_valid && (f->page_flag & PAGEFLAG_last_page)) {
-         Uint32 current_end = f->known_loc_for_packet;
-         /*  then let's infer the size of the (probably) short final frame */
+         uint32 current_end = f->known_loc_for_packet;
+         // then let's infer the size of the (probably) short final frame
          if (current_end < f->current_loc + (right_end-left_start)) {
             if (current_end < f->current_loc) {
-               /*  negative truncation, that's impossible! */
+               // negative truncation, that's impossible!
                *len = 0;
             } else {
                *len = current_end - f->current_loc;
             }
-            *len += left_start; /*  this doesn't seem right, but has no ill effect on my test files */
-            if (*len > right_end) *len = right_end; /*  this should never happen */
+            *len += left_start; // this doesn't seem right, but has no ill effect on my test files
+            if (*len > right_end) *len = right_end; // this should never happen
             f->current_loc += *len;
-            return SDL_TRUE;
+            return TRUE;
          }
       }
-      /*  otherwise, just set our sample loc */
-      /*  guess that the ogg granule pos refers to the _middle_ of the */
-      /*  last frame? */
-      /*  set f->current_loc to the position of left_start */
+      // otherwise, just set our sample loc
+      // guess that the ogg granule pos refers to the _middle_ of the
+      // last frame?
+      // set f->current_loc to the position of left_start
       f->current_loc = f->known_loc_for_packet - (n2-left_start);
-      f->current_loc_valid = SDL_TRUE;
+      f->current_loc_valid = TRUE;
    }
    if (f->current_loc_valid)
       f->current_loc += (right_start - left_start);
 
    if (f->alloc.alloc_buffer)
-      SDL_assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
-   *len = right_end;  /*  ignore samples after the window goes to 0 */
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   *len = right_end;  // ignore samples after the window goes to 0
    CHECK(f);
 
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static int vorbis_decode_packet(vorb *f, int *len, int *p_left, int *p_right)
@@ -3517,15 +3542,15 @@ static int vorbis_decode_packet(vorb *f, int *len, int *p_left, int *p_right)
 static int vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
 {
    int prev,i,j;
-   /*  we use right&left (the start of the right- and left-window sin()-regions) */
-   /*  to determine how much to return, rather than inferring from the rules */
-   /* (same result, clearer code); 'left' indicates where our sin() window */
-   /*  starts, therefore where the previous window's right edge starts, and */
-   /* therefore where to start mixing from the previous buffer. 'right' */
-   /*  indicates where our sin() ending-window starts, therefore that's where */
-   /*  we start saving, and where our returned-data ends. */
+   // we use right&left (the start of the right- and left-window sin()-regions)
+   // to determine how much to return, rather than inferring from the rules
+   // (same result, clearer code); 'left' indicates where our sin() window
+   // starts, therefore where the previous window's right edge starts, and
+   // therefore where to start mixing from the previous buffer. 'right'
+   // indicates where our sin() ending-window starts, therefore that's where
+   // we start saving, and where our returned-data ends.
 
-   /*  mixin from previous window */
+   // mixin from previous window
    if (f->previous_length) {
       int i,j, n = f->previous_length;
       float *w = get_window(f, n);
@@ -3540,26 +3565,26 @@ static int vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
 
    prev = f->previous_length;
 
-   /*  last half of this data becomes previous window */
+   // last half of this data becomes previous window
    f->previous_length = len - right;
 
-   /*  @OPTIMIZE: could avoid this copy by double-buffering the */
-   /*  output (flipping previous_window with channel_buffers), but */
-   /*  then previous_window would have to be 2x as large, and */
-   /* channel_buffers couldn't be temp mem (although they're NOT */
-   /*  currently temp mem, they could be (unless we want to level */
-   /*  performance by spreading out the computation)) */
+   // @OPTIMIZE: could avoid this copy by double-buffering the
+   // output (flipping previous_window with channel_buffers), but
+   // then previous_window would have to be 2x as large, and
+   // channel_buffers couldn't be temp mem (although they're NOT
+   // currently temp mem, they could be (unless we want to level
+   // performance by spreading out the computation))
    for (i=0; i < f->channels; ++i)
       for (j=0; right+j < len; ++j)
          f->previous_window[i][j] = f->channel_buffers[i][right+j];
 
    if (!prev)
-      /*  there was no previous packet, so this data isn't valid... */
-      /*  this isn't entirely true, only the would-have-overlapped data */
-      /*  isn't valid, but this seems to be what the spec requires */
+      // there was no previous packet, so this data isn't valid...
+      // this isn't entirely true, only the would-have-overlapped data
+      // isn't valid, but this seems to be what the spec requires
       return 0;
 
-   /*  truncate a short frame */
+   // truncate a short frame
    if (len < right) right = len;
 
    f->samples_output += right-left;
@@ -3574,57 +3599,57 @@ static int vorbis_pump_first_frame(stb_vorbis *f)
    if (res)
       vorbis_finish_frame(f, len, left, right);
    f->current_playback_loc = 0;
-   f->current_playback_loc_valid = SDL_TRUE;
+   f->current_playback_loc_valid = TRUE;
    return res;
 }
 
 #ifndef STB_VORBIS_NO_PUSHDATA_API
 static int is_whole_packet_present(stb_vorbis *f)
 {
-   /*  make sure that we have the packet available before continuing... */
-   /*  this requires a full ogg parse, but we know we can fetch from f->stream */
+   // make sure that we have the packet available before continuing...
+   // this requires a full ogg parse, but we know we can fetch from f->stream
 
-   /*  instead of coding this out explicitly, we could save the current read state, */
-   /*  read the next packet with get8() until end-of-packet, check f->eof, then */
-   /*  reset the state? but that would be slower, esp. since we'd have over 256 bytes */
-   /*  of state to restore (primarily the page segment table) */
+   // instead of coding this out explicitly, we could save the current read state,
+   // read the next packet with get8() until end-of-packet, check f->eof, then
+   // reset the state? but that would be slower, esp. since we'd have over 256 bytes
+   // of state to restore (primarily the page segment table)
 
-   int s = f->next_seg, first = SDL_TRUE;
-   Uint8 *p = f->stream;
+   int s = f->next_seg, first = TRUE;
+   uint8 *p = f->stream;
 
-   if (s != -1) { /* if we're not starting the packet with a 'continue on next page' flag */
+   if (s != -1) { // if we're not starting the packet with a 'continue on next page' flag
       for (; s < f->segment_count; ++s) {
          p += f->segments[s];
-         if (f->segments[s] < 255)               /*  stop at first short segment */
+         if (f->segments[s] < 255)               // stop at first short segment
             break;
       }
-      /*  either this continues, or it ends it... */
+      // either this continues, or it ends it...
       if (s == f->segment_count)
-         s = -1; /* set 'crosses page' flag */
+         s = -1; // set 'crosses page' flag
       if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
-      first = SDL_FALSE;
+      first = FALSE;
    }
    for (; s == -1;) {
-      Uint8 *q;
+      uint8 *q;
       int n;
 
-      /*  check that we have the page header ready */
+      // check that we have the page header ready
       if (p + 26 >= f->stream_end)               return error(f, VORBIS_need_more_data);
-      /*  validate the page */
-      if (SDL_memcmp(p, ogg_page_header, 4))         return error(f, VORBIS_invalid_stream);
+      // validate the page
+      if (memcmp(p, ogg_page_header, 4))         return error(f, VORBIS_invalid_stream);
       if (p[4] != 0)                             return error(f, VORBIS_invalid_stream);
-      if (first) { /* the first segment must NOT have 'continued_packet', later ones MUST */
+      if (first) { // the first segment must NOT have 'continued_packet', later ones MUST
          if (f->previous_length)
             if ((p[5] & PAGEFLAG_continued_packet))  return error(f, VORBIS_invalid_stream);
-         /*  if no previous length, we're resynching, so we can come in on a continued-packet, */
-         /*  which we'll just drop */
+         // if no previous length, we're resynching, so we can come in on a continued-packet,
+         // which we'll just drop
       } else {
          if (!(p[5] & PAGEFLAG_continued_packet)) return error(f, VORBIS_invalid_stream);
       }
-      n = p[26]; /*  segment counts */
-      q = p+27;  /*  q points to segment table */
-      p = q + n; /*  advance past header */
-      /*  make sure we've read the segment table */
+      n = p[26]; // segment counts
+      q = p+27;  // q points to segment table
+      p = q + n; // advance past header
+      // make sure we've read the segment table
       if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
       for (s=0; s < n; ++s) {
          p += q[s];
@@ -3632,32 +3657,32 @@ static int is_whole_packet_present(stb_vorbis *f)
             break;
       }
       if (s == n)
-         s = -1; /* set 'crosses page' flag */
+         s = -1; // set 'crosses page' flag
       if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
-      first = SDL_FALSE;
+      first = FALSE;
    }
-   return SDL_TRUE;
+   return TRUE;
 }
-#endif /*  !STB_VORBIS_NO_PUSHDATA_API */
+#endif // !STB_VORBIS_NO_PUSHDATA_API
 
 static int start_decoder(vorb *f)
 {
-   Uint8 header[6], x,y;
+   uint8 header[6], x,y;
    int len,i,j,k, max_submaps = 0;
    int longest_floorlist=0;
 
-   /*  first page, first packet */
-   f->first_decode = SDL_TRUE;
+   // first page, first packet
+   f->first_decode = TRUE;
 
-   if (!start_page(f))                              return SDL_FALSE;
-   /*  validate page flag */
+   if (!start_page(f))                              return FALSE;
+   // validate page flag
    if (!(f->page_flag & PAGEFLAG_first_page))       return error(f, VORBIS_invalid_first_page);
    if (f->page_flag & PAGEFLAG_last_page)           return error(f, VORBIS_invalid_first_page);
    if (f->page_flag & PAGEFLAG_continued_packet)    return error(f, VORBIS_invalid_first_page);
-   /*  check for expected packet length */
+   // check for expected packet length
    if (f->segment_count != 1)                       return error(f, VORBIS_invalid_first_page);
    if (f->segments[0] != 30) {
-      /*  check for the Ogg skeleton fishead identifying header to refine our error */
+      // check for the Ogg skeleton fishead identifying header to refine our error
       if (f->segments[0] == 64 &&
           getn(f, header, 6) &&
           header[0] == 'f' &&
@@ -3672,19 +3697,19 @@ static int start_decoder(vorb *f)
                                                     return error(f, VORBIS_invalid_first_page);
    }
 
-   /*  read packet */
-   /*  check packet header */
+   // read packet
+   // check packet header
    if (get8(f) != VORBIS_packet_id)                 return error(f, VORBIS_invalid_first_page);
    if (!getn(f, header, 6))                         return error(f, VORBIS_unexpected_eof);
    if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_first_page);
-   /*  vorbis_version */
+   // vorbis_version
    if (get32(f) != 0)                               return error(f, VORBIS_invalid_first_page);
    f->channels = get8(f); if (!f->channels)         return error(f, VORBIS_invalid_first_page);
    if (f->channels > STB_VORBIS_MAX_CHANNELS)       return error(f, VORBIS_too_many_channels);
    f->sample_rate = get32(f); if (!f->sample_rate)  return error(f, VORBIS_invalid_first_page);
-   get32(f); /*  bitrate_maximum */
-   get32(f); /*  bitrate_nominal */
-   get32(f); /*  bitrate_minimum */
+   get32(f); // bitrate_maximum
+   get32(f); // bitrate_nominal
+   get32(f); // bitrate_minimum
    x = get8(f);
    {
       int log0,log1;
@@ -3697,21 +3722,21 @@ static int start_decoder(vorb *f)
       if (log0 > log1)                                 return error(f, VORBIS_invalid_setup);
    }
 
-   /*  framing_flag */
+   // framing_flag
    x = get8(f);
    if (!(x & 1))                                    return error(f, VORBIS_invalid_first_page);
 
-   /*  second packet! */
-   if (!start_page(f))                              return SDL_FALSE;
+   // second packet!
+   if (!start_page(f))                              return FALSE;
 
-   if (!start_packet(f))                            return SDL_FALSE;
+   if (!start_packet(f))                            return FALSE;
 
-   if (!next_segment(f))                            return SDL_FALSE;
+   if (!next_segment(f))                            return FALSE;
 
    if (get8_packet(f) != VORBIS_packet_comment)            return error(f, VORBIS_invalid_setup);
    for (i=0; i < 6; ++i) header[i] = get8_packet(f);
    if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_setup);
-   /* file vendor */
+   //file vendor
    len = get32_packet(f);
    f->vendor = (char*)setup_malloc(f, sizeof(char) * (len+1));
    if (f->vendor == NULL)                           return error(f, VORBIS_outofmem);
@@ -3719,7 +3744,7 @@ static int start_decoder(vorb *f)
       f->vendor[i] = get8_packet(f);
    }
    f->vendor[len] = (char)'\0';
-   /* user comments */
+   //user comments
    f->comment_list_length = get32_packet(f);
    f->comment_list = NULL;
    if (f->comment_list_length > 0)
@@ -3739,7 +3764,7 @@ static int start_decoder(vorb *f)
       f->comment_list[i][len] = (char)'\0';
    }
 
-   /*  framing_flag */
+   // framing_flag
    x = get8_packet(f);
    if (!(x & 1))                                    return error(f, VORBIS_invalid_setup);
 
@@ -3753,37 +3778,38 @@ static int start_decoder(vorb *f)
       f->bytes_in_seg = 0;
    } while (len);
 
-   /*  third packet! */
-   if (!start_packet(f))                            return SDL_FALSE;
+   // third packet!
+   if (!start_packet(f))                            return FALSE;
 
    #ifndef STB_VORBIS_NO_PUSHDATA_API
    if (IS_PUSH_MODE(f)) {
       if (!is_whole_packet_present(f)) {
-         /*  convert error in ogg header to write type */
+         // convert error in ogg header to write type
          if (f->error == VORBIS_invalid_stream)
             f->error = VORBIS_invalid_setup;
-         return SDL_FALSE;
+         return FALSE;
       }
    }
    #endif
 
-   crc32_init(); /*  always init it, to avoid multithread race conditions */
+   crc32_init(); // always init it, to avoid multithread race conditions
 
    if (get8_packet(f) != VORBIS_packet_setup)       return error(f, VORBIS_invalid_setup);
    for (i=0; i < 6; ++i) header[i] = get8_packet(f);
    if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_setup);
 
-   /*  codebooks */
+   // codebooks
 
    f->codebook_count = get_bits(f,8) + 1;
+   if (f->valid_bits < 0)                           return error(f, VORBIS_unexpected_eof);
    f->codebooks = (Codebook *) setup_malloc(f, sizeof(*f->codebooks) * f->codebook_count);
    if (f->codebooks == NULL)                        return error(f, VORBIS_outofmem);
-   SDL_memset(f->codebooks, 0, sizeof(*f->codebooks) * f->codebook_count);
+   memset(f->codebooks, 0, sizeof(*f->codebooks) * f->codebook_count);
    for (i=0; i < f->codebook_count; ++i) {
-      Uint32 *values;
+      uint32 *values;
       int ordered, sorted_count;
       int total=0;
-      Uint8 *lengths;
+      uint8 *lengths;
       Codebook *c = f->codebooks+i;
       CHECK(f);
       x = get_bits(f, 8); if (x != 0x42)            return error(f, VORBIS_invalid_setup);
@@ -3798,11 +3824,13 @@ static int start_decoder(vorb *f)
       c->sparse = ordered ? 0 : get_bits(f,1);
 
       if (c->dimensions == 0 && c->entries != 0)    return error(f, VORBIS_invalid_setup);
+      if (f->valid_bits < 0)                        return error(f, VORBIS_unexpected_eof);
 
-      if (c->sparse)
-         lengths = (Uint8 *) setup_temp_malloc(f, c->entries);
-      else
-         lengths = c->codeword_lengths = (Uint8 *) setup_malloc(f, c->entries);
+      if (c->sparse) {
+         lengths = (uint8 *) setup_temp_malloc(f, c->entries);
+         f->temp_lengths = lengths;
+      } else
+         lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
 
       if (!lengths) return error(f, VORBIS_outofmem);
 
@@ -3812,20 +3840,21 @@ static int start_decoder(vorb *f)
          while (current_entry < c->entries) {
             int limit = c->entries - current_entry;
             int n = get_bits(f, ilog(limit));
+            if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
             if (current_length >= 32) return error(f, VORBIS_invalid_setup);
-            if (current_entry + n > (int) c->entries) { return error(f, VORBIS_invalid_setup); }
-            SDL_memset(lengths + current_entry, current_length, n);
+            if (current_entry + n > (int) c->entries) return error(f, VORBIS_invalid_setup);
+            memset(lengths + current_entry, current_length, n);
             current_entry += n;
             ++current_length;
          }
       } else {
          for (j=0; j < c->entries; ++j) {
             int present = c->sparse ? get_bits(f,1) : 1;
+            if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
             if (present) {
                lengths[j] = get_bits(f, 5) + 1;
                ++total;
-               if (lengths[j] == 32)
-                  return error(f, VORBIS_invalid_setup);
+               if (lengths[j] == 32) return error(f, VORBIS_invalid_setup);
             } else {
                lengths[j] = NO_CODE;
             }
@@ -3833,19 +3862,19 @@ static int start_decoder(vorb *f)
       }
 
       if (c->sparse && total >= c->entries >> 2) {
-         /*  convert sparse items to non-sparse! */
+         // convert sparse items to non-sparse!
          if (c->entries > (int) f->setup_temp_memory_required)
             f->setup_temp_memory_required = c->entries;
 
-         c->codeword_lengths = (Uint8 *) setup_malloc(f, c->entries);
+         c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
          if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
-         SDL_memcpy(c->codeword_lengths, lengths, c->entries);
-         setup_temp_free(f, lengths, c->entries); /*  note this is only safe if there have been no intervening temp mallocs! */
+         memcpy(c->codeword_lengths, lengths, c->entries);
+         setup_temp_free(f, &f->temp_lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
          lengths = c->codeword_lengths;
          c->sparse = 0;
       }
 
-      /*  compute the size of the sorted tables */
+      // compute the size of the sorted tables
       if (c->sparse) {
          sorted_count = total;
       } else {
@@ -3862,16 +3891,18 @@ static int start_decoder(vorb *f)
 
       CHECK(f);
       if (!c->sparse) {
-         c->codewords = (Uint32 *) setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
+         c->codewords = (uint32 *) setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
          if (!c->codewords)                  return error(f, VORBIS_outofmem);
       } else {
          unsigned int size;
          if (c->sorted_entries) {
-            c->codeword_lengths = (Uint8 *) setup_malloc(f, c->sorted_entries);
+            c->codeword_lengths = (uint8 *) setup_malloc(f, c->sorted_entries);
             if (!c->codeword_lengths)           return error(f, VORBIS_outofmem);
-            c->codewords = (Uint32 *) setup_temp_malloc(f, sizeof(*c->codewords) * c->sorted_entries);
+            c->codewords = (uint32 *) setup_temp_malloc(f, sizeof(*c->codewords) * c->sorted_entries);
+            f->temp_codewords = c->codewords;
             if (!c->codewords)                  return error(f, VORBIS_outofmem);
-            values = (Uint32 *) setup_temp_malloc(f, sizeof(*values) * c->sorted_entries);
+            values = (uint32 *) setup_temp_malloc(f, sizeof(*values) * c->sorted_entries);
+            f->temp_values = values;
             if (!values)                        return error(f, VORBIS_outofmem);
          }
          size = c->entries + (sizeof(*c->codewords) + sizeof(*values)) * c->sorted_entries;
@@ -3880,16 +3911,15 @@ static int start_decoder(vorb *f)
       }
 
       if (!compute_codewords(c, lengths, c->entries, values)) {
-         if (c->sparse) setup_temp_free(f, values, 0);
          return error(f, VORBIS_invalid_setup);
       }
 
       if (c->sorted_entries) {
-         /*  allocate an extra slot for sentinels */
-         c->sorted_codewords = (Uint32 *) setup_malloc(f, sizeof(*c->sorted_codewords) * (c->sorted_entries+1));
+         // allocate an extra slot for sentinels
+         c->sorted_codewords = (uint32 *) setup_malloc(f, sizeof(*c->sorted_codewords) * (c->sorted_entries+1));
          if (c->sorted_codewords == NULL) return error(f, VORBIS_outofmem);
-         /*  allocate an extra slot at the front so that c->sorted_values[-1] is defined */
-         /*  so that we can catch that case without an extra if */
+         // allocate an extra slot at the front so that c->sorted_values[-1] is defined
+         // so that we can catch that case without an extra if
          c->sorted_values    = ( int   *) setup_malloc(f, sizeof(*c->sorted_values   ) * (c->sorted_entries+1));
          if (c->sorted_values == NULL) return error(f, VORBIS_outofmem);
          ++c->sorted_values;
@@ -3898,9 +3928,9 @@ static int start_decoder(vorb *f)
       }
 
       if (c->sparse) {
-         setup_temp_free(f, values, sizeof(*values)*c->sorted_entries);
-         setup_temp_free(f, c->codewords, sizeof(*c->codewords)*c->sorted_entries);
-         setup_temp_free(f, lengths, c->entries);
+         setup_temp_free(f, &f->temp_values, sizeof(*values)*c->sorted_entries);
+         setup_temp_free(f, &f->temp_codewords, sizeof(*c->codewords)*c->sorted_entries);
+         setup_temp_free(f, &f->temp_lengths, c->entries);
          c->codewords = NULL;
       }
 
@@ -3910,7 +3940,7 @@ static int start_decoder(vorb *f)
       c->lookup_type = get_bits(f, 4);
       if (c->lookup_type > 2) return error(f, VORBIS_invalid_setup);
       if (c->lookup_type > 0) {
-         Uint16 *mults;
+         uint16 *mults;
          c->minimum_value = float32_unpack(get_bits(f, 32));
          c->delta_value = float32_unpack(get_bits(f, 32));
          c->value_bits = get_bits(f, 4)+1;
@@ -3918,16 +3948,19 @@ static int start_decoder(vorb *f)
          if (c->lookup_type == 1) {
             int values = lookup1_values(c->entries, c->dimensions);
             if (values < 0) return error(f, VORBIS_invalid_setup);
-            c->lookup_values = (Uint32) values;
+            c->lookup_values = (uint32) values;
          } else {
-            c->lookup_values = c->entries * c->dimensions;
+            /* unsigned multiply to suppress (legitimate) warning.
+             * https://github.com/nothings/stb/issues/1168 */
+            c->lookup_values = (unsigned)c->entries * (unsigned)c->dimensions;
          }
          if (c->lookup_values == 0) return error(f, VORBIS_invalid_setup);
-         mults = (Uint16 *) setup_temp_malloc(f, sizeof(mults[0]) * c->lookup_values);
+         mults = (uint16 *) setup_temp_malloc(f, sizeof(mults[0]) * c->lookup_values);
+         f->temp_mults = mults;
          if (mults == NULL) return error(f, VORBIS_outofmem);
          for (j=0; j < (int) c->lookup_values; ++j) {
             int q = get_bits(f, c->value_bits);
-            if (q == EOP) { setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_invalid_setup); }
+            if (f->valid_bits < 0) return error(f, VORBIS_invalid_setup);
             mults[j] = q;
          }
 
@@ -3935,13 +3968,13 @@ static int start_decoder(vorb *f)
          if (c->lookup_type == 1) {
             int len, sparse = c->sparse;
             float last=0;
-            /*  pre-expand the lookup1-style multiplicands, to avoid a divide in the inner loop */
+            // pre-expand the lookup1-style multiplicands, to avoid a divide in the inner loop
             if (sparse) {
                if (c->sorted_entries == 0) goto skip;
                c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->sorted_entries * c->dimensions);
             } else
                c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->entries        * c->dimensions);
-            if (c->multiplicands == NULL) { setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_outofmem); }
+            if (c->multiplicands == NULL) return error(f, VORBIS_outofmem);
             len = sparse ? c->sorted_entries : c->entries;
             for (j=0; j < len; ++j) {
                unsigned int z = sparse ? c->sorted_values[j] : j;
@@ -3954,7 +3987,6 @@ static int start_decoder(vorb *f)
                      last = val;
                   if (k+1 < c->dimensions) {
                      if (div > UINT_MAX / (unsigned int) c->lookup_values) {
-                        setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values);
                         return error(f, VORBIS_invalid_setup);
                      }
                      div *= c->lookup_values;
@@ -3969,7 +4001,7 @@ static int start_decoder(vorb *f)
             float last=0;
             CHECK(f);
             c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->lookup_values);
-            if (c->multiplicands == NULL) { setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_outofmem); }
+            if (c->multiplicands == NULL) return error(f, VORBIS_outofmem);
             for (j=0; j < (int) c->lookup_values; ++j) {
                float val = mults[j] * c->delta_value + c->minimum_value + last;
                c->multiplicands[j] = val;
@@ -3980,23 +4012,24 @@ static int start_decoder(vorb *f)
 #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
         skip:;
 #endif
-         setup_temp_free(f, mults, sizeof(mults[0])*c->lookup_values);
+         setup_temp_free(f, &f->temp_mults, sizeof(mults[0])*c->lookup_values);
 
          CHECK(f);
       }
       CHECK(f);
    }
 
-   /*  time domain transfers (notused) */
+   // time domain transfers (notused)
 
    x = get_bits(f, 6) + 1;
    for (i=0; i < x; ++i) {
-      Uint32 z = get_bits(f, 16);
+      uint32 z = get_bits(f, 16);
       if (z != 0) return error(f, VORBIS_invalid_setup);
    }
 
-   /*  Floors */
+   // Floors
    f->floor_count = get_bits(f, 6)+1;
+   if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
    f->floor_config = (Floor *)  setup_malloc(f, f->floor_count * sizeof(*f->floor_config));
    if (f->floor_config == NULL) return error(f, VORBIS_outofmem);
    for (i=0; i < f->floor_count; ++i) {
@@ -4026,12 +4059,13 @@ static int start_decoder(vorb *f)
          for (j=0; j <= max_class; ++j) {
             g->class_dimensions[j] = get_bits(f, 3)+1;
             g->class_subclasses[j] = get_bits(f, 2);
+            if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
             if (g->class_subclasses[j]) {
                g->class_masterbooks[j] = get_bits(f, 8);
                if (g->class_masterbooks[j] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
             }
             for (k=0; k < 1 << g->class_subclasses[j]; ++k) {
-               g->subclass_books[j][k] = (Sint16)get_bits(f,8)-1;
+               g->subclass_books[j][k] = (int16)get_bits(f,8)-1;
                if (g->subclass_books[j][k] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
             }
          }
@@ -4047,7 +4081,7 @@ static int start_decoder(vorb *f)
                ++g->values;
             }
          }
-         /*  precompute the sorting */
+         // precompute the sorting
          for (j=0; j < g->values; ++j) {
             p[j].x = g->Xlist[j];
             p[j].id = j;
@@ -4057,8 +4091,8 @@ static int start_decoder(vorb *f)
             if (p[j].x == p[j+1].x)
                return error(f, VORBIS_invalid_setup);
          for (j=0; j < g->values; ++j)
-            g->sorted_order[j] = (Uint8) p[j].id;
-         /*  precompute the neighbors */
+            g->sorted_order[j] = (uint8) p[j].id;
+         // precompute the neighbors
          for (j=2; j < g->values; ++j) {
             int low = 0,hi = 0;
             neighbors(g->Xlist, j, &low,&hi);
@@ -4071,13 +4105,14 @@ static int start_decoder(vorb *f)
       }
    }
 
-   /*  Residue */
+   // Residue
    f->residue_count = get_bits(f, 6)+1;
+   if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
    f->residue_config = (Residue *) setup_malloc(f, f->residue_count * sizeof(f->residue_config[0]));
    if (f->residue_config == NULL) return error(f, VORBIS_outofmem);
-   SDL_memset(f->residue_config, 0, f->residue_count * sizeof(f->residue_config[0]));
+   memset(f->residue_config, 0, f->residue_count * sizeof(f->residue_config[0]));
    for (i=0; i < f->residue_count; ++i) {
-      Uint8 residue_cascade[64];
+      uint8 residue_cascade[64];
       Residue *r = f->residue_config+i;
       f->residue_types[i] = get_bits(f, 16);
       if (f->residue_types[i] > 2) return error(f, VORBIS_invalid_setup);
@@ -4087,35 +4122,38 @@ static int start_decoder(vorb *f)
       r->part_size = get_bits(f,24)+1;
       r->classifications = get_bits(f,6)+1;
       r->classbook = get_bits(f,8);
+      if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
       if (r->classbook >= f->codebook_count) return error(f, VORBIS_invalid_setup);
       for (j=0; j < r->classifications; ++j) {
-         Uint8 high_bits=0;
-         Uint8 low_bits=get_bits(f,3);
+         uint8 high_bits=0;
+         uint8 low_bits=get_bits(f,3);
          if (get_bits(f,1))
             high_bits = get_bits(f,5);
          residue_cascade[j] = high_bits*8 + low_bits;
       }
+      if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
       r->residue_books = (short (*)[8]) setup_malloc(f, sizeof(r->residue_books[0]) * r->classifications);
       if (r->residue_books == NULL) return error(f, VORBIS_outofmem);
       for (j=0; j < r->classifications; ++j) {
          for (k=0; k < 8; ++k) {
             if (residue_cascade[j] & (1 << k)) {
                r->residue_books[j][k] = get_bits(f, 8);
+               if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
                if (r->residue_books[j][k] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
             } else {
                r->residue_books[j][k] = -1;
             }
          }
       }
-      /*  precompute the classifications[] array to avoid inner-loop mod/divide */
-      /*  call it 'classdata' since we already have r->classifications */
-      r->classdata = (Uint8 **) setup_malloc(f, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
+      // precompute the classifications[] array to avoid inner-loop mod/divide
+      // call it 'classdata' since we already have r->classifications
+      r->classdata = (uint8 **) setup_malloc(f, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
       if (!r->classdata) return error(f, VORBIS_outofmem);
-      SDL_memset(r->classdata, 0, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
+      memset(r->classdata, 0, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
       for (j=0; j < f->codebooks[r->classbook].entries; ++j) {
          int classwords = f->codebooks[r->classbook].dimensions;
          int temp = j;
-         r->classdata[j] = (Uint8 *) setup_malloc(f, sizeof(r->classdata[j][0]) * classwords);
+         r->classdata[j] = (uint8 *) setup_malloc(f, sizeof(r->classdata[j][0]) * classwords);
          if (r->classdata[j] == NULL) return error(f, VORBIS_outofmem);
          for (k=classwords-1; k >= 0; --k) {
             r->classdata[j][k] = temp % r->classifications;
@@ -4125,9 +4163,10 @@ static int start_decoder(vorb *f)
    }
 
    f->mapping_count = get_bits(f,6)+1;
+   if (f->valid_bits < 0) return error(f, VORBIS_unexpected_eof);
    f->mapping = (Mapping *) setup_malloc(f, f->mapping_count * sizeof(*f->mapping));
    if (f->mapping == NULL) return error(f, VORBIS_outofmem);
-   SDL_memset(f->mapping, 0, f->mapping_count * sizeof(*f->mapping));
+   memset(f->mapping, 0, f->mapping_count * sizeof(*f->mapping));
    for (i=0; i < f->mapping_count; ++i) {
       Mapping *m = f->mapping + i;
       int mapping_type = get_bits(f,16);
@@ -4146,6 +4185,7 @@ static int start_decoder(vorb *f)
          for (k=0; k < m->coupling_steps; ++k) {
             m->chan[k].magnitude = get_bits(f, ilog(f->channels-1));
             m->chan[k].angle = get_bits(f, ilog(f->channels-1));
+            if (f->valid_bits < 0)                          return error(f, VORBIS_unexpected_eof);
             if (m->chan[k].magnitude >= f->channels)        return error(f, VORBIS_invalid_setup);
             if (m->chan[k].angle     >= f->channels)        return error(f, VORBIS_invalid_setup);
             if (m->chan[k].magnitude == m->chan[k].angle)   return error(f, VORBIS_invalid_setup);
@@ -4153,7 +4193,7 @@ static int start_decoder(vorb *f)
       } else
          m->coupling_steps = 0;
 
-      /*  reserved field */
+      // reserved field
       if (get_bits(f,2)) return error(f, VORBIS_invalid_setup);
       if (m->submaps > 1) {
          for (j=0; j < f->channels; ++j) {
@@ -4161,12 +4201,12 @@ static int start_decoder(vorb *f)
             if (m->chan[j].mux >= m->submaps)                return error(f, VORBIS_invalid_setup);
          }
       } else
-         /*  @SPECIFICATION: this case is missing from the spec */
+         // @SPECIFICATION: this case is missing from the spec
          for (j=0; j < f->channels; ++j)
             m->chan[j].mux = 0;
 
       for (j=0; j < m->submaps; ++j) {
-         get_bits(f,8); /*  discard */
+         get_bits(f,8); // discard
          m->submap_floor[j] = get_bits(f,8);
          m->submap_residue[j] = get_bits(f,8);
          if (m->submap_floor[j] >= f->floor_count)      return error(f, VORBIS_invalid_setup);
@@ -4174,7 +4214,7 @@ static int start_decoder(vorb *f)
       }
    }
 
-   /*  Modes */
+   // Modes
    f->mode_count = get_bits(f, 6)+1;
    for (i=0; i < f->mode_count; ++i) {
       Mode *m = f->mode_config+i;
@@ -4182,6 +4222,7 @@ static int start_decoder(vorb *f)
       m->windowtype = get_bits(f,16);
       m->transformtype = get_bits(f,16);
       m->mapping = get_bits(f,8);
+      if (f->valid_bits < 0)                  return error(f, VORBIS_unexpected_eof);
       if (m->windowtype != 0)                 return error(f, VORBIS_invalid_setup);
       if (m->transformtype != 0)              return error(f, VORBIS_invalid_setup);
       if (m->mapping >= f->mapping_count)     return error(f, VORBIS_invalid_setup);
@@ -4194,17 +4235,17 @@ static int start_decoder(vorb *f)
    for (i=0; i < f->channels; ++i) {
       f->channel_buffers[i] = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1);
       f->previous_window[i] = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1/2);
-      f->finalY[i]          = (Sint16 *) setup_malloc(f, sizeof(Sint16) * longest_floorlist);
+      f->finalY[i]          = (int16 *) setup_malloc(f, sizeof(int16) * longest_floorlist);
       if (f->channel_buffers[i] == NULL || f->previous_window[i] == NULL || f->finalY[i] == NULL) return error(f, VORBIS_outofmem);
-      SDL_memset(f->channel_buffers[i], 0, sizeof(float) * f->blocksize_1);
+      memset(f->channel_buffers[i], 0, sizeof(float) * f->blocksize_1);
       #ifdef STB_VORBIS_NO_DEFER_FLOOR
       f->floor_buffers[i]   = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1/2);
       if (f->floor_buffers[i] == NULL) return error(f, VORBIS_outofmem);
       #endif
    }
 
-   if (!init_blocksize(f, 0, f->blocksize_0)) return SDL_FALSE;
-   if (!init_blocksize(f, 1, f->blocksize_1)) return SDL_FALSE;
+   if (!init_blocksize(f, 0, f->blocksize_0)) return FALSE;
+   if (!init_blocksize(f, 1, f->blocksize_1)) return FALSE;
    f->blocksize[0] = f->blocksize_0;
    f->blocksize[1] = f->blocksize_1;
 
@@ -4215,12 +4256,12 @@ static int start_decoder(vorb *f)
             integer_divide_table[i][j] = i / j;
 #endif
 
-   /*  compute how much temporary memory is needed */
+   // compute how much temporary memory is needed
 
-   /*  1. */
+   // 1.
    {
-      Uint32 imdct_mem = (f->blocksize_1 * sizeof(float) >> 1);
-      Uint32 classify_mem;
+      uint32 imdct_mem = (f->blocksize_1 * sizeof(float) >> 1);
+      uint32 classify_mem;
       int i,max_part_read=0;
       for (i=0; i < f->residue_count; ++i) {
          Residue *r = f->residue_config + i;
@@ -4233,12 +4274,12 @@ static int start_decoder(vorb *f)
             max_part_read = part_read;
       }
       #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-      classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(Uint8 *));
+      classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(uint8 *));
       #else
       classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(int *));
       #endif
 
-      /*  maximum reasonable partition size is f->blocksize_1 */
+      // maximum reasonable partition size is f->blocksize_1
 
       f->temp_memory_required = classify_mem;
       if (imdct_mem > f->temp_memory_required)
@@ -4247,25 +4288,28 @@ static int start_decoder(vorb *f)
 
 
    if (f->alloc.alloc_buffer) {
-      SDL_assert(f->temp_offset == f->alloc.alloc_buffer_length_in_bytes);
-      /* check if there's enough temp memory so we don't error later */
+      assert(f->temp_offset == f->alloc.alloc_buffer_length_in_bytes);
+      // check if there's enough temp memory so we don't error later
       if (f->setup_offset + sizeof(*f) + f->temp_memory_required > (unsigned) f->temp_offset)
          return error(f, VORBIS_outofmem);
+   } else {
+      f->work_buffer = setup_malloc(f, f->temp_memory_required);
+      if (f->work_buffer == NULL) return error(f, VORBIS_outofmem);
    }
 
-   /*  @TODO: stb_vorbis_seek_start expects first_audio_page_offset to point to a page */
-   /*  without PAGEFLAG_continued_packet, so this either points to the first page, or */
-   /*  the page after the end of the headers. It might be cleaner to point to a page */
-   /*  in the middle of the headers, when that's the page where the first audio packet */
-   /*  starts, but we'd have to also correctly skip the end of any continued packet in */
-   /*  stb_vorbis_seek_start. */
+   // @TODO: stb_vorbis_seek_start expects first_audio_page_offset to point to a page
+   // without PAGEFLAG_continued_packet, so this either points to the first page, or
+   // the page after the end of the headers. It might be cleaner to point to a page
+   // in the middle of the headers, when that's the page where the first audio packet
+   // starts, but we'd have to also correctly skip the end of any continued packet in
+   // stb_vorbis_seek_start.
    if (f->next_seg == -1) {
       f->first_audio_page_offset = stb_vorbis_get_file_offset(f);
    } else {
       f->first_audio_page_offset = 0;
    }
 
-   return SDL_TRUE;
+   return TRUE;
 }
 
 static void vorbis_deinit(stb_vorbis *p)
@@ -4296,9 +4340,10 @@ static void vorbis_deinit(stb_vorbis *p)
          Codebook *c = p->codebooks + i;
          setup_free(p, c->codeword_lengths);
          setup_free(p, c->multiplicands);
-         setup_free(p, c->codewords);
+         if (c->codewords != p->temp_codewords) // Might be the temporary buffer-allocated array.
+            setup_free(p, c->codewords);
          setup_free(p, c->sorted_codewords);
-         /*  c->sorted_values[-1] is the first entry in the array */
+         // c->sorted_values[-1] is the first entry in the array
          setup_free(p, c->sorted_values ? c->sorted_values-1 : NULL);
       }
       setup_free(p, p->codebooks);
@@ -4326,10 +4371,19 @@ static void vorbis_deinit(stb_vorbis *p)
       setup_free(p, p->window[i]);
       setup_free(p, p->bit_reverse[i]);
    }
+   if (!p->alloc.alloc_buffer) {
+      setup_free(p, p->work_buffer);
+      setup_temp_free(p, &p->temp_lengths, 0);
+      setup_temp_free(p, &p->temp_codewords, 0);
+      setup_temp_free(p, &p->temp_values, 0);
+      setup_temp_free(p, &p->temp_mults, 0);
+   }
+   #ifdef STB_VORBIS_SDL
+   if (p->close_on_free) SDL_RWclose(p->rwops);
+   #endif
    #ifndef STB_VORBIS_NO_STDIO
    if (p->close_on_free) fclose(p->f);
    #endif
-   if (p->rw && p->close_on_free) SDL_RWclose(p->rw);
 }
 
 void stb_vorbis_close(stb_vorbis *p)
@@ -4341,7 +4395,7 @@ void stb_vorbis_close(stb_vorbis *p)
 
 static void vorbis_init(stb_vorbis *p, const stb_vorbis_alloc *z)
 {
-   SDL_memset(p, 0, sizeof(*p)); /*  NULL out all malloc'd pointers to start */
+   memset(p, 0, sizeof(*p)); // NULL out all malloc'd pointers to start
    if (z) {
       p->alloc = *z;
       p->alloc.alloc_buffer_length_in_bytes &= ~7;
@@ -4352,14 +4406,17 @@ static void vorbis_init(stb_vorbis *p, const stb_vorbis_alloc *z)
    p->stream = NULL;
    p->codebooks = NULL;
    p->page_crc_tests = -1;
-   p->close_on_free = SDL_FALSE;
+   #ifdef STB_VORBIS_SDL
+   p->close_on_free = FALSE;
+   p->rwops = NULL;
+   #endif
    #ifndef STB_VORBIS_NO_STDIO
+   p->close_on_free = FALSE;
    p->f = NULL;
    #endif
-   p->rw = NULL;
 }
 
-Sint64 stb_vorbis_get_sample_offset(stb_vorbis *f)
+int stb_vorbis_get_sample_offset(stb_vorbis *f)
 {
    if (f->current_loc_valid)
       return f->current_loc;
@@ -4367,7 +4424,7 @@ Sint64 stb_vorbis_get_sample_offset(stb_vorbis *f)
       return -1;
 }
 
-Sint64 stb_vorbis_get_playback_sample_offset(stb_vorbis *f)
+int stb_vorbis_get_playback_sample_offset(stb_vorbis *f)
 {
    if (f->current_playback_loc_valid)
       return f->current_playback_loc;
@@ -4416,55 +4473,55 @@ void stb_vorbis_flush_pushdata(stb_vorbis *f)
    f->previous_length = 0;
    f->page_crc_tests  = 0;
    f->discard_samples_deferred = 0;
-   f->current_loc_valid = SDL_FALSE;
-   f->first_decode = SDL_FALSE;
+   f->current_loc_valid = FALSE;
+   f->first_decode = FALSE;
    f->samples_output = 0;
    f->channel_buffer_start = 0;
    f->channel_buffer_end = 0;
 }
 
-static int vorbis_search_for_page_pushdata(vorb *f, Uint8 *data, int data_len)
+static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
 {
    int i,n;
    for (i=0; i < f->page_crc_tests; ++i)
       f->scan[i].bytes_done = 0;
 
-   /*  if we have room for more scans, search for them first, because */
-   /*  they may cause us to stop early if their header is incomplete */
+   // if we have room for more scans, search for them first, because
+   // they may cause us to stop early if their header is incomplete
    if (f->page_crc_tests < STB_VORBIS_PUSHDATA_CRC_COUNT) {
       if (data_len < 4) return 0;
-      data_len -= 3; /*  need to look for 4-byte sequence, so don't miss */
-                     /*  one that straddles a boundary */
+      data_len -= 3; // need to look for 4-byte sequence, so don't miss
+                     // one that straddles a boundary
       for (i=0; i < data_len; ++i) {
          if (data[i] == 0x4f) {
-            if (0==SDL_memcmp(data+i, ogg_page_header, 4)) {
+            if (0==memcmp(data+i, ogg_page_header, 4)) {
                int j,len;
-               Uint32 crc;
-               /*  make sure we have the whole page header */
+               uint32 crc;
+               // make sure we have the whole page header
                if (i+26 >= data_len || i+27+data[i+26] >= data_len) {
-                  /*  only read up to this page start, so hopefully we'll */
-                  /*  have the whole page header start next time */
+                  // only read up to this page start, so hopefully we'll
+                  // have the whole page header start next time
                   data_len = i;
                   break;
                }
-               /*  ok, we have it all; compute the length of the page */
+               // ok, we have it all; compute the length of the page
                len = 27 + data[i+26];
                for (j=0; j < data[i+26]; ++j)
                   len += data[i+27+j];
-               /*  scan everything up to the embedded crc (which we must 0) */
+               // scan everything up to the embedded crc (which we must 0)
                crc = 0;
                for (j=0; j < 22; ++j)
                   crc = crc32_update(crc, data[i+j]);
-               /*  now process 4 0-bytes */
+               // now process 4 0-bytes
                for (   ; j < 26; ++j)
                   crc = crc32_update(crc, 0);
-               /*  len is the total number of bytes we need to scan */
+               // len is the total number of bytes we need to scan
                n = f->page_crc_tests++;
                f->scan[n].bytes_left = len-j;
                f->scan[n].crc_so_far = crc;
                f->scan[n].goal_crc = data[i+22] + (data[i+23] << 8) + (data[i+24]<<16) + (data[i+25]<<24);
-               /*  if the last frame on a page is continued to the next, then */
-               /*  we can't recover the sample_loc immediately */
+               // if the last frame on a page is continued to the next, then
+               // we can't recover the sample_loc immediately
                if (data[i+27+data[i+26]-1] == 255)
                   f->scan[n].sample_loc = ~0;
                else
@@ -4472,38 +4529,38 @@ static int vorbis_search_for_page_pushdata(vorb *f, Uint8 *data, int data_len)
                f->scan[n].bytes_done = i+j;
                if (f->page_crc_tests == STB_VORBIS_PUSHDATA_CRC_COUNT)
                   break;
-               /*  keep going if we still have room for more */
+               // keep going if we still have room for more
             }
          }
       }
    }
 
    for (i=0; i < f->page_crc_tests;) {
-      Uint32 crc;
+      uint32 crc;
       int j;
       int n = f->scan[i].bytes_done;
       int m = f->scan[i].bytes_left;
       if (m > data_len - n) m = data_len - n;
-      /*  m is the bytes to scan in the current chunk */
+      // m is the bytes to scan in the current chunk
       crc = f->scan[i].crc_so_far;
       for (j=0; j < m; ++j)
          crc = crc32_update(crc, data[n+j]);
       f->scan[i].bytes_left -= m;
       f->scan[i].crc_so_far = crc;
       if (f->scan[i].bytes_left == 0) {
-         /*  does it match? */
+         // does it match?
          if (f->scan[i].crc_so_far == f->scan[i].goal_crc) {
-            /*  Houston, we have page */
-            data_len = n+m; /*  consumption amount is wherever that scan ended */
-            f->page_crc_tests = -1; /*  drop out of page scan mode */
-            f->previous_length = 0; /*  decode-but-don't-output one frame */
-            f->next_seg = -1;       /*  start a new page */
-            f->current_loc = f->scan[i].sample_loc; /*  set the current sample location */
-                                    /*  to the amount we'd have decoded had we decoded this page */
+            // Houston, we have page
+            data_len = n+m; // consumption amount is wherever that scan ended
+            f->page_crc_tests = -1; // drop out of page scan mode
+            f->previous_length = 0; // decode-but-don't-output one frame
+            f->next_seg = -1;       // start a new page
+            f->current_loc = f->scan[i].sample_loc; // set the current sample location
+                                    // to the amount we'd have decoded had we decoded this page
             f->current_loc_valid = f->current_loc != ~0U;
             return data_len;
          }
-         /*  delete entry */
+         // delete entry
          f->scan[i] = f->scan[--f->page_crc_tests];
       } else {
          ++i;
@@ -4513,13 +4570,13 @@ static int vorbis_search_for_page_pushdata(vorb *f, Uint8 *data, int data_len)
    return data_len;
 }
 
-/*  return value: number of bytes we used */
+// return value: number of bytes we used
 int stb_vorbis_decode_frame_pushdata(
-         stb_vorbis *f,                   /*  the file we're decoding */
-         const Uint8 *data, int data_len, /*  the memory available for decoding */
-         int *channels,                   /*  place to write number of float * buffers */
-         float ***output,                 /*  place to write float ** array of float * buffers */
-         int *samples                     /*  place to write number of output samples */
+         stb_vorbis *f,                   // the file we're decoding
+         const uint8 *data, int data_len, // the memory available for decoding
+         int *channels,                   // place to write number of float * buffers
+         float ***output,                 // place to write float ** array of float * buffers
+         int *samples                     // place to write number of output samples
      )
 {
    int i;
@@ -4529,24 +4586,24 @@ int stb_vorbis_decode_frame_pushdata(
 
    if (f->page_crc_tests >= 0) {
       *samples = 0;
-      return vorbis_search_for_page_pushdata(f, (Uint8 *) data, data_len);
+      return vorbis_search_for_page_pushdata(f, (uint8 *) data, data_len);
    }
 
-   f->stream     = (Uint8 *) data;
-   f->stream_end = (Uint8 *) data + data_len;
+   f->stream     = (uint8 *) data;
+   f->stream_end = (uint8 *) data + data_len;
    f->error      = VORBIS__no_error;
 
-   /*  check that we have the entire packet in memory */
+   // check that we have the entire packet in memory
    if (!is_whole_packet_present(f)) {
       *samples = 0;
       return 0;
    }
 
    if (!vorbis_decode_packet(f, &len, &left, &right)) {
-      /*  save the actual error we encountered */
+      // save the actual error we encountered
       enum STBVorbisError error = f->error;
       if (error == VORBIS_bad_packet_type) {
-         /*  flush and resynch */
+         // flush and resynch
          f->error = VORBIS__no_error;
          while (get8_packet(f) != EOP)
             if (f->eof) break;
@@ -4555,8 +4612,8 @@ int stb_vorbis_decode_frame_pushdata(
       }
       if (error == VORBIS_continued_packet_flag_invalid) {
          if (f->previous_length == 0) {
-            /*  we may be resynching, in which case it's ok to hit one */
-            /*  of these; just discard the packet */
+            // we may be resynching, in which case it's ok to hit one
+            // of these; just discard the packet
             f->error = VORBIS__no_error;
             while (get8_packet(f) != EOP)
                if (f->eof) break;
@@ -4564,16 +4621,16 @@ int stb_vorbis_decode_frame_pushdata(
             return (int) (f->stream - data);
          }
       }
-      /*  if we get an error while parsing, what to do? */
-      /*  well, it DEFINITELY won't work to continue from where we are! */
+      // if we get an error while parsing, what to do?
+      // well, it DEFINITELY won't work to continue from where we are!
       stb_vorbis_flush_pushdata(f);
-      /*  restore the error that actually made us bail */
+      // restore the error that actually made us bail
       f->error = error;
       *samples = 0;
       return 1;
    }
 
-   /*  success! */
+   // success!
    len = vorbis_finish_frame(f, len, left, right);
    for (i=0; i < f->channels; ++i)
       f->outputs[i] = f->channel_buffers[i] + left;
@@ -4585,15 +4642,15 @@ int stb_vorbis_decode_frame_pushdata(
 }
 
 stb_vorbis *stb_vorbis_open_pushdata(
-         const unsigned char *data, int data_len, /*  the memory available for decoding */
-         int *data_used,              /*  only defined if result is not NULL */
+         const unsigned char *data, int data_len, // the memory available for decoding
+         int *data_used,              // only defined if result is not NULL
          int *error, const stb_vorbis_alloc *alloc)
 {
    stb_vorbis *f, p;
    vorbis_init(&p, alloc);
-   p.stream     = (Uint8 *) data;
-   p.stream_end = (Uint8 *) data + data_len;
-   p.push_mode  = SDL_TRUE;
+   p.stream     = (uint8 *) data;
+   p.stream_end = (uint8 *) data + data_len;
+   p.push_mode  = TRUE;
    if (!start_decoder(&p)) {
       if (p.eof)
          *error = VORBIS_need_more_data;
@@ -4613,52 +4670,55 @@ stb_vorbis *stb_vorbis_open_pushdata(
       return NULL;
    }
 }
-#endif /*  STB_VORBIS_NO_PUSHDATA_API */
+#endif // STB_VORBIS_NO_PUSHDATA_API
 
 unsigned int stb_vorbis_get_file_offset(stb_vorbis *f)
 {
    #ifndef STB_VORBIS_NO_PUSHDATA_API
    if (f->push_mode) return 0;
    #endif
-   if (USE_RWOPS(f)) return (unsigned int) SDL_RWtell(f->rw) - f->f_start;
+   #ifdef STB_VORBIS_SDL
+   return (unsigned int) (SDL_RWtell(f->rwops) - f->rwops_start);
+   #else
    if (USE_MEMORY(f)) return (unsigned int) (f->stream - f->stream_start);
+   #endif
    #ifndef STB_VORBIS_NO_STDIO
    return (unsigned int) (ftell(f->f) - f->f_start);
    #endif
 }
 
 #ifndef STB_VORBIS_NO_PULLDATA_API
-/*  */
-/*  DATA-PULLING API */
-/*  */
+//
+// DATA-PULLING API
+//
 
-static Uint32 vorbis_find_page(stb_vorbis *f, Uint32 *end, Uint32 *last)
+static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
 {
    for(;;) {
       int n;
       if (f->eof) return 0;
       n = get8(f);
-      if (n == 0x4f) { /*  page header candidate */
+      if (n == 0x4f) { // page header candidate
          unsigned int retry_loc = stb_vorbis_get_file_offset(f);
          int i;
-         /*  check if we're off the end of a file_section stream */
+         // check if we're off the end of a file_section stream
          if (retry_loc - 25 > f->stream_len)
             return 0;
-         /*  check the rest of the header */
+         // check the rest of the header
          for (i=1; i < 4; ++i)
             if (get8(f) != ogg_page_header[i])
                break;
          if (f->eof) return 0;
          if (i == 4) {
-            Uint8 header[27];
-            Uint32 i, crc, goal, len;
+            uint8 header[27];
+            uint32 i, crc, goal, len;
             for (i=0; i < 4; ++i)
                header[i] = ogg_page_header[i];
             for (; i < 27; ++i)
                header[i] = get8(f);
             if (f->eof) return 0;
             if (header[4] != 0) goto invalid;
-            goal = header[22] + (header[23] << 8) + (header[24]<<16) + ((Uint32)header[25]<<24);
+            goal = header[22] + (header[23] << 8) + (header[24]<<16) + ((uint32)header[25]<<24);
             for (i=22; i < 26; ++i)
                header[i] = 0;
             crc = 0;
@@ -4673,16 +4733,16 @@ static Uint32 vorbis_find_page(stb_vorbis *f, Uint32 *end, Uint32 *last)
             if (len && f->eof) return 0;
             for (i=0; i < len; ++i)
                crc = crc32_update(crc, get8(f));
-            /*  finished parsing probable page */
+            // finished parsing probable page
             if (crc == goal) {
-               /*  we could now check that it's either got the last */
-               /*  page flag set, OR it's followed by the capture */
-               /*  pattern, but I guess TECHNICALLY you could have */
-               /*  a file with garbage between each ogg page and recover */
-               /*  from it automatically? So even though that paranoia */
-               /*  might decrease the chance of an invalid decode by */
-               /*  another 2^32, not worth it since it would hose those */
-               /*  invalid-but-useful files? */
+               // we could now check that it's either got the last
+               // page flag set, OR it's followed by the capture
+               // pattern, but I guess TECHNICALLY you could have
+               // a file with garbage between each ogg page and recover
+               // from it automatically? So even though that paranoia
+               // might decrease the chance of an invalid decode by
+               // another 2^32, not worth it since it would hose those
+               // invalid-but-useful files?
                if (end)
                   *end = stb_vorbis_get_file_offset(f);
                if (last) {
@@ -4696,7 +4756,7 @@ static Uint32 vorbis_find_page(stb_vorbis *f, Uint32 *end, Uint32 *last)
             }
          }
         invalid:
-         /*  not a valid page, so rewind and look for next one */
+         // not a valid page, so rewind and look for next one
          set_file_offset(f, retry_loc);
       }
    }
@@ -4705,52 +4765,55 @@ static Uint32 vorbis_find_page(stb_vorbis *f, Uint32 *end, Uint32 *last)
 
 #define SAMPLE_unknown  0xffffffff
 
-/*  seeking is implemented with a binary search, which narrows down the range to */
-/*  64K, before using a linear search (because finding the synchronization */
-/*  pattern can be expensive, and the chance we'd find the end page again is */
-/*  relatively high for small ranges) */
-/*  */
-/*  two initial interpolation-style probes are used at the start of the search */
-/*  to try to bound either side of the binary search sensibly, while still */
-/*  working in O(log n) time if they fail. */
+// seeking is implemented with a binary search, which narrows down the range to
+// 64K, before using a linear search (because finding the synchronization
+// pattern can be expensive, and the chance we'd find the end page again is
+// relatively high for small ranges)
+//
+// two initial interpolation-style probes are used at the start of the search
+// to try to bound either side of the binary search sensibly, while still
+// working in O(log n) time if they fail.
 
 static int get_seek_page_info(stb_vorbis *f, ProbedPage *z)
 {
-   Uint8 header[27], lacing[255];
+   uint8 header[27], lacing[255];
    int i,len;
 
-   /*  record where the page starts */
+   // record where the page starts
    z->page_start = stb_vorbis_get_file_offset(f);
 
-   /*  parse the header */
-   getn(f, header, 27);
+   // parse the header
+   if (!getn(f, header, 27))
+      return 0;
    if (header[0] != 'O' || header[1] != 'g' || header[2] != 'g' || header[3] != 'S')
       return 0;
-   getn(f, lacing, header[26]);
+   if (!getn(f, lacing, header[26]))
+      return 0;
 
-   /*  determine the length of the payload */
+   // determine the length of the payload
    len = 0;
    for (i=0; i < header[26]; ++i)
       len += lacing[i];
 
-   /*  this implies where the page ends */
+   // this implies where the page ends
    z->page_end = z->page_start + 27 + header[26] + len;
 
-   /*  read the last-decoded sample out of the data */
+   // read the last-decoded sample out of the data
    z->last_decoded_sample = header[6] + (header[7] << 8) + (header[8] << 16) + (header[9] << 24);
 
-   /*  restore file state to where we were */
+   // restore file state to where we were
    set_file_offset(f, z->page_start);
    return 1;
 }
 
-/*  rarely used function to seek back to the preceding page while finding the */
-/*  start of a packet */
+// rarely used function to seek back to the preceding page while finding the
+// start of a packet
 static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
 {
-   unsigned int previous_safe, end;
+   unsigned int previous_safe;
+   uint32 end;
 
-   /*  now we want to seek back 64K from the limit */
+   // now we want to seek back 64K from the limit
    if (limit_offset >= 65536 && limit_offset-65536 >= f->first_audio_page_offset)
       previous_safe = limit_offset - 65536;
    else
@@ -4767,26 +4830,26 @@ static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
    return 0;
 }
 
-/*  implements the search logic for finding a page and starting decoding. if */
-/*  the function succeeds, current_loc_valid will be true and current_loc will */
-/*  be less than or equal to the provided sample number (the closer the */
-/*  better). */
-static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
+// implements the search logic for finding a page and starting decoding. if
+// the function succeeds, current_loc_valid will be true and current_loc will
+// be less than or equal to the provided sample number (the closer the
+// better).
+static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
 {
    ProbedPage left, right, mid;
    int i, start_seg_with_known_loc, end_pos, page_start;
-   Uint32 delta, stream_length, padding, last_sample_limit;
+   uint32 delta, stream_length, padding, last_sample_limit;
    double offset = 0.0, bytes_per_sample = 0.0;
    int probe = 0;
 
-   /*  find the last page and validate the target sample */
+   // find the last page and validate the target sample
    stream_length = stb_vorbis_stream_length_in_samples(f);
    if (stream_length == 0)            return error(f, VORBIS_seek_without_length);
    if (sample_number > stream_length) return error(f, VORBIS_seek_invalid);
 
-   /*  this is the maximum difference between the window-center (which is the */
-   /*  actual granule position value), and the right-start (which the spec */
-   /*  indicates should be the granule position (give or take one)). */
+   // this is the maximum difference between the window-center (which is the
+   // actual granule position value), and the right-start (which the spec
+   // indicates should be the granule position (give or take one)).
    padding = ((f->blocksize_1 - f->blocksize_0) >> 2);
    if (sample_number < padding)
       last_sample_limit = 0;
@@ -4795,15 +4858,15 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
 
    left = f->p_first;
    while (left.last_decoded_sample == ~0U) {
-      /* (untested) the first page does not have a 'last_decoded_sample'  */
+      // (untested) the first page does not have a 'last_decoded_sample'
       set_file_offset(f, left.page_end);
       if (!get_seek_page_info(f, &left)) goto error;
    }
 
    right = f->p_last;
-   SDL_assert(right.last_decoded_sample != ~0U);
+   assert(right.last_decoded_sample != ~0U);
 
-   /*  starting from the start is handled differently */
+   // starting from the start is handled differently
    if (last_sample_limit <= left.last_decoded_sample) {
       if (stb_vorbis_seek_start(f)) {
          if (f->current_loc > sample_number)
@@ -4814,28 +4877,28 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
    }
 
    while (left.page_end != right.page_start) {
-      SDL_assert(left.page_end < right.page_start);
-      /*  search range in bytes */
+      assert(left.page_end < right.page_start);
+      // search range in bytes
       delta = right.page_start - left.page_end;
       if (delta <= 65536) {
-         /*  there's only 64K left to search - handle it linearly */
+         // there's only 64K left to search - handle it linearly
          set_file_offset(f, left.page_end);
       } else {
          if (probe < 2) {
             if (probe == 0) {
-               /*  first probe (interpolate) */
+               // first probe (interpolate)
                double data_bytes = right.page_end - left.page_start;
                bytes_per_sample = data_bytes / right.last_decoded_sample;
                offset = left.page_start + bytes_per_sample * (last_sample_limit - left.last_decoded_sample);
             } else {
-               /*  second probe (try to bound the other side) */
+               // second probe (try to bound the other side)
                double error = ((double) last_sample_limit - mid.last_decoded_sample) * bytes_per_sample;
                if (error >= 0 && error <  8000) error =  8000;
                if (error <  0 && error > -8000) error = -8000;
                offset += error * 2;
             }
 
-            /*  ensure the offset is valid */
+            // ensure the offset is valid
             if (offset < left.page_end)
                offset = left.page_end;
             if (offset > right.page_start - 65536)
@@ -4843,8 +4906,8 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
 
             set_file_offset(f, (unsigned int) offset);
          } else {
-            /*  binary search for large ranges (offset by 32K to ensure */
-            /*  we don't hit the right page) */
+            // binary search for large ranges (offset by 32K to ensure
+            // we don't hit the right page)
             set_file_offset(f, left.page_end + (delta / 2) - 32768);
          }
 
@@ -4854,13 +4917,13 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
       for (;;) {
          if (!get_seek_page_info(f, &mid)) goto error;
          if (mid.last_decoded_sample != ~0U) break;
-         /*  (untested) no frames end on this page */
+         // (untested) no frames end on this page
          set_file_offset(f, mid.page_end);
-         SDL_assert(mid.page_start < right.page_start);
+         assert(mid.page_start < right.page_start);
       }
 
-      /* if we've just found the last page again then we're in a tricky file, */
-      /* and we're close enough (if it wasn't an interpolation probe). */
+      // if we've just found the last page again then we're in a tricky file,
+      // and we're close enough (if it wasn't an interpolation probe).
       if (mid.page_start == right.page_start) {
          if (probe >= 2 || delta <= 65536)
             break;
@@ -4874,12 +4937,12 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
       ++probe;
    }
 
-   /*  seek back to start of the last packet */
+   // seek back to start of the last packet
    page_start = left.page_start;
    set_file_offset(f, page_start);
    if (!start_page(f)) return error(f, VORBIS_seek_failed);
    end_pos = f->end_seg_with_known_loc;
-   SDL_assert(end_pos >= 0);
+   assert(end_pos >= 0);
 
    for (;;) {
       for (i = end_pos; i > 0; --i)
@@ -4891,7 +4954,7 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
       if (start_seg_with_known_loc > 0 || !(f->page_flag & PAGEFLAG_continued_packet))
          break;
 
-      /*  (untested) the final packet begins on an earlier page */
+      // (untested) the final packet begins on an earlier page
       if (!go_to_page_before(f, page_start))
          goto error;
 
@@ -4900,9 +4963,9 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
       end_pos = f->segment_count - 1;
    }
 
-   /*  prepare to start decoding */
-   f->current_loc_valid = SDL_FALSE;
-   f->last_seg = SDL_FALSE;
+   // prepare to start decoding
+   f->current_loc_valid = FALSE;
+   f->last_seg = FALSE;
    f->valid_bits = 0;
    f->packet_bytes = 0;
    f->bytes_in_seg = 0;
@@ -4912,7 +4975,7 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
    for (i = 0; i < start_seg_with_known_loc; i++)
       skip(f, f->segments[i]);
 
-   /*  start decoding (optimizable - this frame is generally discarded) */
+   // start decoding (optimizable - this frame is generally discarded)
    if (!vorbis_pump_first_frame(f))
       return 0;
    if (f->current_loc > sample_number)
@@ -4920,12 +4983,12 @@ static int seek_to_sample_coarse(stb_vorbis *f, Uint32 sample_number)
    return 1;
 
 error:
-   /*  try to restore the file to a valid state */
+   // try to restore the file to a valid state
    stb_vorbis_seek_start(f);
    return error(f, VORBIS_seek_failed);
 }
 
-/*  the same as vorbis_decode_initial, but without advancing */
+// the same as vorbis_decode_initial, but without advancing
 static int peek_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
 {
    int bits_read, bytes_read;
@@ -4933,7 +4996,7 @@ static int peek_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int 
    if (!vorbis_decode_initial(f, p_left_start, p_left_end, p_right_start, p_right_end, mode))
       return 0;
 
-   /*  either 1 or 2 bytes were read, figure out which so we can rewind */
+   // either 1 or 2 bytes were read, figure out which so we can rewind
    bits_read = 1 + ilog(f->mode_count-1);
    if (f->mode_config[*mode].blockflag)
       bits_read += 2;
@@ -4953,63 +5016,61 @@ static int peek_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int 
 
 int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
 {
-   Uint32 max_frame_samples;
+   uint32 max_frame_samples;
 
    if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
 
-   /*  fast page-level search */
+   // fast page-level search
    if (!seek_to_sample_coarse(f, sample_number))
       return 0;
 
-   SDL_assert(f->current_loc_valid);
-   SDL_assert(f->current_loc <= sample_number);
+   assert(f->current_loc_valid);
+   assert(f->current_loc <= sample_number);
 
-   /*  linear search for the relevant packet */
+   // linear search for the relevant packet
    max_frame_samples = (f->blocksize_1*3 - f->blocksize_0) >> 2;
    while (f->current_loc < sample_number) {
       int left_start, left_end, right_start, right_end, mode, frame_samples;
       if (!peek_decode_initial(f, &left_start, &left_end, &right_start, &right_end, &mode))
          return error(f, VORBIS_seek_failed);
-      /*  calculate the number of samples returned by the next frame */
+      // calculate the number of samples returned by the next frame
       frame_samples = right_start - left_start;
       if (f->current_loc + frame_samples > sample_number) {
-         return 1; /*  the next frame will contain the sample */
+         return 1; // the next frame will contain the sample
       } else if (f->current_loc + frame_samples + max_frame_samples > sample_number) {
-         /*  there's a chance the frame after this could contain the sample */
+         // there's a chance the frame after this could contain the sample
          vorbis_pump_first_frame(f);
       } else {
-         /*  this frame is too early to be relevant */
+         // this frame is too early to be relevant
          f->current_loc += frame_samples;
          f->previous_length = 0;
          maybe_start_packet(f);
          flush_packet(f);
       }
    }
-   /*  the next frame should start with the sample */
+   // the next frame should start with the sample
    if (f->current_loc != sample_number) return error(f, VORBIS_seek_failed);
    f->current_playback_loc = sample_number;
    return 1;
 }
 
-int stb_vorbis_seek(stb_vorbis *f, Sint64 sn)
+int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number)
 {
-   Uint32 sample_number = sn >= 0 ? (Uint32)sn : 0;
-
-   if (!stb_vorbis_seek_frame(f, (Uint32)sample_number)) {
-      f->current_playback_loc_valid = SDL_FALSE;
+   if (!stb_vorbis_seek_frame(f, sample_number)) {
+      f->current_playback_loc_valid = FALSE;
       return 0;
    }
 
    if (sample_number != f->current_loc) {
       int n;
-      Uint32 frame_start = f->current_loc;
+      uint32 frame_start = f->current_loc;
       stb_vorbis_get_frame_float(f, &n, NULL);
-      SDL_assert(sample_number > frame_start);
-      SDL_assert(f->channel_buffer_start + (int) (sample_number-frame_start) <= f->channel_buffer_end);
+      assert(sample_number > frame_start);
+      assert(f->channel_buffer_start + (int) (sample_number-frame_start) <= f->channel_buffer_end);
       f->channel_buffer_start += (sample_number - frame_start);
    }
 
-   f->current_playback_loc_valid = SDL_TRUE;
+   f->current_playback_loc_valid = TRUE;
    f->current_playback_loc = sample_number;
 
    return 1;
@@ -5020,65 +5081,65 @@ int stb_vorbis_seek_start(stb_vorbis *f)
    if (IS_PUSH_MODE(f)) { return error(f, VORBIS_invalid_api_mixing); }
    set_file_offset(f, f->first_audio_page_offset);
    f->previous_length = 0;
-   f->first_decode = SDL_TRUE;
+   f->first_decode = TRUE;
    f->next_seg = -1;
    return vorbis_pump_first_frame(f);
 }
 
-Sint64 stb_vorbis_stream_length_in_samples(stb_vorbis *f)
+unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
 {
    unsigned int restore_offset, previous_safe;
-   unsigned int end, last_page_loc;
+   unsigned int last_page_loc;
 
    if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
    if (!f->total_samples) {
-      unsigned int last;
-      Uint32 lo,hi;
+      uint32 end,last;
+      uint32 lo,hi;
       char header[6];
 
-      /*  first, store the current decode position so we can restore it */
+      // first, store the current decode position so we can restore it
       restore_offset = stb_vorbis_get_file_offset(f);
 
-      /*  now we want to seek back 64K from the end (the last page must */
-      /*  be at most a little less than 64K, but let's allow a little slop) */
+      // now we want to seek back 64K from the end (the last page must
+      // be at most a little less than 64K, but let's allow a little slop)
       if (f->stream_len >= 65536 && f->stream_len-65536 >= f->first_audio_page_offset)
          previous_safe = f->stream_len - 65536;
       else
          previous_safe = f->first_audio_page_offset;
 
       set_file_offset(f, previous_safe);
-      /*  previous_safe is now our candidate 'earliest known place that seeking */
-      /*  to will lead to the final page' */
+      // previous_safe is now our candidate 'earliest known place that seeking
+      // to will lead to the final page'
 
       if (!vorbis_find_page(f, &end, &last)) {
-         /* if we can't find a page, we're hosed! */
+         // if we can't find a page, we're hosed!
          f->error = VORBIS_cant_find_last_page;
          f->total_samples = 0xffffffff;
          goto done;
       }
 
-      /*  check if there are more pages */
+      // check if there are more pages
       last_page_loc = stb_vorbis_get_file_offset(f);
 
-      /*  stop when the last_page flag is set, not when we reach eof; */
-      /* this allows us to stop short of a 'file_section' end without */
-      /*  explicitly checking the length of the section */
+      // stop when the last_page flag is set, not when we reach eof;
+      // this allows us to stop short of a 'file_section' end without
+      // explicitly checking the length of the section
       while (!last) {
          set_file_offset(f, end);
          if (!vorbis_find_page(f, &end, &last)) {
-            /* the last page we found didn't have the 'last page' flag */
-            /*  set. whoops! */
+            // the last page we found didn't have the 'last page' flag
+            // set. whoops!
             break;
          }
-         /* previous_safe = last_page_loc+1; *//* NOTE: not used after this point, but note for debugging */
+         //previous_safe = last_page_loc+1; // NOTE: not used after this point, but note for debugging
          last_page_loc = stb_vorbis_get_file_offset(f);
       }
 
       set_file_offset(f, last_page_loc);
 
-      /*  parse the header */
+      // parse the header
       getn(f, (unsigned char *)header, 6);
-      /*  extract the absolute granule position */
+      // extract the absolute granule position
       lo = get32(f);
       hi = get32(f);
       if (lo == 0xffffffff && hi == 0xffffffff) {
@@ -5087,7 +5148,7 @@ Sint64 stb_vorbis_stream_length_in_samples(stb_vorbis *f)
          goto done;
       }
       if (hi)
-         lo = 0xfffffffe; /*  saturate */
+         lo = 0xfffffffe; // saturate
       f->total_samples = lo;
 
       f->p_last.page_start = last_page_loc;
@@ -5136,7 +5197,7 @@ stb_vorbis * stb_vorbis_open_file_section(FILE *file, int close_on_free, int *er
    stb_vorbis *f, p;
    vorbis_init(&p, alloc);
    p.f = file;
-   p.f_start = (Uint32) ftell(file);
+   p.f_start = (uint32) ftell(file);
    p.stream_len   = length;
    p.close_on_free = close_on_free;
    if (start_decoder(&p)) {
@@ -5172,44 +5233,41 @@ stb_vorbis * stb_vorbis_open_filename(const char *filename, int *error, const st
    f = fopen(filename, "rb");
 #endif
    if (f)
-      return stb_vorbis_open_file(f, SDL_TRUE, error, alloc);
+      return stb_vorbis_open_file(f, TRUE, error, alloc);
    if (error) *error = VORBIS_file_open_failure;
    return NULL;
 }
-#endif /*  STB_VORBIS_NO_STDIO */
+#endif // STB_VORBIS_NO_STDIO
 
-stb_vorbis * stb_vorbis_open_rwops(SDL_RWops *f, int close_on_free,
-                                    int *error, const stb_vorbis_alloc *alloc)
+#ifdef STB_VORBIS_SDL
+stb_vorbis * stb_vorbis_open_rwops_section(SDL_RWops *rwops, int close_on_free, int *error, const stb_vorbis_alloc *alloc, unsigned int length)
 {
-    unsigned int len, start;
-    start = (unsigned int) SDL_RWtell(f);
-    SDL_RWseek(f, 0, RW_SEEK_END);
-    len = (unsigned int) (SDL_RWtell(f) - start);
-    SDL_RWseek(f, start, RW_SEEK_SET);
-    return stb_vorbis_open_rwops_section(f, close_on_free, error, alloc, len);
+   stb_vorbis *f, p;
+   vorbis_init(&p, alloc);
+   p.rwops = rwops;
+   p.rwops_start = (uint32) SDL_RWtell(rwops);
+   p.stream_len   = length;
+   p.close_on_free = close_on_free;
+   if (start_decoder(&p)) {
+      f = vorbis_alloc(&p);
+      if (f) {
+         memcpy(f, &p, sizeof (stb_vorbis));
+         vorbis_pump_first_frame(f);
+         return f;
+      }
+   }
+   if (error) *error = p.error;
+   vorbis_deinit(&p);
+   return NULL;
 }
 
-stb_vorbis * stb_vorbis_open_rwops_section(SDL_RWops *file, int close_on_free,
-                                    int *error, const stb_vorbis_alloc *alloc, unsigned int length)
+stb_vorbis * stb_vorbis_open_rwops(SDL_RWops *rwops, int close_on_free, int *error, const stb_vorbis_alloc *alloc)
 {
-    stb_vorbis *f, p;
-    vorbis_init(&p, alloc);
-    p.rw = file;
-    p.f_start = (Uint32) SDL_RWtell(file);
-    p.stream_len   = length;
-    p.close_on_free = close_on_free;
-    if (start_decoder(&p)) {
-       f = vorbis_alloc(&p);
-       if (f) {
-          *f = p;
-          vorbis_pump_first_frame(f);
-          return f;
-       }
-    }
-    if (error) *error = p.error;
-    vorbis_deinit(&p);
-    return NULL;
+   const unsigned int start = (unsigned int) SDL_RWtell(rwops);
+   const unsigned int len = (unsigned int) (SDL_RWsize(rwops) - start);
+   return stb_vorbis_open_rwops_section(rwops, close_on_free, error, alloc, len);
 }
+#endif
 
 stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *error, const stb_vorbis_alloc *alloc)
 {
@@ -5219,15 +5277,15 @@ stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *err
       return NULL;
    }
    vorbis_init(&p, alloc);
-   p.stream = (Uint8 *) data;
-   p.stream_end = (Uint8 *) data + len;
-   p.stream_start = (Uint8 *) p.stream;
+   p.stream = (uint8 *) data;
+   p.stream_end = (uint8 *) data + len;
+   p.stream_start = (uint8 *) p.stream;
    p.stream_len = len;
-   p.push_mode = SDL_FALSE;
+   p.push_mode = FALSE;
    if (start_decoder(&p)) {
       f = vorbis_alloc(&p);
       if (f) {
-         *f = p;
+         memcpy(f, &p, sizeof (stb_vorbis));
          vorbis_pump_first_frame(f);
          if (error) *error = VORBIS__no_error;
          return f;
@@ -5247,7 +5305,7 @@ stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *err
 #define C  (PLAYBACK_LEFT  | PLAYBACK_RIGHT | PLAYBACK_MONO)
 #define R  (PLAYBACK_RIGHT | PLAYBACK_MONO)
 
-static Sint8 channel_position[7][6] =
+static int8 channel_position[7][6] =
 {
    { 0 },
    { C },
@@ -5262,14 +5320,16 @@ static Sint8 channel_position[7][6] =
 #ifndef STB_VORBIS_NO_FAST_SCALED_FLOAT
    typedef union {
       float f;
-      int i;
+      // changed this to unsigned to suppress an UBSan error.
+      // upstream: https://github.com/nothings/stb/issues/1168.
+      unsigned int i;
    } float_conv;
    typedef char stb_vorbis_float_size_test[sizeof(float)==4 && sizeof(int) == 4];
    #define FASTDEF(x) float_conv x
-   /*  add (1<<23) to convert to int, then divide by 2^SHIFT, then add 0.5/2^SHIFT to round */
+   // add (1<<23) to convert to int, then divide by 2^SHIFT, then add 0.5/2^SHIFT to round
    #define MAGIC(SHIFT) (1.5f * (1 << (23-SHIFT)) + 0.5f/(1 << SHIFT))
    #define ADDEND(SHIFT) (((150-SHIFT) << 23) + (1 << 22))
-   #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) (temp.f = (x) + MAGIC(s), temp.i - ADDEND(s))
+   #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) (int)(temp.f = (x) + MAGIC(s), temp.i - ADDEND(s))
    #define check_endianness()
 #else
    #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) ((int) ((x) * (1 << (s))))
@@ -5284,7 +5344,7 @@ static void copy_samples(short *dest, float *src, int len)
    for (i=0; i < len; ++i) {
       FASTDEF(temp);
       int v = FAST_SCALED_FLOAT_TO_INT(temp, src[i],15);
-      if ((unsigned int) (v + 32768) > 65535)
+      if ((unsigned int)v + 32768 > 65535)
          v = v < 0 ? -32768 : 32767;
       dest[i] = v;
    }
@@ -5297,7 +5357,7 @@ static void compute_samples(int mask, short *output, int num_c, float **data, in
    int i,j,o,n = STB_BUFFER_SIZE;
    check_endianness();
    for (o = 0; o < len; o += STB_BUFFER_SIZE) {
-      SDL_memset(buffer, 0, sizeof(buffer));
+      memset(buffer, 0, sizeof(buffer));
       if (o + n > len) n = len - o;
       for (j=0; j < num_c; ++j) {
          if (channel_position[num_c][j] & mask) {
@@ -5308,7 +5368,7 @@ static void compute_samples(int mask, short *output, int num_c, float **data, in
       for (i=0; i < n; ++i) {
          FASTDEF(temp);
          int v = FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
-         if ((unsigned int) (v + 32768) > 65535)
+         if ((unsigned int)v + 32768 > 65535)
             v = v < 0 ? -32768 : 32767;
          output[o+i] = v;
       }
@@ -5321,12 +5381,12 @@ static void compute_stereo_samples(short *output, int num_c, float **data, int d
    #define STB_BUFFER_SIZE  32
    float buffer[STB_BUFFER_SIZE];
    int i,j,o,n = STB_BUFFER_SIZE >> 1;
-   /*  o is the offset in the source data */
+   // o is the offset in the source data
    check_endianness();
    for (o = 0; o < len; o += STB_BUFFER_SIZE >> 1) {
-      /*  o2 is the offset in the output data */
+      // o2 is the offset in the output data
       int o2 = o << 1;
-      SDL_memset(buffer, 0, sizeof(buffer));
+      memset(buffer, 0, sizeof(buffer));
       if (o + n > len) n = len - o;
       for (j=0; j < num_c; ++j) {
          int m = channel_position[num_c][j] & (PLAYBACK_LEFT | PLAYBACK_RIGHT);
@@ -5348,7 +5408,7 @@ static void compute_stereo_samples(short *output, int num_c, float **data, int d
       for (i=0; i < (n<<1); ++i) {
          FASTDEF(temp);
          int v = FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
-         if ((unsigned int) (v + 32768) > 65535)
+         if ((unsigned int)v + 32768 > 65535)
             v = v < 0 ? -32768 : 32767;
          output[o2+i] = v;
       }
@@ -5368,7 +5428,7 @@ static void convert_samples_short(int buf_c, short **buffer, int b_offset, int d
       for (i=0; i < limit; ++i)
          copy_samples(buffer[i]+b_offset, data[i]+d_offset, samples);
       for (   ; i < buf_c; ++i)
-         SDL_memset(buffer[i]+b_offset, 0, sizeof(short) * samples);
+         memset(buffer[i]+b_offset, 0, sizeof(short) * samples);
    }
 }
 
@@ -5387,7 +5447,7 @@ static void convert_channels_short_interleaved(int buf_c, short *buffer, int dat
    int i;
    check_endianness();
    if (buf_c != data_c && buf_c <= 2 && data_c <= 6) {
-      SDL_assert(buf_c == 2);
+      assert(buf_c == 2);
       for (i=0; i < buf_c; ++i)
          compute_stereo_samples(buffer, data_c, data, d_offset, len);
    } else {
@@ -5397,8 +5457,8 @@ static void convert_channels_short_interleaved(int buf_c, short *buffer, int dat
          for (i=0; i < limit; ++i) {
             FASTDEF(temp);
             float f = data[i][d_offset+j];
-            int v = FAST_SCALED_FLOAT_TO_INT(temp, f,15);/* data[i][d_offset+j],15); */
-            if ((unsigned int) (v + 32768) > 65535)
+            int v = FAST_SCALED_FLOAT_TO_INT(temp, f,15);//data[i][d_offset+j],15);
+            if ((unsigned int)v + 32768 > 65535)
                v = v < 0 ? -32768 : 32767;
             *buffer++ = v;
          }
@@ -5472,7 +5532,7 @@ int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_
       *sample_rate = v->sample_rate;
    offset = data_len = 0;
    total = limit;
-   data = (short *) SDL_malloc(total * sizeof(*data));
+   data = (short *) malloc(total * sizeof(*data));
    if (data == NULL) {
       stb_vorbis_close(v);
       return -2;
@@ -5498,9 +5558,9 @@ int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_
    stb_vorbis_close(v);
    return data_len;
 }
-#endif /*  NO_STDIO */
+#endif // NO_STDIO
 
-int stb_vorbis_decode_memory(const Uint8 *mem, int len, int *channels, int *sample_rate, short **output)
+int stb_vorbis_decode_memory(const uint8 *mem, int len, int *channels, int *sample_rate, short **output)
 {
    int data_len, offset, total, limit, error;
    short *data;
@@ -5512,7 +5572,7 @@ int stb_vorbis_decode_memory(const Uint8 *mem, int len, int *channels, int *samp
       *sample_rate = v->sample_rate;
    offset = data_len = 0;
    total = limit;
-   data = (short *) SDL_malloc(total * sizeof(*data));
+   data = (short *) malloc(total * sizeof(*data));
    if (data == NULL) {
       stb_vorbis_close(v);
       return -2;
@@ -5525,9 +5585,9 @@ int stb_vorbis_decode_memory(const Uint8 *mem, int len, int *channels, int *samp
       if (offset + limit > total) {
          short *data2;
          total *= 2;
-         data2 = (short *) SDL_realloc(data, total * sizeof(*data));
+         data2 = (short *) realloc(data, total * sizeof(*data));
          if (data2 == NULL) {
-            SDL_free(data);
+            free(data);
             stb_vorbis_close(v);
             return -2;
          }
@@ -5538,7 +5598,7 @@ int stb_vorbis_decode_memory(const Uint8 *mem, int len, int *channels, int *samp
    stb_vorbis_close(v);
    return data_len;
 }
-#endif /*  STB_VORBIS_NO_INTEGER_CONVERSION */
+#endif // STB_VORBIS_NO_INTEGER_CONVERSION
 
 int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats)
 {
@@ -5580,9 +5640,9 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
       if (n+k >= num_samples) k = num_samples - n;
       if (k) {
          for (i=0; i < z; ++i)
-            SDL_memcpy(buffer[i]+n, f->channel_buffers[i]+f->channel_buffer_start, sizeof(float)*k);
+            memcpy(buffer[i]+n, f->channel_buffers[i]+f->channel_buffer_start, sizeof(float)*k);
          for (   ; i < channels; ++i)
-            SDL_memset(buffer[i]+n, 0, sizeof(float) * k);
+            memset(buffer[i]+n, 0, sizeof(float) * k);
       }
       n += k;
       f->channel_buffer_start += k;
@@ -5594,7 +5654,7 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
    f->current_playback_loc += n;
    return n;
 }
-#endif /*  STB_VORBIS_NO_PULLDATA_API */
+#endif // STB_VORBIS_NO_PULLDATA_API
 
 /* Version history
     1.17    - 2019-07-08 - fix CVE-2019-13217, -13218, -13219, -13220, -13221, -13222, -13223
@@ -5657,7 +5717,7 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
     0.90 - first public release
 */
 
-#endif /*  STB_VORBIS_HEADER_ONLY */
+#endif // STB_VORBIS_HEADER_ONLY
 
 
 /*


### PR DESCRIPTION
- Keeps the original stb_vorbis as intact as possible so
  that future updates from mainstream would be painless.
- Reduces STB_VORBIS_MAX_CHANNELS from 16 to 6 (objections?)
- Adds several missing libm function overrides,
- SDL_mixer now requires SDL >= 2.0.9 because of SDL_exp()
- Fixes slow loads and leaks in start_decoder:
  https://github.com/nothings/stb/pull/1174
- Fixes submap array out-of-bounds indexing bug:
  https://github.com/nothings/stb/pull/1312
- Replace signed overflow clamps with unsigned overflow:
  https://github.com/nothings/stb/issues/1168
- Replaces alloca() usage with setup_malloc() (from libxmp.)
- Fixes '-Wmaybe-uninitialized' warnings in get_seek_page_info:
  https://github.com/nothings/stb/pull/1172
- A minor UBSan fix and suppression:
  https://github.com/nothings/stb/issues/1168
- Fixes signature of dummy realloc() for STB_VORBIS_NO_CRT:
  https://github.com/nothings/stb/pull/1198
- Renames BUFFER_SIZE macro to STB_BUFFER_SIZE:
  https://github.com/nothings/stb/pull/1078
- Pulls in sample-accurate offset patch of Vitaly Novichkov:
  (stb_vorbis_get_playback_sample_offset, because it's used
  in OGG_Tell and OGG_GetSome):
  https://github.com/nothings/stb/issues/1294
  https://github.com/nothings/stb/pull/1295
- Fixes a few warnings here and there in some environments.
- Replaces two dummy '(void) 0' with 'do {} while(0)'