### PR TITLE
wavpack: WavpackOpenFileInput is not used, so don't load it

### DIFF
--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -66,7 +66,6 @@ typedef struct {
     uint32_t libversion;
     uint32_t (*WavpackGetLibraryVersion)(void);
     char *(*WavpackGetErrorMessage)(WavpackContext*);
-    WavpackContext *(*WavpackOpenFileInput)(const char *infilename, char *error, int flags, int norm_offset);
     WavpackContext *(*WavpackOpenFileInputEx)(WavpackStreamReader *reader, void *wv_id, void *wvc_id, char *error, int flags, int norm_offset);
     WavpackContext *(*WavpackCloseFile)(WavpackContext*);
     int (*WavpackGetMode)(WavpackContext*);
@@ -112,7 +111,6 @@ static int WAVPACK_Load(void)
 #endif
         FUNCTION_LOADER(WavpackGetLibraryVersion, uint32_t (*)(void));
         FUNCTION_LOADER(WavpackGetErrorMessage, char *(*)(WavpackContext*));
-        FUNCTION_LOADER(WavpackOpenFileInput, WavpackContext *(*)(const char*, char*, int, int));
         FUNCTION_LOADER(WavpackOpenFileInputEx, WavpackContext *(*)(WavpackStreamReader*, void*, void*, char*, int, int));
         FUNCTION_LOADER(WavpackCloseFile, WavpackContext *(*)(WavpackContext*));
         FUNCTION_LOADER(WavpackGetMode, int (*)(WavpackContext*));


### PR DESCRIPTION
`ftruncate` is used through`WavpackOpenFileInput`.
Since SDL_mixer uses `WavpackOpenFileInputEx` instead of `WavpackOpenFileInput`, don't look for `WavpackOpenFileInput`.

Depends on https://github.com/libsdl-org/WavPack/pull/2

Fixes #585