### PR TITLE
Add missing error handling to SDL_realloc call

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -758,6 +758,7 @@ Mix_Chunk *Mix_LoadWAV_RW(SDL_RWops *src, int freesrc)
     SDL_AudioCVT wavecvt;
     int samplesize;
     int wavfree;        /* to decide how to free chunk->abuf. */
+    Uint8 *resized_buf;
 
     /* rcg06012001 Make sure src is valid */
     if (!src) {
@@ -860,7 +861,12 @@ Mix_Chunk *Mix_LoadWAV_RW(SDL_RWops *src, int freesrc)
             return(NULL);
         }
 
-        chunk->abuf = SDL_realloc(wavecvt.buf, wavecvt.len_cvt);
+        resized_buf = SDL_realloc(wavecvt.buf, wavecvt.len_cvt);
+        if (resized_buf == NULL) {
+            chunk->abuf = wavecvt.buf;
+        } else {
+            chunk->abuf = resized_buf;
+        }
         chunk->alen = wavecvt.len_cvt;
         wavfree = 0;
     }


### PR DESCRIPTION
Sorry, I previously forgot to error check the return value of SDL_realloc.
This is a minimal way of error handling, since I am not sure how realloc errors are appropriately handled in the code base.

So, feel free to edit the PR branch or let me know how I should change it.