### PR TITLE
update after SDL_AUDIO_DEVICE_DEFAULT_OUTPUT rename

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -502,7 +502,7 @@ int Mix_OpenAudio(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec)
     }
 
     if (devid == 0) {
-        devid = SDL_AUDIO_DEVICE_DEFAULT_OUTPUT;
+        devid = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
     }
 
     if ((audio_device = SDL_OpenAudioDevice(devid, spec)) == 0) {


### PR DESCRIPTION
changed SDL_AUDIO_DEVICE_DEFAULT_OUTPUT to SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK
https://github.com/libsdl-org/SDL/commit/38f0214e8a579664d19c3eb95ff1df660e519420