### PR TITLE
Fixed crash at WavPack module

### DIFF
--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -243,6 +243,7 @@ static int sdl_setpos_abs32(void *id, uint32_t pos)
 
 static int sdl_pushback_byte(void *id, int c)
 {
+    (void)c;
     /* libwavpack calls ungetc(), but doesn't really modify buffer. */
     return (SDL_RWseek((SDL_RWops*)id, -1, RW_SEEK_CUR) < 0)? -1 : 0;
 }

--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -329,7 +329,7 @@ static void *WAVPACK_CreateFromFile(const char *file)
     music = WAVPACK_CreateFromRW_internal(src1, src2, 1, &freesrc2);
     if (!music) {
         SDL_RWclose(src1);
-        if (freesrc2) {
+        if (freesrc2 && src2) {
             SDL_RWclose(src2);
         }
     }


### PR DESCRIPTION
There is a crash that will happen when attempting to open an invalid or non-WavPack file by WAVPACK_CreateFromFile() call. There is an attempt to close the RW context with a NULL value.