### PR TITLE
cmake: disable OP_DISABLE_EXAMPLES for vendored opusfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ if(SDL2MIXER_OPUS)
         add_subdirectory(external/opus EXCLUDE_FROM_ALL)
 
         set(OP_DISABLE_DOCS TRUE CACHE BOOL "Disable opusfile documentation")
+        set(OP_DISABLE_EXAMPLES TRUE CACHE BOOL "Disable opusfile examples")
         set(OP_DISABLE_HTTP TRUE CACHE BOOL "Disable opusfile HTTP SUPPORT")
         message(STATUS "Using vendored opusfile")
         set(BUILD_SHARED_LIBS ${SDL2MIXER_OPUS_SHARED})


### PR DESCRIPTION
Fixes #458 

`BUILD_TESTING` does not need to be set, as the option is not used in there and no [`enable_testing`](https://cmake.org/cmake/help/latest/command/enable_testing.html) is called.