### PR TITLE
Unbreak build with gcc on macOS

### DIFF
--- a/src/codecs/music_opus.c
+++ b/src/codecs/music_opus.c
@@ -60,11 +60,11 @@ static opus_loader opus;
     if (opus.FUNC == NULL) { Mix_SetError("Missing opus.framework"); return -1; }
 #endif
 
-static int OPUS_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int OPUS_Load(void)
 {
     if (opus.loaded == 0) {
 #ifdef OPUS_DYNAMIC

--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -96,11 +96,11 @@ static wavpack_loader wvpk;
     if (wvpk.FUNC == NULL) { Mix_SetError("Missing wavpack.framework"); return -1; }
 #endif
 
-static int WAVPACK_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int WAVPACK_Load(void)
 {
     if (wvpk.loaded == 0) {
 #ifdef WAVPACK_DYNAMIC

--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -76,11 +76,11 @@ static xmp_loader libxmp;
     if (libxmp.FUNC == NULL) { Mix_SetError("Missing xmp.framework"); return -1; }
 #endif
 
-static int XMP_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int XMP_Load(void)
 {
     if (libxmp.loaded == 0) {
 #ifdef XMP_DYNAMIC


### PR DESCRIPTION
The existing placement of `__attribute__ ((optnone))` does not spit an error with Clang, because Clang is indifferent to the sequence here, but it breaks build with GCC.
Fix this finally.