### PR TITLE
music_wav.c: Fixed ADPCM buffer overflow

### DIFF
--- a/src/codecs/music_wav.c
+++ b/src/codecs/music_wav.c
@@ -561,7 +561,7 @@ static int MS_ADPCM_Init(ADPCM_DecoderState *state, const Uint8 *chunk_data, Uin
 
     state->output.read = 0;
     state->output.pos = 0;
-    state->output.size = state->samplesperblock;
+    state->output.size = state->samplesperblock * state->channels;
     state->output.data = (Sint16 *)SDL_malloc(state->output.size * sizeof(Sint16));
     if (!state->output.data) {
         return Mix_OutOfMemory();
@@ -791,7 +791,7 @@ static int IMA_ADPCM_Init(ADPCM_DecoderState *state, const Uint8 *chunk_data, Ui
 
     state->output.read = 0;
     state->output.pos = 0;
-    state->output.size = state->samplesperblock;
+    state->output.size = state->samplesperblock * state->channels;
     state->output.data = (Sint16 *)SDL_malloc(state->output.size * sizeof(Sint16));
     if (!state->output.data) {
         return Mix_OutOfMemory();


### PR DESCRIPTION
I accidentally found that the output buffer was been created for mono output only, and therefore, on attempt to play stereo files, the buffer overflow gets occured. So, the size of the buffer must be multipled by a number of channels.

The test file that causes a problem, was attatched to the referred issue.

Fixes #550