### PR TITLE
Don't wait for the music to fade out in Mix_FreeMusic if it is inactive

### DIFF
--- a/src/music.c
+++ b/src/music.c
@@ -739,7 +739,7 @@ void Mix_FreeMusic(Mix_Music *music)
         Mix_LockAudio();
         if (music == music_playing) {
             /* Wait for any fade out to finish */
-            while (music->fading == MIX_FADING_OUT) {
+            while (music_active && music->fading == MIX_FADING_OUT) {
                 Mix_UnlockAudio();
                 SDL_Delay(100);
                 Mix_LockAudio();


### PR DESCRIPTION
Avoid a infinite loop / hang if the user's program has the music paused when trying to free it. If the music isn't active, it will never finish fading out.