### PR TITLE
Add Mix_ChannelFinished to SDL_mixer.sym

### DIFF
--- a/src/SDL_mixer.sym
+++ b/src/SDL_mixer.sym
@@ -1,6 +1,7 @@
 SDL3_mixer_0.0.0 {
   global:
     Mix_AllocateChannels;
+    Mix_ChannelFinished;
     Mix_CloseAudio;
     Mix_ExpireChannel;
     Mix_FadeInChannel;


### PR DESCRIPTION
Adds a function to SDL_mixer.sym that was previously missed and was causing me some linker errors.