### PR TITLE
Add Mix_PauseGroup and Mix_ResumeGroup functions

### DIFF
--- a/include/SDL3_mixer/SDL_mixer.h
+++ b/include/SDL3_mixer/SDL_mixer.h
@@ -2181,6 +2181,31 @@ extern DECLSPEC Mix_Fading SDLCALL Mix_FadingChannel(int which);
 extern DECLSPEC void SDLCALL Mix_Pause(int channel);
 
 /**
+ * Pause playing of a group of channels by arbitrary tag.
+ *
+ * Pausing a channel will prevent further playback of the assigned chunk but
+ * will maintain the chunk's current mixing position. When resumed, this
+ * channel will continue to mix the chunk where it left off.
+ *
+ * A paused channel can be resumed by calling Mix_Resume() or
+ * Mix_ResumeGroup().
+ *
+ * A paused channel with an expiration will not expire while paused (the
+ * expiration countdown will be adjusted once resumed).
+ *
+ * A tag is an arbitrary number that can be assigned to several mixer
+ * channels, to form groups of channels.
+ *
+ * The default tag for a channel is -1.
+ *
+ * \param tag an arbitrary value, assigned to channels, to search for.
+ * \returns zero, whether any channels were halted or not.
+ *
+ * \since This function is available since SDL_mixer 3.0.0.
+ */
+extern DECLSPEC int SDLCALL Mix_PauseGroup(int tag);
+
+/**
  * Resume a particular channel.
  *
  * It is legal to resume an unpaused or invalid channel; it causes no effect
@@ -2197,6 +2222,27 @@ extern DECLSPEC void SDLCALL Mix_Pause(int channel);
  * \since This function is available since SDL_mixer 3.0.0.
  */
 extern DECLSPEC void SDLCALL Mix_Resume(int channel);
+
+/**
+ * Resume playing of a group of channels by arbitrary tag.
+ *
+ * It is legal to resume an unpaused or invalid channel; it causes no effect
+ * and reports no error.
+ *
+ * If the paused channel has an expiration, its expiration countdown resumes
+ * now, as well.
+ *
+ * A tag is an arbitrary number that can be assigned to several mixer
+ * channels, to form groups of channels.
+ *
+ * The default tag for a channel is -1.
+ *
+ * \param tag an arbitrary value, assigned to channels, to search for.
+ * \returns zero, whether any channels were resumed or not.
+ *
+ * \since This function is available since SDL_mixer 3.0.0.
+ */
+extern DECLSPEC int SDLCALL Mix_ResumeGroup(int tag);
 
 /**
  * Query whether a particular channel is paused.

--- a/src/SDL_mixer.sym
+++ b/src/SDL_mixer.sym
@@ -59,6 +59,7 @@ SDL3_mixer_0.0.0 {
     Mix_OpenAudio;
     Mix_OpenAudioDevice;
     Mix_Pause;
+    Mix_PauseGroup;
     Mix_PauseAudio;
     Mix_PauseMusic;
     Mix_Paused;
@@ -75,6 +76,7 @@ SDL3_mixer_0.0.0 {
     Mix_RegisterEffect;
     Mix_ReserveChannels;
     Mix_Resume;
+    Mix_ResumeGroup;
     Mix_ResumeMusic;
     Mix_RewindMusic;
     Mix_SetDistance;

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -1415,6 +1415,19 @@ void Mix_Pause(int which)
     }
 }
 
+/* Pause playing of a particular group of channels */
+int Mix_PauseGroup(int tag)
+{
+    int i;
+
+    for (i=0; i<num_channels; ++i) {
+        if (mix_channel[i].tag == tag) {
+            Mix_Pause(i);
+        }
+    }
+    return(0);
+}
+
 /* Resume a paused channel */
 void Mix_Resume(int which)
 {
@@ -1439,6 +1452,19 @@ void Mix_Resume(int which)
         }
     }
     Mix_UnlockAudio();
+}
+
+/* Resume playing of a particular group of channels */
+int Mix_ResumeGroup(int tag)
+{
+    int i;
+
+    for (i=0; i<num_channels; ++i) {
+        if (mix_channel[i].tag == tag) {
+            Mix_Resume(i);
+        }
+    }
+    return(0);
 }
 
 int Mix_Paused(int which)


### PR DESCRIPTION
Adds a couple helper functions similar to `Mix_HaltGroup` that make it easy to pause and resume groups of channels together. In my game I group in-game sounds so I can easily pause and resume them when the game pauses.