### PR TITLE
wikiheaders: don't warn about missing files by default

### DIFF
--- a/.wikiheaders-options
+++ b/.wikiheaders-options
@@ -12,5 +12,5 @@ selectheaderregex = \ASDL_mixer\.h\Z
 projecturl = https://libsdl.org/projects/SDL_mixer
 wikiurl = https://wiki.libsdl.org/SDL_mixer
 bugreporturl = https://github.com/libsdl-org/sdlwiki/issues/new
-warn_about_missing = 1
+warn_about_missing = 0
 wikipreamble = (This function is part of SDL_mixer, a separate library from SDL.)


### PR DESCRIPTION
https://github.com/libsdl-org/SDL_mixer/issues/542

`wikiheaders.pl` has [`--warn-about-missing`](https://github.com/libsdl-org/SDL_mixer/blob/489716b38b7293f2539f37714dc0890cbace37c5/build-scripts/wikiheaders.pl#L36) to force the value to 0.

@icculus Is this ok? Or is a `--no-warn-about-missing` option preferred?