### PR TITLE
Fix potential infinite loop in `Mix_FreeChunk` when called in a channel finish callback

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -926,9 +926,9 @@ Mix_Chunk *Mix_QuickLoad_RAW(Uint8 *mem, Uint32 len)
 static void  Mix_HaltChannel_locked(int which)
 {
     if (Mix_Playing(which)) {
-        _Mix_channel_done_playing(which);
         mix_channel[which].playing = 0;
         mix_channel[which].looping = 0;
+        _Mix_channel_done_playing(which);
     }
     mix_channel[which].expire = 0;
     if (mix_channel[which].fading != MIX_NO_FADING) /* Restore volume */


### PR DESCRIPTION
In a recent update to my app's dependencies, I noticed that my channel finished callback, which simply frees the current chunk with `Mix_FreeChunk`, was causing a stack overflow through infinite recursion. This appears to stem from a change in SDL2_mixer 2.6.0 that moved some logic for halting channels around - the channel finished callback is now called *before* setting the channel as not playing, which means that calling any functions that may attempt to halt the channel, including `Mix_FreeChunk`, inside the callback will result in an infinite loop.

This PR adjusts `Mix_HaltChannel_locked` to call `_Mix_channel_done_playing` *after* setting the channel to not playing, which will prevent these sorts of loops. Note that I have yet to test this change, but it shouldn't result in anything major - other code in the file does it in this same order, calling `_Mix_channel_done_playing` only after setting the two fields to 0.