### PR TITLE
native_midi_common.c (ReadMIDIFile): fix possible NULL ptr dereference.

### DIFF
--- a/src/codecs/native_midi/native_midi_common.c
+++ b/src/codecs/native_midi/native_midi_common.c
@@ -260,7 +260,7 @@ static MIDIEvent *MIDItoStream(MIDIFile *mididata)
 
 static int ReadMIDIFile(MIDIFile *mididata, SDL_IOStream *src)
 {
-    int i = 0;
+    int i = -1;
     Uint32 ID = 0;
     Uint32 size = 0;
     Uint16 format = 0;


### PR DESCRIPTION
if allocation of mididata->track ever fails we'd still be dereferencing it under 'bail'

Unless I'm missing something...