### PR TITLE
Updated for new SDL3 audio API.

### DIFF
--- a/examples/playmus.c
+++ b/examples/playmus.c
@@ -113,10 +113,6 @@ static void IntHandler(int sig)
 
 int main(int argc, char *argv[])
 {
-    int audio_rate;
-    Uint16 audio_format;
-    int audio_channels;
-    int audio_buffers;
     int audio_volume = MIX_MAX_VOLUME;
     int looping = 0;
     int interactive = 0;
@@ -128,31 +124,31 @@ int main(int argc, char *argv[])
     const char *tag_album = NULL;
     const char *tag_copyright = NULL;
     double loop_start, loop_end, loop_length, current_position;
+    SDL_AudioSpec spec;
 
     (void) argc;
 
     /* Initialize variables */
-    audio_rate = MIX_DEFAULT_FREQUENCY;
-    audio_format = MIX_DEFAULT_FORMAT;
-    audio_channels = MIX_DEFAULT_CHANNELS;
-    audio_buffers = 4096;
+    spec.freq = MIX_DEFAULT_FREQUENCY;
+    spec.format = MIX_DEFAULT_FORMAT;
+    spec.channels = MIX_DEFAULT_CHANNELS;
 
     /* Check command line usage */
     for (i=1; argv[i] && (*argv[i] == '-'); ++i) {
         if ((SDL_strcmp(argv[i], "-r") == 0) && argv[i+1]) {
             ++i;
-            audio_rate = SDL_atoi(argv[i]);
+            spec.freq = SDL_atoi(argv[i]);
         } else
         if (SDL_strcmp(argv[i], "-m") == 0) {
-            audio_channels = 1;
+            spec.channels = 1;
         } else
         if ((SDL_strcmp(argv[i], "-c") == 0) && argv[i+1]) {
             ++i;
-            audio_channels = SDL_atoi(argv[i]);
+            spec.channels = SDL_atoi(argv[i]);
         } else
         if ((SDL_strcmp(argv[i], "-b") == 0) && argv[i+1]) {
             ++i;
-            audio_buffers = SDL_atoi(argv[i]);
+            /*ignored now. audio_buffers = SDL_atoi(argv[i]); */
         } else
         if ((SDL_strcmp(argv[i], "-v") == 0) && argv[i+1]) {
             ++i;
@@ -165,10 +161,10 @@ int main(int argc, char *argv[])
             interactive = 1;
         } else
         if (SDL_strcmp(argv[i], "-8") == 0) {
-            audio_format = SDL_AUDIO_U8;
+            spec.format = SDL_AUDIO_U8;
         } else
         if (SDL_strcmp(argv[i], "-f32") == 0) {
-            audio_format = SDL_AUDIO_F32;
+            spec.format = SDL_AUDIO_F32;
         } else
         if (SDL_strcmp(argv[i], "-rwops") == 0) {
             rwops = 1;
@@ -194,16 +190,16 @@ int main(int argc, char *argv[])
 #endif
 
     /* Open the audio device */
-    if (Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers) < 0) {
+
+    if (Mix_OpenAudio(0, &spec) < 0) {
         SDL_Log("Couldn't open audio: %s\n", SDL_GetError());
         return(2);
     } else {
-        Mix_QuerySpec(&audio_rate, &audio_format, &audio_channels);
-        SDL_Log("Opened audio at %d Hz %d bit%s %s %d bytes audio buffer\n", audio_rate,
-            (audio_format&0xFF),
-            (SDL_AUDIO_ISFLOAT(audio_format) ? " (float)" : ""),
-            (audio_channels > 2) ? "surround" : (audio_channels > 1) ? "stereo" : "mono",
-            audio_buffers);
+        Mix_QuerySpec(&spec.freq, &spec.format, &spec.channels);
+        SDL_Log("Opened audio at %d Hz %d bit%s %s audio buffer\n", spec.freq,
+            (spec.format&0xFF),
+            (SDL_AUDIO_ISFLOAT(spec.format) ? " (float)" : ""),
+            (spec.channels > 2) ? "surround" : (spec.channels > 1) ? "stereo" : "mono");
     }
     audio_open = 1;
 

--- a/examples/playwave.c
+++ b/examples/playwave.c
@@ -357,9 +357,7 @@ static void flip_sample(Mix_Chunk *wave)
 
 int main(int argc, char *argv[])
 {
-    int audio_rate;
-    Uint16 audio_format;
-    int audio_channels;
+    SDL_AudioSpec spec;
     int loops = 0;
     int i;
     int reverse_stereo = 0;
@@ -374,31 +372,31 @@ int main(int argc, char *argv[])
     output_test_warnings();
 
     /* Initialize variables */
-    audio_rate = MIX_DEFAULT_FREQUENCY;
-    audio_format = MIX_DEFAULT_FORMAT;
-    audio_channels = MIX_DEFAULT_CHANNELS;
+    spec.freq = MIX_DEFAULT_FREQUENCY;
+    spec.format = MIX_DEFAULT_FORMAT;
+    spec.channels = MIX_DEFAULT_CHANNELS;
 
     /* Check command line usage */
     for (i=1; argv[i] && (*argv[i] == '-'); ++i) {
         if ((SDL_strcmp(argv[i], "-r") == 0) && argv[i+1]) {
             ++i;
-            audio_rate = SDL_atoi(argv[i]);
+            spec.freq = SDL_atoi(argv[i]);
         } else
         if (SDL_strcmp(argv[i], "-m") == 0) {
-            audio_channels = 1;
+            spec.channels = 1;
         } else
         if ((SDL_strcmp(argv[i], "-c") == 0) && argv[i+1]) {
             ++i;
-            audio_channels = SDL_atoi(argv[i]);
+            spec.channels = SDL_atoi(argv[i]);
         } else
         if (SDL_strcmp(argv[i], "-l") == 0) {
             loops = -1;
         } else
         if (SDL_strcmp(argv[i], "-8") == 0) {
-            audio_format = SDL_AUDIO_U8;
+            spec.format = SDL_AUDIO_U8;
         } else
         if (SDL_strcmp(argv[i], "-f32") == 0) {
-            audio_format = SDL_AUDIO_F32;
+            spec.format = SDL_AUDIO_F32;
         } else
         if (SDL_strcmp(argv[i], "-f") == 0) { /* rcg06122001 flip stereo */
             reverse_stereo = 1;
@@ -426,16 +424,16 @@ int main(int argc, char *argv[])
 #endif
 
     /* Open the audio device */
-    if (Mix_OpenAudio(audio_rate, audio_format, audio_channels, 4096) < 0) {
+    if (Mix_OpenAudio(0, &spec) < 0) {
         SDL_Log("Couldn't open audio: %s\n", SDL_GetError());
         CleanUp(2);
     } else {
-        Mix_QuerySpec(&audio_rate, &audio_format, &audio_channels);
-        SDL_Log("Opened audio at %d Hz %d bit%s %s", audio_rate,
-            (audio_format&0xFF),
-            (SDL_AUDIO_ISFLOAT(audio_format) ? " (float)" : ""),
-            (audio_channels > 2) ? "surround" :
-            (audio_channels > 1) ? "stereo" : "mono");
+        Mix_QuerySpec(&spec.freq, &spec.format, &spec.channels);
+        SDL_Log("Opened audio at %d Hz %d bit%s %s", spec.freq,
+            (spec.format&0xFF),
+            (SDL_AUDIO_ISFLOAT(spec.format) ? " (float)" : ""),
+            (spec.channels > 2) ? "surround" :
+            (spec.channels > 1) ? "stereo" : "mono");
         if (loops) {
           SDL_Log(" (looping)\n");
         } else {

--- a/include/SDL3/SDL_mixer.h
+++ b/include/SDL3/SDL_mixer.h
@@ -272,100 +272,7 @@ typedef enum {
 typedef struct _Mix_Music Mix_Music;
 
 /**
- * Open the default audio device for playback.
- *
- * An audio device is what generates sound, so the app must open one to make
- * noise.
- *
- * This function will check if SDL's audio system is initialized, and if not,
- * it will initialize it by calling `SDL_Init(SDL_INIT_AUDIO)` on your behalf.
- * You are free to (and encouraged to!) initialize it yourself before calling
- * this function, as this gives your program more control over the process.
- *
- * This function might cover all of an application's needs, but for those that
- * need more flexibility, the more powerful version of this function is
- * Mix_OpenAudioDevice(). This function is equivalent to calling:
- *
- * ```c
- * Mix_OpenAudioDevice(frequency, format, nchannels, chunksize, NULL,
- *                     SDL_AUDIO_ALLOW_FREQUENCY_CHANGE |
- *                     SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
- * ```
- *
- * If you aren't particularly concerned with the specifics of the audio
- * device, and your data isn't in a specific format, the values you use here
- * can just be reasonable defaults. SDL_mixer will convert audio data you feed
- * it to the correct format on demand.
- *
- * That being said, if you have control of your audio data and you know its
- * format ahead of time, you can save CPU time by opening the audio device in
- * that exact format so SDL_mixer does not have to spend time converting
- * anything behind the scenes, and can just pass the data straight through to
- * the hardware. On some platforms, where the hardware only supports specific
- * settings, you might have to be careful to make everything match, but your
- * own data is often easier to control, so aim to open the device for what you
- * need.
- *
- * The other reason to care about specific formats: if you plan to touch the
- * mix buffer directly (with Mix_SetPostMix, a registered effect, or
- * Mix_HookMusic), you might have code that expects it to be in a specific
- * format, and you should specify that here.
- *
- * The audio device frequency is specified in Hz; in modern times, 48000 is
- * often a reasonable default.
- *
- * The audio device format is one of SDL's SDL_AUDIO_* constants.
- * SDL_AUDIO_S16SYS (16-bit audio) is probably a safe default. More modern
- * systems may prefer SDL_AUDIO_F32SYS (32-bit floating point audio).
- *
- * The audio device channels are generally 1 for mono output, or 2 for stereo,
- * but the brave can try surround sound configs with 4 (quad), 6 (5.1), 7
- * (6.1) or 8 (7.1).
- *
- * The audio device's chunk size is the number of sample frames (one sample
- * per frame for mono output, two samples per frame in a stereo setup, etc)
- * that are fed to the device at once. The lower the number, the lower the
- * latency, but you risk dropouts if it gets too low. 2048 is often a
- * reasonable default, but your app might want to experiment with 1024 or
- * 4096.
- *
- * You may only have one audio device open at a time; if you want to change a
- * setting, you must close the device and reopen it, which is not something
- * you can do seamlessly during playback.
- *
- * This function does not allow you to select a specific audio device on the
- * system, it always chooses the best default it can on your behalf (which, in
- * many cases, is exactly what you want anyhow). If you must choose a specific
- * device, you can do so with Mix_OpenAudioDevice() instead.
- *
- * If this function reports success, you are ready to start making noise! Load
- * some audio data and start playing!
- *
- * The app can use Mix_QuerySpec() to determine the final device settings.
- *
- * When done with an audio device, probably at the end of the program, the app
- * should dispose of the device with Mix_CloseAudio().
- *
- * \param frequency the frequency to playback audio at (in Hz).
- * \param format audio format, one of SDL's SDL_AUDIO_* values.
- * \param channels number of channels (1 is mono, 2 is stereo, etc).
- * \param chunksize audio buffer size in sample FRAMES (total samples divided
- *                  by channel count).
- * \returns 0 if successful, -1 on error.
- *
- * \since This function is available since SDL_mixer 2.0.0.
- *
- * \sa Mix_OpenAudioDevice
- * \sa Mix_CloseAudio
- */
-extern DECLSPEC int SDLCALL Mix_OpenAudio(int frequency, Uint16 format, int channels, int chunksize);
-
-
-/**
- * Open a specific audio device for playback.
- *
- * (A slightly simpler version of this function is available in
- * Mix_OpenAudio(), which still might meet most applications' needs.)
+ * Open an audio device for playback.
  *
  * An audio device is what generates sound, so the app must open one to make
  * noise.
@@ -376,70 +283,35 @@ extern DECLSPEC int SDLCALL Mix_OpenAudio(int frequency, Uint16 format, int chan
  * this function, as this gives your program more control over the process.
  *
  * If you aren't particularly concerned with the specifics of the audio
- * device, and your data isn't in a specific format, the values you use here
- * can just be reasonable defaults. SDL_mixer will convert audio data you feed
- * it to the correct format on demand.
+ * device, and your data isn't in a specific format, you can pass a NULL for
+ * the `spec` parameter and SDL_mixer will choose a reasonable default.
+ * SDL_mixer will convert audio data you feed it to the hardware's format
+ * behind the scenes.
  *
  * That being said, if you have control of your audio data and you know its
- * format ahead of time, you can save CPU time by opening the audio device in
+ * format ahead of time, you may save CPU time by opening the audio device in
  * that exact format so SDL_mixer does not have to spend time converting
  * anything behind the scenes, and can just pass the data straight through to
- * the hardware. On some platforms, where the hardware only supports specific
- * settings, you might have to be careful to make everything match, but your
- * own data is often easier to control, so aim to open the device for what you
- * need.
+ * the hardware.
  *
  * The other reason to care about specific formats: if you plan to touch the
  * mix buffer directly (with Mix_SetPostMix, a registered effect, or
  * Mix_HookMusic), you might have code that expects it to be in a specific
  * format, and you should specify that here.
- *
- * The audio device frequency is specified in Hz; in modern times, 48000 is
- * often a reasonable default.
- *
- * The audio device format is one of SDL's SDL_AUDIO_* constants.
- * SDL_AUDIO_S16SYS (16-bit audio) is probably a safe default. More modern
- * systems may prefer SDL_AUDIO_F32SYS (32-bit floating point audio).
- *
- * The audio device channels are generally 1 for mono output, or 2 for stereo,
- * but the brave can try surround sound configs with 4 (quad), 6 (5.1), 7
- * (6.1) or 8 (7.1).
- *
- * The audio device's chunk size is the number of sample frames (one sample
- * per frame for mono output, two samples per frame in a stereo setup, etc)
- * that are fed to the device at once. The lower the number, the lower the
- * latency, but you risk dropouts if it gets too low. 2048 is often a
- * reasonable default, but your app might want to experiment with 1024 or
- * 4096.
  *
  * You may only have one audio device open at a time; if you want to change a
  * setting, you must close the device and reopen it, which is not something
  * you can do seamlessly during playback.
  *
  * This function allows you to select specific audio hardware on the system
- * with the `device` parameter. If you specify NULL, SDL_mixer will choose the
+ * with the `devid` parameter. If you specify 0, SDL_mixer will choose the
  * best default it can on your behalf (which, in many cases, is exactly what
- * you want anyhow). SDL_mixer does not offer a mechanism to determine device
- * names to open, but you can use SDL_GetNumAudioDevices() to get a count of
- * available devices and then SDL_GetAudioDeviceName() in a loop to obtain a
- * list. If you do this, be sure to call `SDL_Init(SDL_INIT_AUDIO)` first to
- * initialize SDL's audio system!
- *
- * The `allowed_changes` parameter specifies what settings are flexible. These
- * are the `SDL_AUDIO_ALLOW_*` flags from SDL. These tell SDL_mixer that the
- * app doesn't mind if a specific setting changes. For example, the app might
- * need stereo data in Sint16 format, but if the sample rate or chunk size
- * changes, the app can handle that. In that case, the app would specify
- * `SDL_AUDIO_ALLOW_FORMAT_CHANGE|SDL_AUDIO_ALLOW_SAMPLES_CHANGE`. In this
- * case, if the system's hardware requires something other than the requested
- * format, SDL_mixer can select what the hardware demands instead of the app.
- * If the `SDL_AUDIO_ALLOW_` flag is not specified, SDL_mixer must convert
- * data behind the scenes between what the app demands and what the hardware
- * requires. If your app needs precisely what is requested, specify zero for
- * `allowed_changes`.
- *
- * If changes were allowed, the app can use Mix_QuerySpec() to determine the
- * final device settings.
+ * you want anyhow). This is equivalent to specifying
+ * `SDL_AUDIO_DEVICE_DEFAULT_OUTPUT`, but is less wordy. SDL_mixer does not
+ * offer a mechanism to determine device IDs to open, but you can use
+ * SDL_GetAudioOutputDevices() to get a list of available devices. If you do
+ * this, be sure to call `SDL_Init(SDL_INIT_AUDIO)` first to initialize SDL's
+ * audio system!
  *
  * If this function reports success, you are ready to start making noise! Load
  * some audio data and start playing!
@@ -447,14 +319,8 @@ extern DECLSPEC int SDLCALL Mix_OpenAudio(int frequency, Uint16 format, int chan
  * When done with an audio device, probably at the end of the program, the app
  * should dispose of the device with Mix_CloseDevice().
  *
- * \param frequency the frequency to playback audio at (in Hz).
- * \param format audio format, one of SDL's SDL_AUDIO_* values.
- * \param channels number of channels (1 is mono, 2 is stereo, etc).
- * \param chunksize audio buffer size in sample FRAMES (total samples divided
- *                  by channel count).
- * \param device the device name to open, or NULL to choose a reasonable
- *               default.
- * \param allowed_changes Allow change flags (see SDL_AUDIO_ALLOW_* flags)
+ * \param devid the device name to open, or 0 for a reasonable default.
+ * \param spec the audio format you'd like SDL_mixer to work in.
  * \returns 0 if successful, -1 on error.
  *
  * \since This function is available since SDL_mixer 2.0.2.
@@ -463,7 +329,7 @@ extern DECLSPEC int SDLCALL Mix_OpenAudio(int frequency, Uint16 format, int chan
  * \sa Mix_CloseDevice
  * \sa Mix_QuerySpec
  */
-extern DECLSPEC int SDLCALL Mix_OpenAudioDevice(int frequency, Uint16 format, int channels, int chunksize, const char* device, int allowed_changes);
+extern DECLSPEC int SDLCALL Mix_OpenAudio(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec);
 
 /**
  * Suspend or resume the whole audio output.

--- a/src/codecs/load_aiff.c
+++ b/src/codecs/load_aiff.c
@@ -227,7 +227,6 @@ SDL_AudioSpec *Mix_LoadAIFF_RW (SDL_RWops *src, SDL_bool freesrc,
             goto done;
     }
     spec->channels = (Uint8) channels;
-    spec->samples = 4096;       /* Good default buffer size */
 
     *audio_len = channels * numsamples * (samplesize / 8);
     *audio_buf = (Uint8 *)SDL_malloc(*audio_len);

--- a/src/codecs/load_voc.c
+++ b/src/codecs/load_voc.c
@@ -450,8 +450,6 @@ SDL_AudioSpec *Mix_LoadVOC_RW (SDL_RWops *src, SDL_bool freesrc,
         fillptr = ((Uint8 *) ptr) + (*audio_len - v.rest);
     }
 
-    spec->samples = (Uint16)(*audio_len / v.size);
-
     /* Don't return a buffer that isn't a multiple of samplesize */
     samplesize = ((spec->format & 0xFF)/8)*spec->channels;
     *audio_len &= (Uint32) ~(samplesize-1);

--- a/src/codecs/music_flac.c
+++ b/src/codecs/music_flac.c
@@ -372,6 +372,8 @@ static void flac_metadata_music_cb(
     (void)decoder;
 
     if (metadata->type == FLAC__METADATA_TYPE_STREAMINFO) {
+        SDL_AudioSpec srcspec;
+
         music->sample_rate = metadata->data.stream_info.sample_rate;
         music->channels = metadata->data.stream_info.channels;
         music->bits_per_sample = metadata->data.stream_info.bits_per_sample;
@@ -388,12 +390,10 @@ static void flac_metadata_music_cb(
 
         /* We check for NULL stream later when we get data */
         SDL_assert(!music->stream);
-        music->stream = SDL_CreateAudioStream(SDL_AUDIO_S16SYS,
-                                              (Uint8)channels,
-                                              (int)music->sample_rate,
-                                              music_spec.format,
-                                              music_spec.channels,
-                                              music_spec.freq);
+        srcspec.format = SDL_AUDIO_S16SYS;
+        srcspec.channels = channels;
+        srcspec.freq = (int)music->sample_rate;
+        music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     } else if (metadata->type == FLAC__METADATA_TYPE_VORBIS_COMMENT) {
         FLAC__uint32 i;
 

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -207,6 +207,7 @@ static int initialize_from_track_info(GME_Music *music, int track)
 
 static void *GME_CreateFromRW(struct SDL_RWops *src, SDL_bool freesrc)
 {
+    SDL_AudioSpec spec;
     void *mem = 0;
     size_t size;
     GME_Music *music;
@@ -222,17 +223,16 @@ static void *GME_CreateFromRW(struct SDL_RWops *src, SDL_bool freesrc)
     music->tempo = 1.0;
     music->gain = 1.0;
 
-    music->stream = SDL_CreateAudioStream(SDL_AUDIO_S16SYS, 2,
-                                          music_spec.freq,
-                                          music_spec.format,
-                                          music_spec.channels,
-                                          music_spec.freq);
+    srcspec.format = SDL_AUDIO_S16SYS;
+    srcspec.channels = 2;
+    srcspec.freq = music_spec.freq;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         GME_Delete(music);
         return NULL;
     }
 
-    music->buffer_size = music_spec.samples * sizeof(Sint16) * 2/*channels*/ * music_spec.channels;
+    music->buffer_size = 4096/*music_spec.samples*/ * sizeof(Sint16) * 2/*channels*/ * music_spec.channels;
     music->buffer = SDL_malloc(music->buffer_size);
     if (!music->buffer) {
         SDL_OutOfMemory();

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -207,7 +207,7 @@ static int initialize_from_track_info(GME_Music *music, int track)
 
 static void *GME_CreateFromRW(struct SDL_RWops *src, SDL_bool freesrc)
 {
-    SDL_AudioSpec spec;
+    SDL_AudioSpec srcspec;
     void *mem = 0;
     size_t size;
     GME_Music *music;

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -163,6 +163,7 @@ static int MODPLUG_Open(const SDL_AudioSpec *spec)
 /* Load a modplug stream from an SDL_RWops object */
 void *MODPLUG_CreateFromRW(SDL_RWops *src, SDL_bool freesrc)
 {
+    SDL_AudioSpec srcspec;
     MODPLUG_Music *music;
     void *buffer;
     size_t size;
@@ -175,18 +176,16 @@ void *MODPLUG_CreateFromRW(SDL_RWops *src, SDL_bool freesrc)
 
     music->volume = MIX_MAX_VOLUME;
 
-    music->stream = SDL_CreateAudioStream((settings.mBits == 8) ? SDL_AUDIO_U8 : SDL_AUDIO_S16SYS,
-                                          (Uint8)settings.mChannels,
-                                          settings.mFrequency,
-                                          music_spec.format,
-                                          music_spec.channels,
-                                          music_spec.freq);
+    srcspec.format = (settings.mBits == 8) ? SDL_AUDIO_U8 : SDL_AUDIO_S16SYS;
+    srcspec.channels = settings.mChannels;
+    srcspec.freq = settings.mFrequency;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         MODPLUG_Delete(music);
         return NULL;
     }
 
-    music->buffer_size = music_spec.samples * (settings.mBits / 8) * settings.mChannels;
+    music->buffer_size = 4096/*music_spec.samples*/ * (settings.mBits / 8) * settings.mChannels;
     music->buffer = SDL_malloc((size_t)music->buffer_size);
     if (!music->buffer) {
         MODPLUG_Delete(music);

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -188,6 +188,7 @@ static void OGG_Delete(void *context);
 
 static int OGG_UpdateSection(OGG_music *music)
 {
+    SDL_AudioSpec srcspec;
     vorbis_info *vi;
 
     vi = vorbis.ov_info(&music->vf, -1);
@@ -211,16 +212,15 @@ static int OGG_UpdateSection(OGG_music *music)
         music->stream = NULL;
     }
 
-    music->stream = SDL_CreateAudioStream(SDL_AUDIO_S16SYS,
-                                          (Uint8)vi->channels, (int)vi->rate,
-                                          music_spec.format,
-                                          music_spec.channels,
-                                          music_spec.freq);
+    srcspec.format = SDL_AUDIO_S16SYS;
+    srcspec.channels = vi->channels;
+    srcspec.freq = (int)vi->rate;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         return -1;
     }
 
-    music->buffer_size = music_spec.samples * (int)sizeof(Sint16) * vi->channels;
+    music->buffer_size = 4096/*music_spec.samples*/ * (int)sizeof(Sint16) * vi->channels;
     music->buffer = (char *)SDL_malloc((size_t)music->buffer_size);
     if (!music->buffer) {
         return -1;

--- a/src/codecs/music_ogg_stb.c
+++ b/src/codecs/music_ogg_stb.c
@@ -123,6 +123,7 @@ static void OGG_Delete(void *context);
 static int OGG_UpdateSection(OGG_music *music)
 {
     stb_vorbis_info vi;
+    SDL_AudioSpec srcspec;
 
     vi = stb_vorbis_get_info(music->vf);
 
@@ -141,17 +142,15 @@ static int OGG_UpdateSection(OGG_music *music)
         music->stream = NULL;
     }
 
-    music->stream = SDL_CreateAudioStream(SDL_AUDIO_F32SYS,
-                                          (Uint8)vi.channels,
-                                          (int)vi.sample_rate,
-                                          music_spec.format,
-                                          music_spec.channels,
-                                          music_spec.freq);
+    srcspec.format = SDL_AUDIO_F32SYS;
+    srcspec.channels = vi.channels;
+    srcspec.freq = (int)vi.sample_rate;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         return -1;
     }
 
-    music->buffer_size = music_spec.samples * (int)sizeof(float) * vi.channels;
+    music->buffer_size = 4096/*music_spec.samples*/ * (int)sizeof(float) * vi.channels;
     if (music->buffer_size <= 0) {
         return -1;
     }
@@ -324,7 +323,7 @@ static int OGG_GetSome(void *context, void *data, int bytes, SDL_bool *done)
     amount = stb_vorbis_get_samples_float_interleaved(music->vf,
                                                 music->vi.channels,
                                                 (float *)music->buffer,
-                                                music_spec.samples * music->vi.channels);
+                                                4096/*music_spec.samples*/ * music->vi.channels);
 
     amount *= music->vi.channels * sizeof(float);
 

--- a/src/codecs/music_opus.c
+++ b/src/codecs/music_opus.c
@@ -169,6 +169,7 @@ static void OPUS_Delete(void*);
 static int OPUS_UpdateSection(OPUS_music *music)
 {
     const OpusHead *op_info;
+    SDL_AudioSpec srcspec;
 
     op_info = opus.op_head(music->of, -1);
     if (!op_info) {
@@ -191,17 +192,15 @@ static int OPUS_UpdateSection(OPUS_music *music)
         music->stream = NULL;
     }
 
-    music->stream = SDL_CreateAudioStream(SDL_AUDIO_S16SYS,
-                                          (Uint8)op_info->channel_count,
-                                          48000,
-                                          music_spec.format,
-                                          music_spec.channels,
-                                          music_spec.freq);
+    srcspec.format = SDL_AUDIO_S16SYS;
+    srcspec.channels = op_info->channel_count;
+    srcspec.freq = 48000;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         return -1;
     }
 
-    music->buffer_size = (int)music_spec.samples * (int)sizeof(opus_int16) * op_info->channel_count;
+    music->buffer_size = (int)4096/*music_spec.samples*/ * (int)sizeof(opus_int16) * op_info->channel_count;
     music->buffer = (char *)SDL_malloc((size_t)music->buffer_size);
     if (!music->buffer) {
         return -1;

--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -112,14 +112,13 @@ void *TIMIDITY_CreateFromRW(SDL_RWops *src, SDL_bool freesrc)
     }
 
     if (need_stream) {
-        music->stream = SDL_CreateAudioStream(spec.format, spec.channels, spec.freq,
-                                           music_spec.format, music_spec.channels, music_spec.freq);
+        music->stream = SDL_CreateAudioStream(&spec, &music_spec);
         if (!music->stream) {
             TIMIDITY_Delete(music);
             return NULL;
         }
 
-        music->buffer_size = spec.samples * (SDL_AUDIO_BITSIZE(spec.format) / 8) * spec.channels;
+        music->buffer_size = 4096/*spec.samples*/ * (SDL_AUDIO_BITSIZE(spec.format) / 8) * spec.channels;
         music->buffer = SDL_malloc((size_t)music->buffer_size);
         if (!music->buffer) {
             SDL_OutOfMemory();

--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -343,6 +343,7 @@ static void *WAVPACK_CreateFromFile(const char *file)
 /* Load a WavPack stream from an SDL_RWops object */
 static void *WAVPACK_CreateFromRW_internal(SDL_RWops *src1, SDL_RWops *src2, SDL_bool freesrc, SDL_bool *freesrc2)
 {
+    SDL_AudioSpec srcspec;
     WAVPACK_music *music;
     SDL_AudioFormat format;
     char *tag;
@@ -413,14 +414,18 @@ static void *WAVPACK_CreateFromRW_internal(SDL_RWops *src1, SDL_RWops *src2, SDL
         format = (music->mode & MODE_FLOAT) ? SDL_AUDIO_F32SYS : SDL_AUDIO_S32SYS;
         break;
     }
-    music->stream = SDL_CreateAudioStream(format, (Uint8)music->channels, (int)music->samplerate / music->decimation,
-                                       music_spec.format, music_spec.channels, music_spec.freq);
+
+
+    srcspec.format = format;
+    srcspec.channels = music->channels;
+    srcspec.freq = (int)music->samplerate / music->decimation;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         WAVPACK_Delete(music);
         return NULL;
     }
 
-    music->frames = music_spec.samples;
+    music->frames = 4096/*music_spec.samples*/;
     music->buffer = SDL_malloc(music->frames * music->channels * sizeof(int32_t) * music->decimation);
     if (!music->buffer) {
         SDL_OutOfMemory();

--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -193,6 +193,7 @@ static long xmp_ftell(void *src) {
 /* Load a libxmp stream from an SDL_RWops object */
 void *XMP_CreateFromRW(SDL_RWops *src, SDL_bool freesrc)
 {
+    SDL_AudioSpec srcspec;
     XMP_Music *music;
     struct xmp_callbacks file_callbacks = {
            xmp_fread, xmp_fseek, xmp_ftell, NULL
@@ -211,7 +212,7 @@ void *XMP_CreateFromRW(SDL_RWops *src, SDL_bool freesrc)
         goto e0;
     }
 
-    music->buffer_size = music_spec.samples * 2 * 2;
+    music->buffer_size = 4096/*music_spec.samples*/ * 2 * 2;
     music->buffer = SDL_malloc((size_t)music->buffer_size);
     if (!music->buffer) {
         SDL_OutOfMemory();
@@ -243,11 +244,10 @@ void *XMP_CreateFromRW(SDL_RWops *src, SDL_bool freesrc)
     }
 
     music->volume = MIX_MAX_VOLUME;
-    music->stream = SDL_CreateAudioStream(SDL_AUDIO_S16SYS, 2,
-                                          music_spec.freq,
-                                          music_spec.format,
-                                          music_spec.channels,
-                                          music_spec.freq);
+    srcspec.format = SDL_AUDIO_S16SYS;
+    srcspec.channels = 2;
+    srcspec.freq = music_spec.freq;
+    music->stream = SDL_CreateAudioStream(&srcspec, &music_spec);
     if (!music->stream) {
         goto e3;
     }

--- a/src/codecs/timidity/timidity.c
+++ b/src/codecs/timidity/timidity.c
@@ -577,10 +577,10 @@ static void do_song_load(SDL_RWops *rw, SDL_AudioSpec *audio, MidiSong **out)
     goto fail;
   }
 
-  song->buffer_size = audio->samples;
-  song->resample_buffer = SDL_malloc(audio->samples * sizeof(sample_t));
+  song->buffer_size = 4096/*audio->samples*/;
+  song->resample_buffer = SDL_malloc(4096/*audio->samples*/ * sizeof(sample_t));
   if (!song->resample_buffer) goto fail;
-  song->common_buffer = SDL_malloc(audio->samples * 2 * sizeof(Sint32));
+  song->common_buffer = SDL_malloc(4096/*audio->samples*/ * 2 * sizeof(Sint32));
   if (!song->common_buffer) goto fail;
 
   song->control_ratio = audio->freq / CONTROLS_PER_SECOND;

--- a/src/music.c
+++ b/src/music.c
@@ -530,7 +530,7 @@ void open_music(const SDL_AudioSpec *spec)
     Mix_VolumeMusic(MIX_MAX_VOLUME);
 
     /* Calculate the number of ms for each callback */
-    ms_per_step = (int) (((float)spec->samples * 1000.0f) / spec->freq);
+    ms_per_step = (int) ((4096.0f * 1000.0f) / spec->freq);
 }
 
 /* Return SDL_TRUE if the music type is available */


### PR DESCRIPTION
This is a draft PR until the new audio API is merged into SDL3, but once that is, this will update SDL_mixer to work with it.

This makes two API changes to SDL mixer.

First, Mix_OpenAudio is simplified, and can even be called as `Mix_OpenAudio(0, NULL);` and probably get the exact desired result in most use cases.

Second, Mix_OpenAudioDevice is gone, as redundant.

Internally, this is the most minimal patch that gets SDL_mixer working again, which is to say it cleans up a few things that expected SDL_AudioSpec to have more fields, and it changes the library to use a single SDL_AudioStream with a callback instead of the SDL2 audio device callback.

One could certainly get more creative, turning each SDL_mixer channel into an audio stream bound to the device, each of them firing a callback that allows SDL_mixer to decode audio on the fly and perform effects, but that's something we should think about if we ever decide to do a serious SDL_mixer overhaul.

This PR is just making sure the library is still usable.