### PR TITLE
Added Mix_PauseAudio() call to suspend/resume entire audio output

### DIFF
--- a/include/SDL_mixer.h
+++ b/include/SDL_mixer.h
@@ -458,6 +458,15 @@ extern DECLSPEC int SDLCALL Mix_OpenAudio(int frequency, Uint16 format, int chan
 extern DECLSPEC int SDLCALL Mix_OpenAudioDevice(int frequency, Uint16 format, int channels, int chunksize, const char* device, int allowed_changes);
 
 /**
+ * Suspend or resume the whole audio output.
+ *
+ * \since This function is available since SDL_mixer 2.8.0.
+ *
+ * @param pause_on Set audio output to pause, 1 (to pause) or 0 (to resume)
+ */
+extern DECLSPEC void SDLCALL Mix_PauseAudio(int pause_on);
+
+/**
  * Find out what the actual audio device parameters are.
  *
  * If Mix_OpenAudioDevice() was called with `allowed_changes` set to anything

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -533,6 +533,15 @@ int Mix_OpenAudio(int frequency, Uint16 format, int nchannels, int chunksize)
                                 SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
 }
 
+/* Pause or resume the audio streaming */
+void Mix_PauseAudio(int pause_on)
+{
+    SDL_PauseAudioDevice(audio_device, pause_on);
+    Mix_LockAudio();
+    pause_async_music(pause_on);
+    Mix_UnlockAudio();
+}
+
 /* Dynamically change the number of channels managed by the mixer.
    If decreasing the number of channels, the upper channels are
    stopped.

--- a/src/music.c
+++ b/src/music.c
@@ -378,6 +378,23 @@ void SDLCALL music_mixer(void *udata, Uint8 *stream, int len)
     }
 }
 
+void pause_async_music(int pause_on)
+{
+    if (!music_active || !music_playing || !music_playing->interface) {
+        return;
+    }
+
+    if (pause_on) {
+        if (music_playing->interface->Pause) {
+            music_playing->interface->Pause(music_playing->context);
+        }
+    } else {
+        if (music_playing->interface->Resume) {
+            music_playing->interface->Resume(music_playing->context);
+        }
+    }
+}
+
 /* Load the music interface libraries for a given music type */
 SDL_bool load_music_type(Mix_MusicType type)
 {

--- a/src/music.h
+++ b/src/music.h
@@ -163,6 +163,7 @@ extern void open_music(const SDL_AudioSpec *spec);
 extern int music_pcm_getaudio(void *context, void *data, int bytes, int volume,
                               int (*GetSome)(void *context, void *data, int bytes, SDL_bool *done));
 extern void SDLCALL music_mixer(void *udata, Uint8 *stream, int len);
+extern void pause_async_music(int pause_on);
 extern void close_music(void);
 extern void unload_music(void);
 


### PR DESCRIPTION
This call allows cheaper pausing/resuming of the whole audio processing without pausing every playing channel or music stream.

For example, this call can be used to pause the entire audio playback when the game is not focused.

Note: the "pause_async_music" call is required for music which is playing asynchronously from the main audio output processor, for example, OS Native MIDI. ~~However, the stuff doesn't affect CMD Music which will still play (however, never tested this as I never used CMD music for my needs)~~ Tested this, and it works, because it uses SIGSTOP and SIGCONT signals were literally suspended/resumes the running process.