### PR TITLE
Change FluidSynth maximum gain to 1.0 to avoid possible clicks in MIDI music

### DIFF
--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -259,9 +259,9 @@ static void *FLUIDSYNTH_CreateFromRW(SDL_RWops *src, int freesrc)
 static void FLUIDSYNTH_SetVolume(void *context, int volume)
 {
     FLUIDSYNTH_Music *music = (FLUIDSYNTH_Music *)context;
-    /* FluidSynth's default is 0.2. Make 1.2 the maximum. */
+    /* FluidSynth's default gain is 0.2. Make 1.0 the maximum gain value to avoid sound overload. */
     music->volume = volume;
-    fluidsynth.fluid_synth_set_gain(music->synth, (float) (volume * 1.2 / MIX_MAX_VOLUME));
+    fluidsynth.fluid_synth_set_gain(music->synth, (float) (volume * 1.0 / MIX_MAX_VOLUME));
 }
 
 static int FLUIDSYNTH_GetVolume(void *context)


### PR DESCRIPTION
Hello everyone!

This PR makes FluidSynth to adjust volume gain in interval from 0 to 1.0 instead of 0 to 1.2.
It is done to avoid possible clicks in MIDI music and have music loudness the same as for other MIDI playback engines.

The issue of clicks in MIDI music is discussed in https://github.com/ihhub/fheroes2/issues/6429#issuecomment-1478565944 and it is reproduced when the music volume is set to the value, more than 0.8 of the maximum value (`MIX_MAX_VOLUME`). 

This PR is also related to one phrase in #284:
> I also find Fluidsynth to be much louder than other MIDI playback engines.

As SDL_mixer can use many MIDI playback engines it will be good if their gain level will be approximately the same.