### PR TITLE
[SDL2] Fixes for WAV playing

### DIFF
--- a/src/codecs/music_wav.c
+++ b/src/codecs/music_wav.c
@@ -344,7 +344,7 @@ static int fetch_float64be(void *context, int length)
     if (length % music->samplesize != 0) {
         length -= length % music->samplesize;
     }
-    for (i = 0, o = 0; i <= length; i += 8, o += 4) {
+    for (i = 0, o = 0; i < length; i += 8, o += 4) {
         union
         {
             float f;
@@ -367,7 +367,7 @@ static int fetch_float64le(void *context, int length)
     if (length % music->samplesize != 0) {
         length -= length % music->samplesize;
     }
-    for (i = 0, o = 0; i <= length; i += 8, o += 4) {
+    for (i = 0, o = 0; i < length; i += 8, o += 4) {
         union
         {
             float f;

--- a/src/codecs/music_wav.c
+++ b/src/codecs/music_wav.c
@@ -959,6 +959,12 @@ static SDL_bool LoadWAVMusic(WAV_Music *wave)
                 return SDL_FALSE;
             break;
         }
+
+        /* RIFF chunks have a 2-byte alignment. Skip padding byte. */
+        if (chunk_length & 1) {
+            if (SDL_RWseek(src, 1, RW_SEEK_CUR) < 0)
+                return SDL_FALSE;
+        }
     }
 
     if (!found_FMT) {


### PR DESCRIPTION
There are two bugs got been fixed:
- Added the skipping of pad byte to fix the work of several WAV files like this one:
[Cymatics_-_BELL_Dusty_C.wav.zip](https://github.com/libsdl-org/SDL_mixer/files/12448832/Cymatics_-_BELL_Dusty_C.wav.zip) that contains `bext` chunk with 603 length, but actual size of the chunk os 604 because of a pad byte.
- Fixed the memory out-of-range access at fetch_float64be() and fetch_float64le() calls.
