### PR TITLE
minimp3: remove TAG+ support

### DIFF
--- a/src/codecs/minimp3/minimp3_ex.h
+++ b/src/codecs/minimp3/minimp3_ex.h
@@ -139,11 +139,7 @@ static void mp3dec_skip_id3v1(const uint8_t *buf, size_t *pbuf_size)
     size_t buf_size = *pbuf_size;
 #ifndef MINIMP3_NOSKIP_ID3V1
     if (buf_size >= 128 && !memcmp(buf + buf_size - 128, "TAG", 3))
-    {
         buf_size -= 128;
-        if (buf_size >= 227 && !memcmp(buf + buf_size - 227, "TAG+", 4))
-            buf_size -= 227;
-    }
 #endif
 #ifndef MINIMP3_NOSKIP_APEV2
     if (buf_size > 32 && !memcmp(buf + buf_size - 32, "APETAGEX", 8))


### PR DESCRIPTION
It's a still-born extension that no one uses, no player supports, and no tag library parses.

And it's not impossible to hit it as a false positive..

(The removal has already been suggested to mainstream at https://github.com/lieff/minimp3/issues/66)

---

If https://github.com/mackron/dr_libs/issues/263 doesn't get  resolved and we won't go back to dr_mp3, please merge this and also cherry-pick to SDL3 branch as well.