### PR TITLE
Fix huge memory waste with resampled sound samples

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -860,7 +860,7 @@ Mix_Chunk *Mix_LoadWAV_RW(SDL_RWops *src, int freesrc)
             return(NULL);
         }
 
-        chunk->abuf = wavecvt.buf;
+        chunk->abuf = SDL_realloc(wavecvt.buf, wavecvt.len_cvt);
         chunk->alen = wavecvt.len_cvt;
         wavfree = 0;
     }


### PR DESCRIPTION
At the moment SDL’s sample rate conversion requests a really big buffer which is 4x the necessary size when the target format is 16 bit integer. In some cases we even saw buffers 6x the necessary size. This change ensures that after format conversion only the necessary buffer size is kept.