### PR TITLE
[SDL2] mp3util.c: Fixed unitialized "pos" at read_id3v2_from_mem()

### DIFF
--- a/src/codecs/mp3utils.c
+++ b/src/codecs/mp3utils.c
@@ -1155,6 +1155,7 @@ int read_id3v2_from_mem(Mix_MusicMetaTags *out_tags, Uint8 *data, size_t length)
         fil.src = src;
         fil.start = 0;
         fil.length = (Sint64)length;
+        fil.pos = 0;
 
         if (!is_id3v2(data, length)) {
             SDL_RWclose(src);


### PR DESCRIPTION
Via CLang, I accidentally found that `.pos` field of the `mp3file_t` structure was not being initialized at the read_id3v2_from_mem() call. So, I added that missing initialisation and fixed that problem.