### PR TITLE
add Mix_SetMusicBeat and Mix_GetMusicBeat

### DIFF
--- a/include/SDL_mixer.h
+++ b/include/SDL_mixer.h
@@ -2472,6 +2472,29 @@ extern DECLSPEC double SDLCALL Mix_GetMusicPosition(Mix_Music *music);
 extern DECLSPEC double SDLCALL Mix_MusicDuration(Mix_Music *music);
 
 /**
+ * Set the current position in the music stream, in beats.
+ *
+ * This function is only implemented for MIDI via Timidity at the moment.
+ *
+ * \param beat the new position, in beats (as a int).
+ * \returns 0 if successful, or -1 if it failed or not implemented.
+ *
+ * \since This function is available since SDL_mixer 2.7.0.
+ */
+extern DECLSPEC int SDLCALL Mix_SetMusicBeat(int beat);
+
+/**
+ * Get the current position in the music stream, in beats.
+ *
+ * This function is only implemented for MIDI via Timidity at the moment.
+ *
+ * \returns current beat position if successful, or -1 if it failed or not implemented.
+ *
+ * \since This function is available since SDL_mixer 2.7.0.
+ */
+extern DECLSPEC int SDLCALL Mix_GetMusicBeat();
+
+/**
  * Get the loop start time position of music stream, in seconds.
  *
  * To convert to milliseconds, multiply by 1000.0.

--- a/playmus.c
+++ b/playmus.c
@@ -119,9 +119,11 @@ int main(int argc, char *argv[])
     int audio_channels;
     int audio_buffers;
     int audio_volume = MIX_MAX_VOLUME;
+    int beat = 0;
     int looping = 0;
     int interactive = 0;
     int rwops = 0;
+    int supports_beats;
     int i;
     const char *typ;
     const char *tag_title = NULL;
@@ -161,6 +163,10 @@ int main(int argc, char *argv[])
         } else
         if (strcmp(argv[i], "-l") == 0) {
             looping = -1;
+        } else
+        if (strcmp(argv[i], "-n") == 0 && argv[i+1]) {
+            ++i;
+            beat = atoi(argv[i]);
         } else
         if (strcmp(argv[i], "-i") == 0) {
             interactive = 1;
@@ -295,14 +301,22 @@ int main(int argc, char *argv[])
         if (loop_start > 0.0 && loop_end > 0.0 && loop_length > 0.0) {
             SDL_Log("Loop points: start %g s, end %g s, length %g s\n", loop_start, loop_end, loop_length);
         }
-        Mix_FadeInMusic(music,looping,2000);
+        Mix_PlayMusic(music, looping);
+
+        supports_beats = Mix_GetMusicBeat(music) != -1;
+        if (supports_beats)
+            Mix_SetMusicBeat(beat);
+
         while (!next_track && (Mix_PlayingMusic() || Mix_PausedMusic())) {
             if(interactive)
                 Menu();
             else {
                 current_position = Mix_GetMusicPosition(music);
                 if (current_position >= 0.0) {
-                    printf("Position: %g seconds             \r", current_position);
+                    if (supports_beats)
+                        printf("Position: %0.2f seconds      Beat: %d\r", current_position, Mix_GetMusicBeat(music));
+                    else
+                        printf("Position: %0.2f seconds             \r", current_position);
                     fflush(stdout);
                 }
                 SDL_Delay(100);

--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -225,10 +225,23 @@ static int TIMIDITY_Seek(void *context, double position)
     return 0;
 }
 
+static int TIMIDITY_SeekBeat(void *context, int index)
+{
+    TIMIDITY_Music *music = (TIMIDITY_Music *)context;
+    Timidity_SeekBeat(music->song, (Uint32)index);
+    return 0;
+}
+
 static double TIMIDITY_Tell(void *context)
 {
     TIMIDITY_Music *music = (TIMIDITY_Music *)context;
     return Timidity_GetSongTime(music->song) / 1000.0;
+}
+
+static int TIMIDITY_TellBeat(void *context)
+{
+    TIMIDITY_Music *music = (TIMIDITY_Music *)context;
+    return Timidity_GetSongBeat(music->song);
 }
 
 static double TIMIDITY_Duration(void *context)
@@ -291,7 +304,9 @@ Mix_MusicInterface Mix_MusicInterface_TIMIDITY =
     TIMIDITY_Stop,
     TIMIDITY_Delete,
     TIMIDITY_Close,
-    NULL    /* Unload */
+    NULL,   /* Unload */
+    TIMIDITY_SeekBeat,
+    TIMIDITY_TellBeat
 };
 
 #endif /* MUSIC_MID_TIMIDITY */

--- a/src/codecs/timidity/readmidi.c
+++ b/src/codecs/timidity/readmidi.c
@@ -502,6 +502,7 @@ static MidiEvent *groom_list(MidiSong *song, Sint32 divisions,Sint32 *eventsp,
 	  /* Add the event to the list */
 	  *lp=meep->event;
 	  lp->time=st;
+	  lp->beat = meep->event.time / divisions;
 	  lp++;
 	  our_event_count++;
 	}
@@ -510,6 +511,7 @@ static MidiEvent *groom_list(MidiSong *song, Sint32 divisions,Sint32 *eventsp,
     }
   /* Add an End-of-Track event */
   lp->time=st;
+  lp->beat=UINT8_MAX;
   lp->type=ME_EOT;
   our_event_count++;
   free_midi_list(song);

--- a/src/codecs/timidity/timidity.h
+++ b/src/codecs/timidity/timidity.h
@@ -98,6 +98,7 @@ typedef struct {
 typedef struct {
     Sint32 time;
     Uint8 channel, type, a, b;
+    Uint32 beat;
 } MidiEvent;
 
 typedef struct _MidiEventList {
@@ -154,7 +155,9 @@ extern int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len);
 extern MidiSong *Timidity_LoadSong(SDL_RWops *rw, SDL_AudioSpec *audio);
 extern void Timidity_Start(MidiSong *song);
 extern void Timidity_Seek(MidiSong *song, Uint32 ms);
+extern void Timidity_SeekBeat(MidiSong *song, Uint32 beat);
 extern Uint32 Timidity_GetSongLength(MidiSong *song); /* returns millseconds */
+extern Uint32 Timidity_GetSongBeat(MidiSong *song); /* returns current beat (aka quarter note) */
 extern Uint32 Timidity_GetSongTime(MidiSong *song);   /* returns millseconds */
 extern void Timidity_Stop(MidiSong *song);
 extern int Timidity_IsActive(MidiSong *song);

--- a/src/music.c
+++ b/src/music.c
@@ -1032,6 +1032,52 @@ int Mix_SetMusicPosition(double position)
     return(retval);
 }
 
+int Mix_SetMusicBeat(int beat)
+{
+    int retval;
+
+    Mix_LockAudio();
+    if (music_playing) {
+        if (music_playing->interface->SeekBeat) {
+            retval = music_playing->interface->SeekBeat(music_playing->context, beat);
+        } else {
+            retval = -1;
+        }
+        if (retval < 0) {
+            Mix_SetError("Seek beat not implemented for music type");
+        }
+    } else {
+        Mix_SetError("Music isn't playing");
+        retval = -1;
+    }
+    Mix_UnlockAudio();
+
+    return(retval);
+}
+
+int Mix_GetMusicBeat()
+{
+    int retval;
+
+    Mix_LockAudio();
+    if (music_playing) {
+        if (music_playing->interface->TellBeat) {
+            retval = music_playing->interface->TellBeat(music_playing->context);
+        } else {
+            retval = -1;
+        }
+        if (retval < 0) {
+            Mix_SetError("Get beat not implemented for music type");
+        }
+    } else {
+        Mix_SetError("Music isn't playing");
+        retval = -1;
+    }
+    Mix_UnlockAudio();
+
+    return(retval);
+}
+
 /* Set the playing music position */
 static double music_internal_position_get(Mix_Music *music)
 {

--- a/src/music.h
+++ b/src/music.h
@@ -157,6 +157,12 @@ typedef struct
 
     /* Unload the library */
     void (*Unload)(void);
+
+    /* Seek to a play position (in beats) */
+    int (*SeekBeat)(void *music, int beats);
+
+    /* Tell current beat */
+    int (*TellBeat)(void *music);
 } Mix_MusicInterface;
 
 


### PR DESCRIPTION
I have a use case where I must set the position of MIDI music to a particular beat index (something supported by the old allegro 4 midi player, and perhaps other midi players).

Example MIDI: https://drive.google.com/file/d/1qiE7sVyvQoVRxJftKhz-n4juuArfwri8/view?usp=share_link

And positions of tunes within:

```
0:    Wind Fish
81:   Overworld
233:  Hyrule Castle
553:  Lost Woods
814:  Great Sea
985:  East Hyrule
1153: Dancing Dragon
1333: Stone Tower
1556: Villages
1801: Swamp + Desert
2069: Outset Island
2189: Kakariko Village
2569: Clock Town
2753: Temple
2856: Dark World
3042: Dragon Roost
3125: Horse Race
3217: Credits
3296: Zelda's Lullaby
```

Note: I'm not certain if there's an off-by-one error in this code, or in the source midi player these positions are defined to work in (allegro 4), but I found I need to take the beat values above and subtract one to get the exact right positioning.

You can use the `playmus` example program to seek to a specific tune (you'll need a timidity.cfg and soundfont within your build directory, as always):

```
./playmus -n 552 TheTravelsOfLink.mid
```

Draft until some feedback (then I'll update the other music interfaces with NULL stubs).