### PR TITLE
Prevent a double call of the Mix_ChannelFinished() callback when using Mix_FadeOutChannel()

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -406,6 +406,8 @@ mix_channels(void *udata, Uint8 *stream, int len)
 
                     /* rcg06072001 Alert app if channel is done playing. */
                     if (!mix_channel[i].playing && !mix_channel[i].looping) {
+                        mix_channel[i].fading = MIX_NO_FADING;
+                        mix_channel[i].expire = 0;
                         _Mix_channel_done_playing(i);
 
                         /* Update the volume after the application callback */


### PR DESCRIPTION
Currently, in the `main` branch, in a situation when `Mix_FadeOutChannel()` is called before the end of the playback, but when there is less than `ms` milliseconds left before the end of the track, there will be two calls of `Mix_ChannelFinished()` callback instead of one - the first is when playback is finished, and the second is when the fade timer expires. This may lead to various issues (e.g. to the double-free issue when `Mix_ChannelFinished()` callback is used to release the `Mix_Chunk`).