### PR TITLE
Fix static linking to Autotools builds using CMake

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,6 +25,7 @@ CFLAGS  = @BUILD_CFLAGS@
 EXTRA_CFLAGS = @EXTRA_CFLAGS@
 LDFLAGS = @BUILD_LDFLAGS@
 EXTRA_LDFLAGS = @EXTRA_LDFLAGS@
+MIXER_LIBS = @MIXER_LIBS@
 LIBTOOL = @LIBTOOL@
 INSTALL = @INSTALL@
 AR	= @AR@
@@ -94,7 +95,7 @@ $(objects)/.created:
 .PHONY: all install install-hdrs install-lib install-bin uninstall uninstall-hdrs uninstall-lib uninstall-bin clean distclean dist
 
 $(objects)/$(TARGET): $(OBJECTS) $(VERSION_OBJECTS)
-	$(LIBTOOL) --mode=link $(CC) -o $@ $(OBJECTS) $(VERSION_OBJECTS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
+	$(LIBTOOL) --mode=link $(CC) -o $@ $(OBJECTS) $(VERSION_OBJECTS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) $(SDL_LIBS) $(MIXER_LIBS)
 
 $(objects)/playwave$(EXE): $(objects)/playwave.lo $(objects)/$(TARGET)
 	$(LIBTOOL) --mode=link $(CC) -o $@ $(objects)/playwave.lo $(SDL_CFLAGS) $(objects)/$(TARGET) $(SDL_LIBS) $(LDFLAGS)

--- a/configure
+++ b/configure
@@ -820,6 +820,7 @@ PC_LIBS
 PC_REQUIRES
 SDL_VERSION
 EXE
+MIXER_LIBS
 EXTRA_LDFLAGS
 BUILD_LDFLAGS
 EXTRA_CFLAGS
@@ -4929,13 +4930,13 @@ then :
 else $as_nop
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4932: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4933: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4935: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4936: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4938: output\"" >&5)
+  (eval echo "\"\$as_me:4939: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -6194,7 +6195,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6197 "configure"' > conftest.$ac_ext
+  echo '#line 6198 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7867,11 +7868,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7870: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7871: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7874: \$? = $ac_status" >&5
+   echo "$as_me:7875: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8217,11 +8218,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8220: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8221: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8224: \$? = $ac_status" >&5
+   echo "$as_me:8225: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8324,11 +8325,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8327: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8328: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8331: \$? = $ac_status" >&5
+   echo "$as_me:8332: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -8380,11 +8381,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8383: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8384: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8387: \$? = $ac_status" >&5
+   echo "$as_me:8388: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -10823,7 +10824,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10826 "configure"
+#line 10827 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10920,7 +10921,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10923 "configure"
+#line 10924 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -14582,11 +14583,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14585: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14586: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:14589: \$? = $ac_status" >&5
+   echo "$as_me:14590: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -14683,11 +14684,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14686: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14687: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:14690: \$? = $ac_status" >&5
+   echo "$as_me:14691: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -14736,11 +14737,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14739: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14740: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:14743: \$? = $ac_status" >&5
+   echo "$as_me:14744: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -16191,6 +16192,7 @@ BUILD_CFLAGS="$CFLAGS $CPPFLAGS -I$srcdir/include -I$srcdir/src -I$srcdir/src/co
 EXTRA_CFLAGS="$INCLUDE $BASE_CFLAGS"
 BUILD_LDFLAGS="$LDFLAGS"
 EXTRA_LDFLAGS="$BASE_LDFLAGS"
+MIXER_LIBS=
 ## These are common directories to find software packages
 #for path in /usr/freeware /usr/pkg /usr/local; do
 #    if test -d $path/include; then
@@ -16753,7 +16755,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
   rm -f conf.sdltest
 
 EXTRA_CFLAGS="$EXTRA_CFLAGS $SDL_CFLAGS"
-EXTRA_LDFLAGS="$EXTRA_LDFLAGS $SDL_LIBS"
 
 CheckWarnAll
 
@@ -17090,7 +17091,7 @@ fi
             echo "-- dynamic libmodplug -> $modplug_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMODPLUG_DYNAMIC=\\\"$modplug_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $MODPLUG_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $MODPLUG_LIBS"
             if test x$have_libmodplug_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmodplug"
             else
@@ -17323,7 +17324,7 @@ fi
             echo "-- dynamic libxmp -> $xmp_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DXMP_DYNAMIC=\\\"$xmp_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $XMP_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $XMP_LIBS"
             if test x$have_libxmp_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES lib$xmplib"
             else
@@ -17395,17 +17396,17 @@ fi
         case "$host" in
             *-*-cygwin* | *-*-mingw*)
                 use_music_midi_native=yes
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lwinmm"
+                MIXER_LIBS="$MIXER_LIBS -lwinmm"
                 PC_LIBS="$PC_LIBS -lwinmm"
                 ;;
             *-*-darwin*)
                 use_music_midi_native=yes
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
+                MIXER_LIBS="$MIXER_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
                 PC_LIBS="$PC_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
                 ;;
             *-*-haiku*)
                 use_music_midi_native=yes_cpp
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lmidi"
+                MIXER_LIBS="$MIXER_LIBS -lmidi"
                 PC_LIBS="$PC_LIBS -lmidi"
                 ;;
         esac
@@ -17627,7 +17628,7 @@ fi
                 echo "-- dynamic libfluidsynth -> $fluidsynth_lib"
                 EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLUIDSYNTH_DYNAMIC=\\\"$fluidsynth_lib\\\""
             else
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS $FLUIDSYNTH_LIBS"
+                MIXER_LIBS="$MIXER_LIBS $FLUIDSYNTH_LIBS"
                 if test x$have_fluidsynth_pc = xyes; then
                     PC_REQUIRES="$PC_REQUIRES fluidsynth"
                 else
@@ -17883,7 +17884,7 @@ fi
             echo "-- dynamic libvorbisfile -> $ogg_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $VORBIS_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $VORBIS_LIBS"
             if test x$have_ogg_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisfile"
             else
@@ -18108,7 +18109,7 @@ fi
             echo "-- dynamic libvorbisidec -> $ogg_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $TREMOR_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $TREMOR_LIBS"
             if test x$have_tremor_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisidec"
             else
@@ -18394,7 +18395,7 @@ printf "%s\n" "$have_flac_ver" >&6; }
             echo "-- dynamic libFLAC -> $flac_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLAC_DYNAMIC=\\\"$flac_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $FLAC_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $FLAC_LIBS"
             if test x$have_flac_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES flac"
             else
@@ -18640,7 +18641,7 @@ fi
             echo "-- dynamic libmpg123 -> $mpg123_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMPG123_DYNAMIC=\\\"$mpg123_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $MPG123_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $MPG123_LIBS"
             if test x$have_mpg123_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmpg123"
             else
@@ -18867,7 +18868,7 @@ fi
             echo "-- dynamic opusfile -> $opusfile_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOPUS_DYNAMIC=\\\"$opusfile_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $OPUSFILE_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $OPUSFILE_LIBS"
             if test x$have_opusfile_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES opusfile"
             else
@@ -18885,7 +18886,7 @@ fi
 
 CheckNoUndef
 
-EXTRA_LDFLAGS="$EXTRA_LDFLAGS $LIBM"
+MIXER_LIBS="$MIXER_LIBS $LIBM"
 
 OBJECTS=`echo $SOURCES`
 DEPENDS=`echo $SOURCES`
@@ -18933,6 +18934,7 @@ PLAYMUS_DEPENDS=`echo "$PLAYMUS_DEPENDS" | sed 's,\\$,\\\\$,g'`
 eval pkg_prefix=$prefix
 eval pkg_cmakedir=$libdir/cmake/SDL2_mixer
 cmake_prefix_relpath="$(echo -n "$pkg_cmakedir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g")"
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ BUILD_CFLAGS="$CFLAGS $CPPFLAGS -I$srcdir/include -I$srcdir/src -I$srcdir/src/co
 EXTRA_CFLAGS="$INCLUDE $BASE_CFLAGS"
 BUILD_LDFLAGS="$LDFLAGS"
 EXTRA_LDFLAGS="$BASE_LDFLAGS"
+MIXER_LIBS=
 ## These are common directories to find software packages
 #for path in /usr/freeware /usr/pkg /usr/local; do
 #    if test -d $path/include; then
@@ -279,7 +280,6 @@ AM_PATH_SDL2($SDL_VERSION,
             AC_MSG_ERROR([*** SDL version $SDL_VERSION not found!])
 )
 EXTRA_CFLAGS="$EXTRA_CFLAGS $SDL_CFLAGS"
-EXTRA_LDFLAGS="$EXTRA_LDFLAGS $SDL_LIBS"
 
 dnl check for GCC warning options
 CheckWarnAll
@@ -367,7 +367,7 @@ if test x$enable_music_mod = xyes -a x$enable_music_mod_modplug = xyes; then
             echo "-- dynamic libmodplug -> $modplug_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMODPLUG_DYNAMIC=\\\"$modplug_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $MODPLUG_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $MODPLUG_LIBS"
             if test x$have_libmodplug_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmodplug"
             else
@@ -426,7 +426,7 @@ if test x$enable_music_mod = xyes -a x$enable_music_mod_xmp = xyes; then
             echo "-- dynamic libxmp -> $xmp_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DXMP_DYNAMIC=\\\"$xmp_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $XMP_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $XMP_LIBS"
             if test x$have_libxmp_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES lib$xmplib"
             else
@@ -476,17 +476,17 @@ if test x$enable_music_midi = xyes; then
         case "$host" in
             *-*-cygwin* | *-*-mingw*)
                 use_music_midi_native=yes
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lwinmm"
+                MIXER_LIBS="$MIXER_LIBS -lwinmm"
                 PC_LIBS="$PC_LIBS -lwinmm"
                 ;;
             *-*-darwin*)
                 use_music_midi_native=yes
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
+                MIXER_LIBS="$MIXER_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
                 PC_LIBS="$PC_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
                 ;;
             *-*-haiku*)
                 use_music_midi_native=yes_cpp
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lmidi"
+                MIXER_LIBS="$MIXER_LIBS -lmidi"
                 PC_LIBS="$PC_LIBS -lmidi"
                 ;;
         esac
@@ -540,7 +540,7 @@ if test x$enable_music_midi = xyes; then
                 echo "-- dynamic libfluidsynth -> $fluidsynth_lib"
                 EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLUIDSYNTH_DYNAMIC=\\\"$fluidsynth_lib\\\""
             else
-                EXTRA_LDFLAGS="$EXTRA_LDFLAGS $FLUIDSYNTH_LIBS"
+                MIXER_LIBS="$MIXER_LIBS $FLUIDSYNTH_LIBS"
                 if test x$have_fluidsynth_pc = xyes; then
                     PC_REQUIRES="$PC_REQUIRES fluidsynth"
                 else
@@ -615,7 +615,7 @@ if test x$enable_music_ogg = xyes -a x$enable_music_ogg_vorbis = xyes; then
             echo "-- dynamic libvorbisfile -> $ogg_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $VORBIS_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $VORBIS_LIBS"
             if test x$have_ogg_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisfile"
             else
@@ -671,7 +671,7 @@ if test x$enable_music_ogg = xyes -a x$enable_music_ogg_tremor = xyes; then
             echo "-- dynamic libvorbisidec -> $ogg_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $TREMOR_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $TREMOR_LIBS"
             if test x$have_tremor_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisidec"
             else
@@ -758,7 +758,7 @@ if test x$enable_music_flac = xyes -a x$enable_music_flac_libflac = xyes; then
             echo "-- dynamic libFLAC -> $flac_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLAC_DYNAMIC=\\\"$flac_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $FLAC_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $FLAC_LIBS"
             if test x$have_flac_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES flac"
             else
@@ -824,7 +824,7 @@ if test x$enable_music_mp3 = xyes -a x$enable_music_mp3_mpg123 = xyes; then
             echo "-- dynamic libmpg123 -> $mpg123_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMPG123_DYNAMIC=\\\"$mpg123_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $MPG123_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $MPG123_LIBS"
             if test x$have_mpg123_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmpg123"
             else
@@ -881,7 +881,7 @@ if test x$enable_music_opus = xyes; then
             echo "-- dynamic opusfile -> $opusfile_lib"
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOPUS_DYNAMIC=\\\"$opusfile_lib\\\""
         else
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $OPUSFILE_LIBS"
+            MIXER_LIBS="$MIXER_LIBS $OPUSFILE_LIBS"
             if test x$have_opusfile_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES opusfile"
             else
@@ -898,7 +898,7 @@ fi
 dnl check for LD --no-undefined option
 CheckNoUndef
 
-EXTRA_LDFLAGS="$EXTRA_LDFLAGS $LIBM"
+MIXER_LIBS="$MIXER_LIBS $LIBM"
 
 OBJECTS=`echo $SOURCES`
 DEPENDS=`echo $SOURCES`
@@ -959,6 +959,7 @@ AC_SUBST(BUILD_CFLAGS)
 AC_SUBST(EXTRA_CFLAGS)
 AC_SUBST(BUILD_LDFLAGS)
 AC_SUBST(EXTRA_LDFLAGS)
+AC_SUBST(MIXER_LIBS)
 AC_SUBST(EXE)
 AC_SUBST(SDL_VERSION)
 AC_SUBST(SDL_CFLAGS)

--- a/sdl2_mixer-config.cmake.in
+++ b/sdl2_mixer-config.cmake.in
@@ -71,7 +71,7 @@ set(exec_prefix "@exec_prefix@")
 set(bindir "@bindir@")
 set(includedir "@includedir@")
 set(libdir "@libdir@")
-set(_sdl2mixer_extra_static_libraries "@PC_LIBS@")
+set(_sdl2mixer_extra_static_libraries "@MIXER_LIBS@ @PC_LIBS@")
 string(STRIP "${_sdl2mixer_extra_static_libraries}" _sdl2mixer_extra_static_libraries)
 
 set(_sdl2mixer_bindir   "${bindir}")


### PR DESCRIPTION
* autotools: Move mandatory dependencies from EXTRA_LDFLAGS to MIXER_LIBS
    
    Autotools variables whose names end with _LDFLAGS are usually for
    linker options such as -Wl,--export-dynamic which would not be
    appropriate to copy into the pkg-config or CMake metadata.
    
    Move these dependencies into a separate _LIBS variable, which is
    conventionally a list of -L and -l options (only) and *can* be copied
    into pkg-config or CMake metadata. This follows the same pattern as
    IMG_LIBS and TTF_LIBS in SDL_image and SDL_ttf.

    Exclude SDL_LIBS from this, because the CMake metadata has a special
    case for finding SDL, and linking to a different SDL causes link failure
    on our macOS CI. Link SDL via $(SDL_LIBS) instead.

* sdl2_mixer-config.cmake.in: Use MIXER_LIBS for static linking
    
    We can't rely on all mandatory dependencies being in PC_LIBS, because
    if we found a dependency such as libflac via pkg-config, we would have
    put the name of the pkg-config module in PC_REQUIRES instead.
    
    Resolves: https://github.com/libsdl-org/SDL_mixer/issues/411