### PR TITLE
cmake: check existence of signal.h and setbuf for samples (SDL3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ else()
     set(vendored_default OFF)
 endif()
 
+include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CMakeDependentOption)
 include(CMakePackageConfigHelpers)
@@ -930,12 +931,21 @@ if(SDL3MIXER_INSTALL)
 endif()
 
 if(SDL3MIXER_SAMPLES)
+    check_include_file("signal.h" HAVE_SIGNAL_H)
+    check_symbol_exists("setbuf" "stdio.h" HAVE_SETBUF)
+
     add_executable(playmus playmus.c)
     add_executable(playwave playwave.c)
 
     foreach(prog playmus playwave)
         target_link_libraries(${prog} PRIVATE SDL3_mixer::${sdl3_mixer_export_name})
         target_link_libraries(${prog} PRIVATE ${sdl3_target_name})
+        if(HAVE_SIGNAL_H)
+            target_compile_definitions(${prog} PRIVATE HAVE_SIGNAL_H)
+        endif()
+        if(HAVE_SETBUF)
+            target_compile_definitions(${prog} PRIVATE HAVE_SETBUF)
+        endif()
 
         if(SDL3MIXER_SAMPLES_INSTALL)
             install(TARGETS ${prog}


### PR DESCRIPTION
Fixes #489