### PR TITLE
stb_vorbis CVE fixes

### DIFF
--- a/src/codecs/music_ogg_stb.c
+++ b/src/codecs/music_ogg_stb.c
@@ -198,6 +198,14 @@ static void *OGG_CreateFromRW(SDL_RWops *src, int freesrc)
     }
 
     rate = music->vi.sample_rate;
+
+    music->full_length = stb_vorbis_stream_length_in_samples(music->vf);
+    if (music->full_length <= 0) {
+        Mix_SetError("No samples in ogg/vorbis stream.");
+        OGG_Delete(music);
+        return NULL;
+    }
+
     vc = stb_vorbis_get_comment(music->vf);
     if (vc.comment_list != NULL) {
         for (i = 0; i < vc.comment_list_length; i++) {
@@ -250,7 +258,6 @@ static void *OGG_CreateFromRW(SDL_RWops *src, int freesrc)
         }
     }
 
-    music->full_length = stb_vorbis_stream_length_in_samples(music->vf);
     if ((music->loop_end > 0) && (music->loop_end <= music->full_length) &&
         (music->loop_start < music->loop_end)) {
         music->loop = 1;

--- a/src/codecs/stb_vorbis/stb_vorbis.h
+++ b/src/codecs/stb_vorbis/stb_vorbis.h
@@ -3750,9 +3750,12 @@ static int start_decoder(vorb *f)
    f->comment_list = NULL;
    if (f->comment_list_length > 0)
    {
+      if (INT_MAX / sizeof(char*) < f->comment_list_length)
+          goto no_comment;
       len = sizeof(char*) * f->comment_list_length;
       f->comment_list = (char**) setup_malloc(f, len);
       if (f->comment_list == NULL) {
+         no_comment:
          f->comment_list_length = 0;
          return error(f, VORBIS_outofmem);
       }

--- a/src/codecs/stb_vorbis/stb_vorbis.h
+++ b/src/codecs/stb_vorbis/stb_vorbis.h
@@ -1840,7 +1840,7 @@ static int codebook_decode_scalar(vorb *f, Codebook *c)
 
 #define DECODE(var,f,c)                                       \
    DECODE_RAW(var,f,c)                                        \
-   if (c->sparse) var = c->sorted_values[var];
+   if (c->sparse && var >= 0) var = c->sorted_values[var];
 
 #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
   #define DECODE_VQ(var,f,c)   DECODE_RAW(var,f,c)

--- a/src/codecs/stb_vorbis/stb_vorbis.h
+++ b/src/codecs/stb_vorbis/stb_vorbis.h
@@ -986,6 +986,7 @@ static void *make_block_array(void *mem, int count, int size)
 
 static void *setup_malloc(vorb *f, int sz)
 {
+   if (sz < 0 || INT_MAX - 7 < sz) return NULL;
    sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    f->setup_memory_required += sz;
    if (f->alloc.alloc_buffer) {

--- a/src/codecs/stb_vorbis/stb_vorbis.h
+++ b/src/codecs/stb_vorbis/stb_vorbis.h
@@ -3750,8 +3750,13 @@ static int start_decoder(vorb *f)
    f->comment_list = NULL;
    if (f->comment_list_length > 0)
    {
-      f->comment_list = (char**) setup_malloc(f, sizeof(char*) * (f->comment_list_length));
-      if (f->comment_list == NULL)                  return error(f, VORBIS_outofmem);
+      len = sizeof(char*) * f->comment_list_length;
+      f->comment_list = (char**) setup_malloc(f, len);
+      if (f->comment_list == NULL) {
+         f->comment_list_length = 0;
+         return error(f, VORBIS_outofmem);
+      }
+      memset(f->comment_list, 0, len);
    }
 
    for(i=0; i < f->comment_list_length; ++i) {


### PR DESCRIPTION
The following 4 patches are based on PR submissions at mainstream.
I modified most of the patches and notified the patch author about
them.

(1) Fix CVE-2023-45676 and CVE-2023-45677 (integer overflow in setup_malloc()):
Based on the patches by Jaroslav Lobačevski (@JarLob) submitted
to mainstream at: https://github.com/nothings/stb/pull/1554 and https://github.com/nothings/stb/pull/1555
GHSL-2023-166/CVE-2023-45676: Multi-byte write heap buffer overflow in start_decoder()
GHSL-2023-167/CVE-2023-45677: Heap buffer out of bounds write in start_decoder()
Test files (for convenience): [1554.ogg.zip](https://github.com/libsdl-org/SDL_mixer/files/13630602/1554.ogg.zip), [1555.ogg.zip](https://github.com/libsdl-org/SDL_mixer/files/13630603/1555.ogg.zip)

(2) Fix CVE-2023-45679 and CVE-2023-45680:
Based on the patches by Jaroslav Lobačevski (@JarLob) submitted
to mainstream at: https://github.com/nothings/stb/pull/1557 and https://github.com/nothings/stb/pull/1558
GHSL-2023-169/CVE-2023-45679: Attempt to free an uninitialized memory pointer in vorbis_deinit()
GHSL-2023-170/CVE-2023-45680: Null pointer dereference in vorbis_deinit()
Test files (for convenience): [1557.ogg.zip](https://github.com/libsdl-org/SDL_mixer/files/13630605/1557.ogg.zip), [1558.ogg.zip](https://github.com/libsdl-org/SDL_mixer/files/13630606/1558.ogg.zip)

(3) Fix CVE-2023-45681 (integer overflow):
Based on patch by Jaroslav Lobačevski (@JarLob) submitted to
mainstream at https://github.com/nothings/stb/pull/1559
GHSL-2023-171/CVE-2023-45681: Out of bounds heap buffer write
Test files (for convenience): [1559.ogg.zip](https://github.com/libsdl-org/SDL_mixer/files/13630607/1559.ogg.zip)

(4) Fix CVE-2023-45682:
Based on patch by Jaroslav Lobačevski (@JarLob) submitted to
mainstream at https://github.com/nothings/stb/pull/1560
GHSL-2023-172/CVE-2023-45682: Wild address read in vorbis_decode_packet_rest()
Test files (for convenience): [1560.ogg.zip](https://github.com/libsdl-org/SDL_mixer/files/13630611/1560.ogg.zip)

(5) music_ogg_stb.c: Error-out early if the vorbis file has no samples
This is not a CVE fix, but 1560.ogg attached above runs in an endless loop
in our playmus program, so this was my quick solution. Any other solutions
are welcome, of course.

This is prepared against SDL2 branch: If this goes in, I will cherry-pick
into SDL3 branch (and can also apply to Ryan's SDL_sound.)

@slouken, @icculus: Please review.
