### PR TITLE
configure.ac: Make sure to set VERSION

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,10 @@ AC_SUBST(MINOR_VERSION)
 AC_SUBST(MICRO_VERSION)
 AC_SUBST(INTERFACE_AGE)
 AC_SUBST(BINARY_AGE)
-AC_SUBST(VERSION)
+# Automake defines VERSION to be the same as PACKAGE_VERSION, but we're
+# not using Automake in SDL_mixer, so we need to set up the @VERSION@
+# substitution for SDL2_mixer.pc ourselves
+AC_SUBST([VERSION], [$PACKAGE_VERSION])
 
 dnl libtool versioning
 LT_INIT([win32-dll])


### PR DESCRIPTION
Plain Autoconf only defines PACKAGE_NAME, PACKAGE_VERSION and similar
substitution variables, to which Automake adds PACKAGE and VERSION.
SDL_mixer doesn't use Automake, so it doesn't have the VERSION required
by our SDL2_mixer.pc.in (and SDL2_mixer.spec.in) unless we set it
explicitly.

Resolves: https://github.com/libsdl-org/SDL_mixer/issues/421  
Fixes: 52d3f2c "Rewrite CMake build script"