### PR TITLE
Fix issue finding libxmp dependency

### DIFF
--- a/cmake/Findlibxmp-lite.cmake
+++ b/cmake/Findlibxmp-lite.cmake
@@ -1,3 +1,5 @@
+include(FindPackageHandleStandardArgs)
+
 find_library(libxmp_lite_LIBRARY
     NAMES xmp
 )

--- a/cmake/Findlibxmp.cmake
+++ b/cmake/Findlibxmp.cmake
@@ -1,3 +1,5 @@
+include(FindPackageHandleStandardArgs)
+
 find_library(libxmp_LIBRARY
     NAMES xmp
 )


### PR DESCRIPTION
## Description
I was trying to compile `SDL_mixer` for `PS2` using the `cmake` functionality and it was always failing to try to find `libxmp`, however, it was properly installed.
After the change is done in this PR the library is properly detected.

Cheers