### PR TITLE
cmake: check existence of signal.h and setbuf for samples (SDL2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
     set(vendored_default OFF)
 endif()
 
+include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CMakeDependentOption)
 include(CMakePackageConfigHelpers)
@@ -958,6 +959,9 @@ if(SDL2MIXER_INSTALL)
 endif()
 
 if(SDL2MIXER_SAMPLES)
+    check_include_file("signal.h" HAVE_SIGNAL_H)
+    check_symbol_exists("setbuf" "stdio.h" HAVE_SETBUF)
+
     add_executable(playmus playmus.c)
     add_executable(playwave playwave.c)
 
@@ -974,6 +978,12 @@ if(SDL2MIXER_SAMPLES)
             target_link_libraries(${prog} PRIVATE SDL2::SDL2main)
         endif()
         target_link_libraries(${prog} PRIVATE ${sdl2_target_name})
+        if(HAVE_SIGNAL_H)
+            target_compile_definitions(${prog} PRIVATE HAVE_SIGNAL_H)
+        endif()
+        if(HAVE_SETBUF)
+            target_compile_definitions(${prog} PRIVATE HAVE_SETBUF)
+        endif()
 
         if(SDL2MIXER_SAMPLES_INSTALL)
             install(TARGETS ${prog}

--- a/cmake/PrivateSdlFunctions.cmake
+++ b/cmake/PrivateSdlFunctions.cmake
@@ -60,7 +60,7 @@ macro(sdl_find_sdl2 TARGET VERSION)
     # or for those installations where no target is generated.
     if (NOT TARGET ${TARGET})
         message(STATUS "Using private SDL2 find module")
-        find_package(PrivateSDL2 ${VERSION} REQUIRED)
+        find_package(PrivateSDL2 ${VERSION} REQUIRED MODULE)
         add_library(${TARGET} INTERFACE IMPORTED)
         set_target_properties(${TARGET} PROPERTIES
             INTERFACE_LINK_LIBRARIES "PrivateSDL2::PrivateSDL2"


### PR DESCRIPTION
Check existence of `signal.h` and `setbuf` for samples.

Fixes #489