### PR TITLE
Mix_AllocateChannels realloc fix

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -575,6 +575,8 @@ void Mix_PauseAudio(int pause_on)
  */
 int Mix_AllocateChannels(int numchans)
 {
+    struct _Mix_Channel *mix_channel_tmp;
+
     if (numchans<0 || numchans==num_channels)
         return num_channels;
 
@@ -587,27 +589,36 @@ int Mix_AllocateChannels(int numchans)
         }
     }
     Mix_LockAudio();
-    mix_channel = (struct _Mix_Channel *) SDL_realloc(mix_channel, numchans * sizeof(struct _Mix_Channel));
-    if (numchans > num_channels) {
-        /* Initialize the new channels */
-        int i;
-        for (i = num_channels; i < numchans; i++) {
-            mix_channel[i].chunk = NULL;
-            mix_channel[i].playing = 0;
-            mix_channel[i].looping = 0;
-            mix_channel[i].volume = MIX_MAX_VOLUME;
-            mix_channel[i].fade_volume = MIX_MAX_VOLUME;
-            mix_channel[i].fade_volume_reset = MIX_MAX_VOLUME;
-            mix_channel[i].fading = MIX_NO_FADING;
-            mix_channel[i].tag = -1;
-            mix_channel[i].expire = 0;
-            mix_channel[i].effects = NULL;
-            mix_channel[i].paused = 0;
+    /* Allocate channels into temporary pointer */
+    mix_channel_tmp = (struct _Mix_Channel *) SDL_realloc(mix_channel, numchans * sizeof(struct _Mix_Channel));
+    /* Check the allocation */
+    if (mix_channel_tmp) {
+        /* Apply the temporary pointer on success */
+        mix_channel = mix_channel_tmp;
+        if (numchans > num_channels) {
+            /* Initialize the new channels */
+            int i;
+            for (i = num_channels; i < numchans; i++) {
+                mix_channel[i].chunk = NULL;
+                mix_channel[i].playing = 0;
+                mix_channel[i].looping = 0;
+                mix_channel[i].volume = MIX_MAX_VOLUME;
+                mix_channel[i].fade_volume = MIX_MAX_VOLUME;
+                mix_channel[i].fade_volume_reset = MIX_MAX_VOLUME;
+                mix_channel[i].fading = MIX_NO_FADING;
+                mix_channel[i].tag = -1;
+                mix_channel[i].expire = 0;
+                mix_channel[i].effects = NULL;
+                mix_channel[i].paused = 0;
+            }
         }
+        num_channels = numchans;
+    } else {
+        /* On error mix_channel remains intact */
+        Mix_SetError("Channel allocation failed");
     }
-    num_channels = numchans;
     Mix_UnlockAudio();
-    return num_channels;
+    return num_channels; /* If the return value equals numchans the allocation was successful */
 }
 
 /* Return the actual mixer parameters */

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -590,9 +590,15 @@ int Mix_AllocateChannels(int numchans)
     }
     Mix_LockAudio();
     /* Allocate channels into temporary pointer */
-    mix_channel_tmp = (struct _Mix_Channel *) SDL_realloc(mix_channel, numchans * sizeof(struct _Mix_Channel));
+    if (numchans) {
+        mix_channel_tmp = (struct _Mix_Channel *) SDL_realloc(mix_channel, numchans * sizeof(struct _Mix_Channel));
+    } else {
+        /* Handle 0 numchans */
+        SDL_free(mix_channel);
+        mix_channel_tmp = NULL;
+    }
     /* Check the allocation */
-    if (mix_channel_tmp) {
+    if (mix_channel_tmp || !numchans) {
         /* Apply the temporary pointer on success */
         mix_channel = mix_channel_tmp;
         if (numchans > num_channels) {


### PR DESCRIPTION
Hi! I recently noticed that Mix_AllocateChannels didn't have a useful return value, it just returned the same number of channels that I passed in as parameter. Therefore I found out that there is not a single error checking on the success of the allocation, and in the case of an unsuccessful allocation an invalid address would have been used.
Solution: I added the missing error checking, the reallocation now uses a temporary pointer to check the success of the allocation, if the allocation was successful it will use the new pointer otherwise it sets an error, and the original pointer remains intact. Also now you can check the return value for useful information on the success of the allocation.