### PR TITLE
cmake: fix Findlibxmp-lite.cmake

### DIFF
--- a/cmake/Findlibxmp-lite.cmake
+++ b/cmake/Findlibxmp-lite.cmake
@@ -1,11 +1,12 @@
 include(FindPackageHandleStandardArgs)
 
 find_library(libxmp_lite_LIBRARY
-    NAMES xmp
+    NAMES xmp-lite
 )
 
 find_path(libxmp_lite_INCLUDE_PATH
     NAMES xmp.h
+    PATH_SUFFIXES libxmp-lite
 )
 
 set(libxmp_lite_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp_lite")
@@ -14,14 +15,14 @@ set(libxmp_lite_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp_l
 
 set(libxmp_lite_LINK_FLAGS "" CACHE STRING "Extra link flags of libxmp_lite")
 
-find_package_handle_standard_args(libxmp_lite
+find_package_handle_standard_args(libxmp-lite
     REQUIRED_VARS libxmp_lite_LIBRARY libxmp_lite_INCLUDE_PATH
 )
 
 if(libxmp_lite_FOUND)
     if(NOT TARGET libxmp-lite::libxmp-lite)
         add_library(libxmp-lite::libxmp-lite UNKNOWN IMPORTED)
-        set_target_properties(libxmp_lite::libxmp_lite-shared PROPERTIES
+        set_target_properties(libxmp-lite::libxmp-lite PROPERTIES
             IMPORTED_LOCATION "${libxmp_lite_LIBRARY}"
             INTERFACE_INCLUDE_DIRECTORIES "${libxmp_lite_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${libxmp_lite_COMPILE_OPTIONS}"


### PR DESCRIPTION
Fixes #497

The `find_path` might pick up the include path of libxmp (instead of libxmp-lite) when both are installed.
But is this an issue? It looks like these are the same for both libraries.
This is only an issue when the installed libxmp and libxmp-lite come from a different version.