### PR TITLE
[SDL2] Fixed detection of FLAC files with ID3 tag at begin

### DIFF
--- a/src/codecs/mp3utils.c
+++ b/src/codecs/mp3utils.c
@@ -1173,4 +1173,29 @@ int read_id3v2_from_mem(Mix_MusicMetaTags *out_tags, Uint8 *data, size_t length)
     }
     return -1;
 }
+
+long get_id3v2_length(SDL_RWops *src)
+{
+    Uint8 buf[TAGS_INPUT_BUFFER_SIZE];
+    size_t readsize;
+    Sint64 start;
+
+    if(!src) {
+        return -1;
+    }
+
+    start = SDL_RWtell(src);
+    readsize = SDL_RWread(src, buf, 1, TAGS_INPUT_BUFFER_SIZE);
+    SDL_RWseek(src, start, RW_SEEK_SET);
+
+    if (!readsize) {
+        return -1;
+    }
+
+    if (!is_id3v2(buf, readsize)) {
+        return -1;
+    }
+
+    return get_id3v2_len(buf, (long)readsize);
+}
 #endif /* ENABLE_ID3V2_TAG */

--- a/src/codecs/mp3utils.h
+++ b/src/codecs/mp3utils.h
@@ -42,6 +42,7 @@ extern int mp3_read_tags(Mix_MusicMetaTags *out_tags, struct mp3file_t *fil, SDL
 
 #ifdef ENABLE_ID3V2_TAG
 extern int read_id3v2_from_mem(Mix_MusicMetaTags *out_tags, Uint8 *data, size_t length);
+extern long get_id3v2_length(SDL_RWops *src);
 #endif
 
 #ifdef ENABLE_ALL_MP3_TAGS


### PR DESCRIPTION
Recently I found that some FLAC files won't play at all. I had checked, and I found it begins with an ID3 tag. Also, I checked around the stuff, and it's not a paranomrmal mess of Audacity: it's one of legacy forms of FLAC files that used ID3 tags at begin.

There is a comment where I explained about this a first time: https://github.com/WohlSoft/SDL-Mixer-X/commit/94e87503c80cc0311dfedb370e21d25573492e33

Example file (I exported it in 2019'th year by the old version of Audacity): [Fox fantasy.mid-battle-chess-gmized.flac.zip](https://github.com/libsdl-org/SDL_mixer/files/11607303/Fox.fantasy.mid-battle-chess-gmized.flac.zip)
