### PR TITLE
examples/playmus: Prevent stack smashing on long input strings

### DIFF
--- a/examples/playmus.c
+++ b/examples/playmus.c
@@ -72,8 +72,7 @@ static void Menu(void)
     char buf[10];
 
     printf("Available commands: (p)ause (r)esume (h)alt volume(v#) > ");
-    fflush(stdin);
-    if (scanf("%s",buf) == 1) {
+    if (fgets(buf, sizeof(buf), stdin)) {
         switch(buf[0]) {
 #if defined(SEEK_TEST)
         case '0': Mix_SetMusicPosition(0); break;


### PR DESCRIPTION
In addition, fflush(stdin) is undefined behaviour, so remove it.