### PR TITLE
CMake: Improve dependency searching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -928,6 +928,7 @@ if(SDL3MIXER_INSTALL)
         FILES
             "${CMAKE_CURRENT_BINARY_DIR}/SDL3_mixerConfig.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/SDL3_mixerConfigVersion.cmake"
+            "${CMAKE_CURRENT_LIST_DIR}/cmake/PkgConfigHelper.cmake"
             cmake/FindFLAC.cmake
             cmake/FindFluidSynth.cmake
             cmake/Findgme.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,11 @@ endif()
 
 # Assume MSVC projects don't have a package manager and need vendored dependencies (by default).
 # Most other platforms have some kind of package manager.
-if(ANDROID OR MSVC AND NOT VCPKG_TOOLCHAIN AND NOT CONAN_CMD)
+# FIXME: consider a package manager such as conan/vcpkg instead of vendoring
+if(ANDROID OR MSVC)
     set(vendored_default ON)
 else()
     set(vendored_default OFF)
-endif()
-
-# Both vcpkg and conan provide the upstream CMake config for the
-# dependencies, so prioritise them over the Find modules
-if(VCPKG_TOOLCHAIN OR CONAN_CMD)
-    set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 endif()
 
 set(sdl3mixer_install_enableable ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,16 @@ endif()
 
 # Assume MSVC projects don't have a package manager and need vendored dependencies (by default).
 # Most other platforms have some kind of package manager.
-# FIXME: consider a package manager such as conan/vcpkg instead of vendoring
-if(ANDROID OR MSVC)
+if(ANDROID OR MSVC AND NOT VCPKG_TOOLCHAIN AND NOT CONAN_CMD)
     set(vendored_default ON)
 else()
     set(vendored_default OFF)
+endif()
+
+# Both vcpkg and conan provide the upstream CMake config for the
+# dependencies, so prioritise them over the Find modules
+if(VCPKG_TOOLCHAIN OR CONAN_CMD)
+    set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 endif()
 
 set(sdl3mixer_install_enableable ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,13 @@ if(POLICY CMP0112)
     cmake_policy(SET CMP0112 NEW)
 endif()
 
+if(POLICY CMP0099)
+    # Make `INTERFACE_LINK_DIRECTORIES` a transitive usage requirement.
+    # This is needed for static dependencies which have transitive dependencies
+    # outside of compiler default search paths.
+    cmake_policy(SET CMP0099 NEW)
+endif()
+
 # Assume MSVC projects don't have a package manager and need vendored dependencies (by default).
 # Most other platforms have some kind of package manager.
 # FIXME: consider a package manager such as conan/vcpkg instead of vendoring
@@ -58,6 +65,8 @@ include(CheckSymbolExists)
 include(CMakeDependentOption)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
+
+include(PkgConfigHelper)
 
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build static libraries with -fPIC" ON)
 option(BUILD_SHARED_LIBS "Build the library as a shared library" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ if ((TARGET SDL3 OR TARGET SDL3-static) AND SDL3_DISABLE_INSTALL)
     set(sdl3mixer_install_enableable OFF)
 endif()
 
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+    set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+endif()
+
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CMakeDependentOption)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,18 +782,18 @@ if(SDL3MIXER_MIDI_FLUIDSYNTH)
     endif()
     if(SDL3MIXER_MIDI_FLUIDSYNTH_SHARED)
         target_include_directories(SDL3_mixer PRIVATE
-            $<TARGET_PROPERTY:FluidSynth::FluidSynth,INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:FluidSynth::FluidSynth,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:FluidSynth::FluidSynth,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:FluidSynth::libfluidsynth,INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:FluidSynth::libfluidsynth,INTERFACE_INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:FluidSynth::libfluidsynth,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
         )
-        target_get_dynamic_library(dynamic_fluidsynth FluidSynth::FluidSynth)
+        target_get_dynamic_library(dynamic_fluidsynth FluidSynth::libfluidsynth)
         message(STATUS "Dynamic fluidsynth: ${dynamic_fluidsynth}")
         target_compile_definitions(SDL3_mixer PRIVATE "FLUIDSYNTH_DYNAMIC=\"${dynamic_fluidsynth}\"")
         if(SDL3MIXER_VENDORED)
-            add_dependencies(SDL3_mixer FluidSynth::FluidSynth)
+            add_dependencies(SDL3_mixer FluidSynth::libfluidsynth)
         endif()
     else()
-        target_link_libraries(SDL3_mixer PRIVATE FluidSynth::FluidSynth)
+        target_link_libraries(SDL3_mixer PRIVATE FluidSynth::libfluidsynth)
     endif()
 endif()
 

--- a/cmake/FindFLAC.cmake
+++ b/cmake/FindFLAC.cmake
@@ -12,7 +12,7 @@ set(FLAC_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of FLAC")
 
 set(FLAC_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of FLAC")
 
-set(FLAC_LINK_FLAGS "" CACHE STRING "Extra link flags of FLAC")
+set(FLAC_LINK_OPTIONS "" CACHE STRING "Extra link flags of FLAC")
 
 find_package_handle_standard_args(FLAC
     REQUIRED_VARS FLAC_LIBRARY FLAC_INCLUDE_PATH
@@ -26,7 +26,7 @@ if(FLAC_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${FLAC_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${FLAC_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${FLAC_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${FLAC_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${FLAC_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/FindFLAC.cmake
+++ b/cmake/FindFLAC.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_FLAC QUIET flac)
+
 find_library(FLAC_LIBRARY
     NAMES FLAC
+    HINTS ${PC_FLAC_LIBDIR}
 )
 
 find_path(FLAC_INCLUDE_PATH
     NAMES FLAC/all.h
+    HINTS ${PC_FLAC_INCLUDEDIR}
 )
 
-set(FLAC_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of FLAC")
+if(PC_FLAC_FOUND)
+    get_flags_from_pkg_config("${FLAC_LIBRARY}" "PC_FLAC" "_flac")
+endif()
 
-set(FLAC_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of FLAC")
+set(FLAC_COMPILE_OPTIONS "${_flac_compile_options}" CACHE STRING "Extra compile options of FLAC")
 
-set(FLAC_LINK_OPTIONS "" CACHE STRING "Extra link flags of FLAC")
+set(FLAC_LINK_LIBRARIES "${_flac_link_libraries}" CACHE STRING "Extra link libraries of FLAC")
+
+set(FLAC_LINK_OPTIONS "${_flac_link_options}" CACHE STRING "Extra link flags of FLAC")
+
+set(FLAC_LINK_DIRECTORIES "${_flac_link_directories}" CACHE PATH "Extra link directories of FLAC")
 
 find_package_handle_standard_args(FLAC
     REQUIRED_VARS FLAC_LIBRARY FLAC_INCLUDE_PATH
@@ -27,6 +38,7 @@ if(FLAC_FOUND)
             INTERFACE_COMPILE_OPTIONS "${FLAC_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${FLAC_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${FLAC_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${FLAC_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/FindFluidSynth.cmake
+++ b/cmake/FindFluidSynth.cmake
@@ -4,7 +4,7 @@ find_package(PkgConfig QUIET)
 pkg_check_modules(PC_FLUIDSYNTH QUIET fluidsynth)
 
 find_library(FluidSynth_LIBRARY
-    NAMES fluidsynth
+    NAMES fluidsynth libfluidsynth
     HINTS ${PC_FLUIDSYNTH_LIBDIR}
 )
 

--- a/cmake/FindFluidSynth.cmake
+++ b/cmake/FindFluidSynth.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_FLUIDSYNTH QUIET fluidsynth)
+
 find_library(FluidSynth_LIBRARY
     NAMES fluidsynth
+    HINTS ${PC_FLUIDSYNTH_LIBDIR}
 )
 
 find_path(FluidSynth_INCLUDE_PATH
     NAMES fluidsynth.h
+    HINTS ${PC_FLUIDSYNTH_INCLUDEDIR}
 )
 
-set(FluidSynth_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of FluidSynth")
+if(PC_FLUIDSYNTH_FOUND)
+    get_flags_from_pkg_config("${FluidSynth_LIBRARY}" "PC_FLUIDSYNTH" "_fluidsynth")
+endif()
 
-set(FluidSynth_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of FluidSynth")
+set(FluidSynth_COMPILE_OPTIONS "${_fluidsynth_compile_options}" CACHE STRING "Extra compile options of FluidSynth")
 
-set(FluidSynth_LINK_OPTIONS "" CACHE STRING "Extra link flags of FluidSynth")
+set(FluidSynth_LINK_LIBRARIES "${_fluidsynth_link_libraries}" CACHE STRING "Extra link libraries of FluidSynth")
+
+set(FluidSynth_LINK_OPTIONS "${_fluidsynth_link_options}" CACHE STRING "Extra link flags of FluidSynth")
+
+set(FluidSynth_LINK_DIRECTORIES "${_fluidsynth_link_directories}" CACHE PATH "Extra link directories of FluidSynth")
 
 find_package_handle_standard_args(FluidSynth
     REQUIRED_VARS FluidSynth_LIBRARY FluidSynth_INCLUDE_PATH
@@ -27,6 +38,7 @@ if(FluidSynth_FOUND)
             INTERFACE_COMPILE_OPTIONS "${FluidSynth_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${FluidSynth_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${FluidSynth_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${FluidSynth_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/FindFluidSynth.cmake
+++ b/cmake/FindFluidSynth.cmake
@@ -12,7 +12,7 @@ set(FluidSynth_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of FluidSy
 
 set(FluidSynth_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of FluidSynth")
 
-set(FluidSynth_LINK_FLAGS "" CACHE STRING "Extra link flags of FluidSynth")
+set(FluidSynth_LINK_OPTIONS "" CACHE STRING "Extra link flags of FluidSynth")
 
 find_package_handle_standard_args(FluidSynth
     REQUIRED_VARS FluidSynth_LIBRARY FluidSynth_INCLUDE_PATH
@@ -26,7 +26,7 @@ if(FluidSynth_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${FluidSynth_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${FluidSynth_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${FluidSynth_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${FluidSynth_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${FluidSynth_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/FindFluidSynth.cmake
+++ b/cmake/FindFluidSynth.cmake
@@ -19,9 +19,9 @@ find_package_handle_standard_args(FluidSynth
 )
 
 if(FluidSynth_FOUND)
-    if(NOT TARGET FluidSynth::FluidSynth)
-        add_library(FluidSynth::FluidSynth UNKNOWN IMPORTED)
-        set_target_properties(FluidSynth::FluidSynth PROPERTIES
+    if(NOT TARGET FluidSynth::libfluidsynth)
+        add_library(FluidSynth::libfluidsynth UNKNOWN IMPORTED)
+        set_target_properties(FluidSynth::libfluidsynth PROPERTIES
             IMPORTED_LOCATION "${FluidSynth_LIBRARY}"
             INTERFACE_INCLUDE_DIRECTORIES "${FluidSynth_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${FluidSynth_COMPILE_OPTIONS}"

--- a/cmake/FindOpusFile.cmake
+++ b/cmake/FindOpusFile.cmake
@@ -1,19 +1,30 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_OPUSFILE QUIET opusfile)
+
 find_library(OpusFile_LIBRARY
     NAMES opusfile
+    HINTS ${PC_OPUSFILE_LIBDIR}
 )
-
-set(OpusFile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of opusfile")
-
-set(OpusFile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of opusfile")
-
-set(OpusFile_LINK_OPTIONS "" CACHE STRING "Extra link flags of opusfile")
 
 find_path(OpusFile_INCLUDE_PATH
     NAMES opusfile.h
     PATH_SUFFIXES opus
+    HINTS ${PC_OPUSFILE_INCLUDEDIR}
 )
+
+if(PC_OPUSFILE_FOUND)
+    get_flags_from_pkg_config("${OpusFile_LIBRARY}" "PC_OPUSFILE" "_opusfile")
+endif()
+
+set(OpusFile_COMPILE_OPTIONS "${_opusfile_compile_options}" CACHE STRING "Extra compile options of opusfile")
+
+set(OpusFile_LINK_LIBRARIES "${_opusfile_link_libraries}" CACHE STRING "Extra link libraries of opusfile")
+
+set(OpusFile_LINK_OPTIONS "${_opusfile_link_options}" CACHE STRING "Extra link flags of opusfile")
+
+set(OpusFile_LINK_DIRECTORIES "${_opusfile_link_directories}" CACHE PATH "Extra link directories of opusfile")
 
 find_package_handle_standard_args(OpusFile
     REQUIRED_VARS OpusFile_LIBRARY OpusFile_INCLUDE_PATH
@@ -32,6 +43,7 @@ if (OpusFile_FOUND)
             INTERFACE_COMPILE_OPTIONS "${OpusFile_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${OpusFile_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${OpusFile_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${OpusFile_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/FindOpusFile.cmake
+++ b/cmake/FindOpusFile.cmake
@@ -8,7 +8,7 @@ set(OpusFile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of opusfile"
 
 set(OpusFile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of opusfile")
 
-set(OpusFile_LINK_FLAGS "" CACHE STRING "Extra link flags of opusfile")
+set(OpusFile_LINK_OPTIONS "" CACHE STRING "Extra link flags of opusfile")
 
 find_path(OpusFile_INCLUDE_PATH
     NAMES opusfile.h
@@ -31,7 +31,7 @@ if (OpusFile_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${OpusFile_dirs}"
             INTERFACE_COMPILE_OPTIONS "${OpusFile_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${OpusFile_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${OpusFile_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${OpusFile_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/FindSndFile.cmake
+++ b/cmake/FindSndFile.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_SNDFILE QUIET sndfile)
+
 find_library(SndFile_LIBRARY
     NAMES sndfile sndfile-1
+    HINTS ${PC_SNDFILE_LIBDIR}
 )
 
 find_path(SndFile_INCLUDE_PATH
     NAMES sndfile.h
+    HINTS ${PC_SNDFILE_INCLUDEDIR}
 )
 
-set(SndFile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libsndfile")
+if(PC_SNDFILE_FOUND)
+    get_flags_from_pkg_config("${SndFile_LIBRARY}" "PC_SNDFILE" "_sndfile")
+endif()
 
-set(SndFile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libsndfile")
+set(SndFile_COMPILE_OPTIONS "${_sndfile_compile_options}" CACHE STRING "Extra compile options of libsndfile")
 
-set(SndFile_LINK_OPTIONS "" CACHE STRING "Extra link flags of libsndfile")
+set(SndFile_LINK_LIBRARIES "${_sndfile_link_libraries}" CACHE STRING "Extra link libraries of libsndfile")
+
+set(SndFile_LINK_OPTIONS "${_sndfile_link_options}" CACHE STRING "Extra link flags of libsndfile")
+
+set(SndFile_LINK_DIRECTORIES "${_sndfile_link_directories}" CACHE PATH "Extra link directories of libsndfile")
 
 find_package_handle_standard_args(SndFile
     REQUIRED_VARS SndFile_LIBRARY SndFile_INCLUDE_PATH
@@ -27,6 +38,7 @@ if(SndFile_FOUND)
             INTERFACE_COMPILE_OPTIONS "${SndFile_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${SndFile_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${SndFile_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${SndFile_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/FindSndFile.cmake
+++ b/cmake/FindSndFile.cmake
@@ -12,7 +12,7 @@ set(SndFile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libsndfile
 
 set(SndFile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libsndfile")
 
-set(SndFile_LINK_FLAGS "" CACHE STRING "Extra link flags of libsndfile")
+set(SndFile_LINK_OPTIONS "" CACHE STRING "Extra link flags of libsndfile")
 
 find_package_handle_standard_args(SndFile
     REQUIRED_VARS SndFile_LIBRARY SndFile_INCLUDE_PATH
@@ -26,7 +26,7 @@ if(SndFile_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${SndFile_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${SndFile_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${SndFile_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${SndFile_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${SndFile_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/FindVorbis.cmake
+++ b/cmake/FindVorbis.cmake
@@ -8,7 +8,7 @@ set(Vorbis_vorbisfile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of 
 
 set(Vorbis_vorbisfile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of vorbisfile")
 
-set(Vorbis_vorbisfile_LINK_FLAGS "" CACHE STRING "Extra link flags of vorbisfile")
+set(Vorbis_vorbisfile_LINK_OPTIONS "" CACHE STRING "Extra link flags of vorbisfile")
 
 find_path(Vorbis_vorbisfile_INCLUDE_PATH
     NAMES vorbis/vorbisfile.h
@@ -26,7 +26,7 @@ if (Vorbis_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_vorbisfile_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${Vorbis_vorbisfile_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${Vorbis_vorbisfile_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${Vorbis_vorbisfile_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${Vorbis_vorbisfile_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/FindVorbis.cmake
+++ b/cmake/FindVorbis.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_VORBIS QUIET vorbisfile)
+
 find_library(Vorbis_vorbisfile_LIBRARY
     NAMES vorbisfile
+    HINTS ${PC_VORBIS_LIBDIR}
 )
-
-set(Vorbis_vorbisfile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of vorbisfile")
-
-set(Vorbis_vorbisfile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of vorbisfile")
-
-set(Vorbis_vorbisfile_LINK_OPTIONS "" CACHE STRING "Extra link flags of vorbisfile")
 
 find_path(Vorbis_vorbisfile_INCLUDE_PATH
     NAMES vorbis/vorbisfile.h
+    HINTS ${PC_VORBIS_INCLUDEDIR}
 )
+
+if(PC_VORBIS_FOUND)
+    get_flags_from_pkg_config("${Vorbis_vorbisfile_LIBRARY}" "PC_VORBIS" "_vorbisfile")
+endif()
+
+set(Vorbis_vorbisfile_COMPILE_OPTIONS "${_vorbisfile_compile_options}" CACHE STRING "Extra compile options of vorbisfile")
+
+set(Vorbis_vorbisfile_LINK_LIBRARIES "${_vorbisfile_link_libraries}" CACHE STRING "Extra link libraries of vorbisfile")
+
+set(Vorbis_vorbisfile_LINK_OPTIONS "${_vorbisfile_link_options}" CACHE STRING "Extra link flags of vorbisfile")
+
+set(Vorbis_vorbisfile_LINK_DIRECTORIES "${_vorbisfile_link_directories}" CACHE PATH "Extra link directories of vorbisfile")
 
 find_package_handle_standard_args(Vorbis
     REQUIRED_VARS Vorbis_vorbisfile_LIBRARY Vorbis_vorbisfile_INCLUDE_PATH
@@ -27,6 +38,7 @@ if (Vorbis_FOUND)
             INTERFACE_COMPILE_OPTIONS "${Vorbis_vorbisfile_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${Vorbis_vorbisfile_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${Vorbis_vorbisfile_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${Vorbis_vorbisfile_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findgme.cmake
+++ b/cmake/Findgme.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_GME QUIET libgme)
+
 find_library(gme_LIBRARY
     NAMES gme
+    HINTS ${PC_GME_LIBDIR}
 )
-
-set(gme_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of gme")
-
-set(gme_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of gme")
-
-set(gme_LINK_OPTIONS "" CACHE STRING "Extra link flags of gme")
 
 find_path(gme_INCLUDE_PATH
     NAMES gme/gme.h
+    HINTS ${PC_GME_INCLUDEDIR}
 )
+
+if(PC_GME_FOUND)
+    get_flags_from_pkg_config("${gme_LIBRARY}" "PC_GME" "_gme")
+endif()
+
+set(gme_COMPILE_OPTIONS "${_gme_compile_options}" CACHE STRING "Extra compile options of gme")
+
+set(gme_LINK_LIBRARIES "${_gme_link_libraries}" CACHE STRING "Extra link libraries of gme")
+
+set(gme_LINK_OPTIONS "${_gme_link_options}" CACHE STRING "Extra link flags of gme")
+
+set(gme_LINK_DIRECTORIES "${_gme_link_directories}" CACHE PATH "Extra link directories of gme")
 
 find_package_handle_standard_args(gme
     REQUIRED_VARS gme_LIBRARY gme_INCLUDE_PATH
@@ -31,6 +42,7 @@ if(gme_FOUND)
             INTERFACE_COMPILE_OPTIONS "${gme_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${gme_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${gme_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${gme_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findgme.cmake
+++ b/cmake/Findgme.cmake
@@ -8,7 +8,7 @@ set(gme_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of gme")
 
 set(gme_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of gme")
 
-set(gme_LINK_FLAGS "" CACHE STRING "Extra link flags of gme")
+set(gme_LINK_OPTIONS "" CACHE STRING "Extra link flags of gme")
 
 find_path(gme_INCLUDE_PATH
     NAMES gme/gme.h
@@ -30,7 +30,7 @@ if(gme_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${gme_dirs}"
             INTERFACE_COMPILE_OPTIONS "${gme_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${gme_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${gme_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${gme_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findlibxmp-lite.cmake
+++ b/cmake/Findlibxmp-lite.cmake
@@ -4,7 +4,7 @@ find_package(PkgConfig QUIET)
 pkg_check_modules(PC_XMPLITE QUIET libxmp-lite)
 
 find_library(libxmp_lite_LIBRARY
-    NAMES xmp-lite
+    NAMES xmp-lite libxmp-lite
     HINTS ${PC_XMPLITE_LIBDIR}
 )
 

--- a/cmake/Findlibxmp-lite.cmake
+++ b/cmake/Findlibxmp-lite.cmake
@@ -13,7 +13,7 @@ set(libxmp_lite_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp
 
 set(libxmp_lite_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp_lite")
 
-set(libxmp_lite_LINK_FLAGS "" CACHE STRING "Extra link flags of libxmp_lite")
+set(libxmp_lite_LINK_OPTIONS "" CACHE STRING "Extra link flags of libxmp_lite")
 
 find_package_handle_standard_args(libxmp-lite
     REQUIRED_VARS libxmp_lite_LIBRARY libxmp_lite_INCLUDE_PATH
@@ -27,7 +27,7 @@ if(libxmp-lite_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${libxmp_lite_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${libxmp_lite_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${libxmp_lite_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${libxmp_lite_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${libxmp_lite_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findlibxmp-lite.cmake
+++ b/cmake/Findlibxmp-lite.cmake
@@ -1,19 +1,30 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_XMPLITE QUIET libxmp-lite)
+
 find_library(libxmp_lite_LIBRARY
     NAMES xmp-lite
+    HINTS ${PC_XMPLITE_LIBDIR}
 )
 
 find_path(libxmp_lite_INCLUDE_PATH
     NAMES xmp.h
     PATH_SUFFIXES libxmp-lite
+    HINTS ${PC_XMPLITE_INCLUDEDIR}
 )
 
-set(libxmp_lite_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp_lite")
+if(PC_XMPLITE_FOUND)
+    get_flags_from_pkg_config("${libxmp_lite_LIBRARY}" "PC_XMPLITE" "_libxmp_lite")
+endif()
 
-set(libxmp_lite_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp_lite")
+set(libxmp_lite_COMPILE_OPTIONS "${_libxmp_lite_compile_options}" CACHE STRING "Extra compile options of libxmp_lite")
 
-set(libxmp_lite_LINK_OPTIONS "" CACHE STRING "Extra link flags of libxmp_lite")
+set(libxmp_lite_LINK_LIBRARIES "${_libxmp_lite_link_libraries}" CACHE STRING "Extra link libraries of libxmp_lite")
+
+set(libxmp_lite_LINK_OPTIONS "${_libxmp_lite_link_options}" CACHE STRING "Extra link flags of libxmp_lite")
+
+set(libxmp_lite_LINK_DIRECTORIES "${_libxmp_lite_link_directories}" CACHE PATH "Extra link directories of libxmp_lite")
 
 find_package_handle_standard_args(libxmp-lite
     REQUIRED_VARS libxmp_lite_LIBRARY libxmp_lite_INCLUDE_PATH
@@ -28,6 +39,7 @@ if(libxmp-lite_FOUND)
             INTERFACE_COMPILE_OPTIONS "${libxmp_lite_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${libxmp_lite_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${libxmp_lite_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${libxmp_lite_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findlibxmp.cmake
+++ b/cmake/Findlibxmp.cmake
@@ -12,7 +12,7 @@ set(libxmp_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp")
 
 set(libxmp_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp")
 
-set(libxmp_LINK_FLAGS "" CACHE STRING "Extra link flags of libxmp")
+set(libxmp_LINK_OPTIONS "" CACHE STRING "Extra link flags of libxmp")
 
 find_package_handle_standard_args(libxmp
     REQUIRED_VARS libxmp_LIBRARY libxmp_INCLUDE_PATH
@@ -26,7 +26,7 @@ if(libxmp_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${libxmp_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${libxmp_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${libxmp_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${libxmp_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${libxmp_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findlibxmp.cmake
+++ b/cmake/Findlibxmp.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_XMP QUIET libxmp)
+
 find_library(libxmp_LIBRARY
     NAMES xmp
+    HINTS ${PC_XMP_LIBDIR}
 )
 
 find_path(libxmp_INCLUDE_PATH
     NAMES xmp.h
+    HINTS ${PC_XMP_INCLUDEDIR}
 )
 
-set(libxmp_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp")
+if(PC_XMP_FOUND)
+    get_flags_from_pkg_config("${libxmp_LIBRARY}" "PC_XMP" "_libxmp")
+endif()
 
-set(libxmp_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp")
+set(libxmp_COMPILE_OPTIONS "${_libxmp_compile_options}" CACHE STRING "Extra compile options of libxmp")
 
-set(libxmp_LINK_OPTIONS "" CACHE STRING "Extra link flags of libxmp")
+set(libxmp_LINK_LIBRARIES "${_libxmp_link_libraries}" CACHE STRING "Extra link libraries of libxmp")
+
+set(libxmp_LINK_OPTIONS "${_libxmp_link_options}" CACHE STRING "Extra link flags of libxmp")
+
+set(libxmp_LINK_DIRECTORIES "${_libxmp_link_directories}" CACHE PATH "Extra link flags of libxmp")
 
 find_package_handle_standard_args(libxmp
     REQUIRED_VARS libxmp_LIBRARY libxmp_INCLUDE_PATH
@@ -27,6 +38,7 @@ if(libxmp_FOUND)
             INTERFACE_COMPILE_OPTIONS "${libxmp_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${libxmp_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${libxmp_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${libxmp_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findmodplug.cmake
+++ b/cmake/Findmodplug.cmake
@@ -1,5 +1,8 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_MODPLUG QUIET libmodplug)
+
 find_library(modplug_LIBRARY
     NAMES modplug
 )
@@ -8,11 +11,17 @@ find_path(modplug_INCLUDE_PATH
     NAMES libmodplug/modplug.h
 )
 
-set(modplug_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of modplug")
+if(PC_MODPLUG_FOUND)
+    get_flags_from_pkg_config("${modplug_LIBRARY}" "PC_MODPLUG" "_modplug")
+endif()
 
-set(modplug_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of modplug")
+set(modplug_COMPILE_OPTIONS "${_modplug_compile_options}" CACHE STRING "Extra compile options of modplug")
 
-set(modplug_LINK_OPTIONS "" CACHE STRING "Extra link flags of modplug")
+set(modplug_LINK_LIBRARIES "${_modplug_link_libraries}" CACHE STRING "Extra link libraries of modplug")
+
+set(modplug_LINK_OPTIONS "${_modplug_link_options}" CACHE STRING "Extra link flags of modplug")
+
+set(modplug_LINK_DIRECTORIES "${_modplug_link_directories}" CACHE PATH "Extra link directories of modplug")
 
 find_package_handle_standard_args(modplug
     REQUIRED_VARS modplug_LIBRARY modplug_INCLUDE_PATH
@@ -28,6 +37,7 @@ if (modplug_FOUND)
             INTERFACE_COMPILE_OPTIONS "${modplug_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${modplug_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${modplug_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${modplug_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findmodplug.cmake
+++ b/cmake/Findmodplug.cmake
@@ -12,7 +12,7 @@ set(modplug_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of modplug")
 
 set(modplug_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of modplug")
 
-set(modplug_LINK_FLAGS "" CACHE STRING "Extra link flags of modplug")
+set(modplug_LINK_OPTIONS "" CACHE STRING "Extra link flags of modplug")
 
 find_package_handle_standard_args(modplug
     REQUIRED_VARS modplug_LIBRARY modplug_INCLUDE_PATH
@@ -27,7 +27,7 @@ if (modplug_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${modplug_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${modplug_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${modplug_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${modplug_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${modplug_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findmpg123.cmake
+++ b/cmake/Findmpg123.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_MPG123 QUIET libmpg123)
+
 find_library(mpg123_LIBRARY
     NAMES mpg123
+    HINTS ${PC_MPG123_LIBDIR}
 )
 
 find_path(mpg123_INCLUDE_PATH
     NAMES mpg123.h
+    HINTS ${PC_MPG123_INCLUDEDIR}
 )
 
-set(mpg123_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of mpg123")
+if(PC_MPG123_FOUND)
+    get_flags_from_pkg_config("${mpg123_LIBRARY}" "PC_MPG123" "_mpg123")
+endif()
 
-set(mpg123_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of mpg123")
+set(mpg123_COMPILE_OPTIONS "${_mpg123_compile_options}" CACHE STRING "Extra compile options of mpg123")
 
-set(mpg123_LINK_OPTIONS "" CACHE STRING "Extra link flags of mpg123")
+set(mpg123_LINK_LIBRARIES "${_mpg123_link_libraries}" CACHE STRING "Extra link libraries of mpg123")
+
+set(mpg123_LINK_OPTIONS "${_mpg123_link_options}" CACHE STRING "Extra link flags of mpg123")
+
+set(mpg123_LINK_DIRECTORIES "${_mpg123_link_directories}" CACHE PATH "Extra link directories of mpg123")
 
 find_package_handle_standard_args(mpg123
     REQUIRED_VARS mpg123_LIBRARY mpg123_INCLUDE_PATH
@@ -27,6 +38,7 @@ if(mpg123_FOUND)
             INTERFACE_COMPILE_OPTIONS "${mpg123_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${mpg123_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${mpg123_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${mpg123_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findmpg123.cmake
+++ b/cmake/Findmpg123.cmake
@@ -12,7 +12,7 @@ set(mpg123_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of mpg123")
 
 set(mpg123_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of mpg123")
 
-set(mpg123_LINK_FLAGS "" CACHE STRING "Extra link flags of mpg123")
+set(mpg123_LINK_OPTIONS "" CACHE STRING "Extra link flags of mpg123")
 
 find_package_handle_standard_args(mpg123
     REQUIRED_VARS mpg123_LIBRARY mpg123_INCLUDE_PATH
@@ -26,7 +26,7 @@ if(mpg123_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${mpg123_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${mpg123_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${mpg123_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${mpg123_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${mpg123_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findtremor.cmake
+++ b/cmake/Findtremor.cmake
@@ -1,18 +1,29 @@
 include(FindPackageHandleStandardArgs)
 
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_TREMOR QUIET vorbisidec)
+
 find_library(tremor_LIBRARY
     NAMES vorbisidec libvorbisidec
+    HINTS ${PC_TREMOR_LIBDIR}
 )
 
 find_path(tremor_INCLUDE_PATH
     NAMES tremor/ivorbisfile.h
+    HINTS ${PC_TREMOR_INCLUDEDIR}
 )
 
-set(tremor_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of vorbis")
+if(PC_TREMOR_FOUND)
+    get_flags_from_pkg_config("${tremor_LIBRARY}" "PC_TREMOR" "_tremor")
+endif()
 
-set(tremor_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of vorbis")
+set(tremor_COMPILE_OPTIONS "${_tremor_compile_options}" CACHE STRING "Extra compile options of vorbis")
 
-set(tremor_LINK_OPTIONS "" CACHE STRING "Extra link flags of vorbis")
+set(tremor_LINK_LIBRARIES "${_tremor_link_libraries}" CACHE STRING "Extra link libraries of vorbis")
+
+set(tremor_LINK_OPTIONS "${_tremor_link_options}" CACHE STRING "Extra link flags of vorbis")
+
+set(tremor_LINK_DIRECTORIES "${_tremor_link_directories}" CACHE PATH "Extra link directories of vorbis")
 
 find_package_handle_standard_args(tremor
     REQUIRED_VARS tremor_LIBRARY tremor_INCLUDE_PATH
@@ -27,6 +38,7 @@ if (tremor_FOUND)
             INTERFACE_COMPILE_OPTIONS "${tremor_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${tremor_LINK_LIBRARIES}"
             INTERFACE_LINK_OPTIONS "${tremor_LINK_OPTIONS}"
+            INTERFACE_LINK_DIRECTORIES "${tremor_LINK_DIRECTORIES}"
         )
     endif()
 endif()

--- a/cmake/Findtremor.cmake
+++ b/cmake/Findtremor.cmake
@@ -12,7 +12,7 @@ set(tremor_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of vorbis")
 
 set(tremor_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of vorbis")
 
-set(tremor_LINK_FLAGS "" CACHE STRING "Extra link flags of vorbis")
+set(tremor_LINK_OPTIONS "" CACHE STRING "Extra link flags of vorbis")
 
 find_package_handle_standard_args(tremor
     REQUIRED_VARS tremor_LIBRARY tremor_INCLUDE_PATH
@@ -26,7 +26,7 @@ if (tremor_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${tremor_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${tremor_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${tremor_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${tremor_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${tremor_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findwavpack.cmake
+++ b/cmake/Findwavpack.cmake
@@ -17,7 +17,7 @@ set(wavpack_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of wavpack")
 
 set(wavpack_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of wavpack")
 
-set(wavpack_LINK_FLAGS "" CACHE STRING "Extra link flags of wavpack")
+set(wavpack_LINK_OPTIONS "" CACHE STRING "Extra link flags of wavpack")
 
 find_package_handle_standard_args(wavpack
     REQUIRED_VARS wavpack_LIBRARY wavpack_INCLUDE_PATH
@@ -31,7 +31,7 @@ if (wavpack_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${wavpack_INCLUDE_PATH}"
             INTERFACE_COMPILE_OPTIONS "${wavpack_COMPILE_OPTIONS}"
             INTERFACE_LINK_LIBRARIES "${wavpack_LINK_LIBRARIES}"
-            INTERFACE_LINK_FLAGS "${wavpack_LINK_FLAGS}"
+            INTERFACE_LINK_OPTIONS "${wavpack_LINK_OPTIONS}"
         )
     endif()
 endif()

--- a/cmake/Findwavpack.cmake
+++ b/cmake/Findwavpack.cmake
@@ -1,7 +1,7 @@
 include(FindPackageHandleStandardArgs)
 
 if(WIN32)
-    set(wavpack_find_names wavpack wavpackdll)
+    set(wavpack_find_names wavpack libwavpack wavpackdll)
 else()
     set(wavpack_find_names wavpack)
 endif()

--- a/cmake/PkgConfigHelper.cmake
+++ b/cmake/PkgConfigHelper.cmake
@@ -1,0 +1,34 @@
+# Helper for Find modules
+
+function(get_flags_from_pkg_config _library _pc_prefix _out_prefix)
+  if("${_library}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+    set(_cflags ${_pc_prefix}_STATIC_CFLAGS_OTHER)
+    set(_link_libraries ${_pc_prefix}_STATIC_LIBRARIES)
+    set(_link_options ${_pc_prefix}_STATIC_LDFLAGS_OTHER)
+    set(_library_dirs ${_pc_prefix}_STATIC_LIBRARY_DIRS)
+  else()
+    set(_cflags ${_pc_prefix}_CFLAGS_OTHER)
+    set(_link_libraries ${_pc_prefix}_LIBRARIES)
+    set(_link_options ${_pc_prefix}_LDFLAGS_OTHER)
+    set(_library_dirs ${_pc_prefix}_LIBRARY_DIRS)
+  endif()
+
+  # The *_LIBRARIES lists always start with the library itself
+  list(POP_FRONT "${_link_libraries}")
+
+  # Work around CMake's flag deduplication when pc files use `-framework A` instead of `-Wl,-framework,A`
+  string(REPLACE "-framework;" "-Wl,-framework," "_filtered_link_options" "${${_link_options}}")
+
+  set(${_out_prefix}_compile_options
+      "${${_cflags}}"
+      PARENT_SCOPE)
+  set(${_out_prefix}_link_libraries
+      "${${_link_libraries}}"
+      PARENT_SCOPE)
+  set(${_out_prefix}_link_options
+      "${_filtered_link_options}"
+      PARENT_SCOPE)
+  set(${_out_prefix}_link_directories
+      "${${_library_dirs}}"
+      PARENT_SCOPE)
+endfunction()

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -62,6 +62,10 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
     include(CMakeFindDependencyMacro)
     include(PkgConfigHelper)
 
+    if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+    endif()
+
     if(SDL3MIXER_SNDFILE AND NOT SDL3MIXER_VENDORED AND NOT TARGET SndFile::sndfile)
         find_dependency(SndFile)
     endif()

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -62,10 +62,6 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
     include(CMakeFindDependencyMacro)
     include(PkgConfigHelper)
 
-    if(VCPKG_TOOLCHAIN OR CONAN_CMD)
-        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-    endif()
-
     if(SDL3MIXER_SNDFILE AND NOT SDL3MIXER_VENDORED AND NOT TARGET SndFile::sndfile)
         find_dependency(SndFile)
     endif()

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -60,6 +60,7 @@ endif()
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
 
     include(CMakeFindDependencyMacro)
+    include(PkgConfigHelper)
 
     if(SDL3MIXER_SNDFILE AND NOT SDL3MIXER_VENDORED AND NOT TARGET SndFile::sndfile)
         find_dependency(SndFile)

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -1,5 +1,7 @@
 # sdl3_mixer cmake project-config input for CMakeLists.txt script
 
+@PACKAGE_INIT@
+
 include(FeatureSummary)
 set_package_properties(SDL3_mixer PROPERTIES
     URL "https://www.libsdl.org/projects/SDL_mixer/"
@@ -117,3 +119,5 @@ if(NOT SDL3MIXER_VENDORED)
     set(CMAKE_MODULE_PATH "${_sdl_cmake_module_path}")
     unset(_sdl_cmake_module_path)
 endif()
+
+check_required_components(SDL3_mixer)

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -80,10 +80,10 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
     endif()
 
     if(SDL3MIXER_MP3_MPG123 AND NOT SDL3MIXER_VENDORED AND NOT TARGET MPG123::mpg123)
-        find_dependency(MPG123)
+        find_dependency(mpg123)
     endif()
 
-    if(SDL3MIXER_MIDI_FLUIDSYNTH AND NOT SDL3MIXER_VENDORED AND NOT TARGET FluidSynth::FluidSynth)
+    if(SDL3MIXER_MIDI_FLUIDSYNTH AND NOT SDL3MIXER_VENDORED AND NOT TARGET FluidSynth::libfluidsynth)
         find_dependency(FluidSynth)
     endif()
 
@@ -95,7 +95,7 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
         find_dependency(Vorbis)
     endif()
 
-    if(SDL3MIXER_OPUS AND NOT SDL3MIXER_VENDORED AND NOT TARGET opusfile::opusfile)
+    if(SDL3MIXER_OPUS AND NOT SDL3MIXER_VENDORED AND NOT TARGET OpusFile::opusfile)
         find_dependency(OpusFile)
     endif()
 

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -62,6 +62,10 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
     include(CMakeFindDependencyMacro)
     include(PkgConfigHelper)
 
+    if(VCPKG_TOOLCHAIN OR CONAN_CMD)
+        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+    endif()
+
     if(SDL3MIXER_SNDFILE AND NOT SDL3MIXER_VENDORED AND NOT TARGET SndFile::sndfile)
         find_dependency(SndFile)
     endif()


### PR DESCRIPTION
## Description

This PR brings a set of changes that should help searching for dependencies. Feedback is greatly appreciated!

Here is a summary of the changes.

### 1. Matching the name with upstream

FluidSynth exports the target `FluidSynth::libfluidsynth`.

In the exported config, the casing of `find_dependency(MPG123)` should be `mpg123`, and `opusfile::opusfile` should be `OpusFile::opusfile`.

### 2. Add `@PACKAGE_INIT@` to the config template

While the config file was already configured using the `configure_package_config_file` helper, it did not have a `@PACKAGE_INIT@`.

When expanded, it provides the `set_and_check` and `check_required_components` macros, as well as setting `PACKAGE_PREFIX_DIR` to the correct directory.

### 3. Correct `INTERFACE_LINK_FLAGS`

This property [does not seem to exist](https://cmake.org/cmake/help/latest/search.html?q=INTERFACE_LINK_FLAGS). The `INTERFACE_LINK_OPTIONS` property seems to be what was wanted ([doc](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_LINK_OPTIONS.html)).

### 4. Get help from pkg-config when available

While a user can manually set for a dependency the `Foo_COMPILE_OPTIONS`, `Foo_LINK_LIBRARIES`, and `Foo_LINK_OPTIONS` to provide the usage requirements, we can use pkg-config when available to pre-fill these cache variables.

This works as follows:
- call `find_package(PkgConfig QUIET)`, we want the search to be quiet as this is just optional help
- search for the module `pkg_check_modules(PC_FOO QUIET foo)`, similarly we want the search to be quiet. Note that it is not necessary to guard this call with `PKG_CONFIG_FOUND`, if pkg-config is not found this call will simply be ignored.
- use the `get_flags_from_pkg_config("${Foo_LIBRARY}" "PC_FOO" "_foo")` helper to get the appropriate set of flags. We use the library suffix to infer whether we should take the static or dynamic flags and prefix them with `_foo`.
- Use these variables to initialise the `Foo_COMPILE_OPTIONS`, `Foo_LINK_LIBRARIES`, `Foo_LINK_OPTIONS`, and `Foo_LINK_DIRECTORIES` cache variables. If pkg-config is unavailable they will simply be empty as they currently are.

For this to work better, the policy [CMP0099](https://cmake.org/cmake/help/latest/policy/CMP0099.html) is set to `NEW`. This covers this very specific use case:
- Have libogg installed in a non-standard directory such as `/opt/my_libs`
- Build libflac statically with this custom libogg.
- Build SDL_mixer statically with examples.
- Build fails due to `ogg not found` 

While `FLAC::FLAC`'s `INTERFACE_LINK_DIRECTORIES` will be properly set `/opt/my_libs`, this will not be propagated unless `CMP0099` is set to `NEW`

### 5. Add logic when vcpkg or conan is used

When either vcpkg or conan is used:
- Turn off vendored libraries by default
- Set `CMAKE_FIND_PACKAGE_PREFER_CONFIG` to `ON`

The latter option makes CMake prioritise using `*-config.cmake`/`*Config.cmake` over the find modules. Both package managers install the upstream CMake config when available, which will commonly include the usage requirements.

### 6. Add alternative names for libraries

Most notably on Windows, static builds of libraries may have a different name from their shared counterpart. For example, a static build of FluidSynth on Windows will produce `libfluidsynth.lib` which would not be found.

---

## Testing

The changes were tested on:
- macOS
  - Using shared libraries provided by Homebrew
  - Using static libraries provided by vcpkg
- Windows
  - Using the `x64-windows` triplet on vcpkg
  - Using the `x64-windows-static` triplet on vcpkg
- 3DS Hombrew
  Platform such as this one that only support static linking and which do not have vcpkg support benefit a lot from the help provided by pkg-config. Previously, making a build with libFLAC, tremor, and opusfile would be a dependency nightmare for linking, but with these changes, the linking process is now trivial. I expect a similar situation for PSP and PSVita Homebrew.