### PR TITLE
music_*: fix remaining cases of incorrect attribute placement

### DIFF
--- a/src/codecs/music_flac.c
+++ b/src/codecs/music_flac.c
@@ -92,11 +92,11 @@ static flac_loader flac;
     if (flac.FUNC == NULL) { Mix_SetError("Missing FLAC.framework"); return -1; }
 #endif
 
-static int FLAC_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int FLAC_Load(void)
 {
     if (flac.loaded == 0) {
 #ifdef FLAC_DYNAMIC

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -60,11 +60,11 @@ static gme_loader gme;
     if (gme.FUNC == NULL) { Mix_SetError("Missing gme.framework"); return -1; }
 #endif
 
-static int GME_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int GME_Load(void)
 {
     if (gme.loaded == 0) {
 #ifdef GME_DYNAMIC

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -62,11 +62,11 @@ static ModPlug_Settings settings;
     if (modplug.FUNC == NULL) { Mix_SetError("Missing libmodplug.framework"); return -1; }
 #endif
 
-static int MODPLUG_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int MODPLUG_Load(void)
 {
     if (modplug.loaded == 0) {
 #ifdef MODPLUG_DYNAMIC

--- a/src/codecs/music_mpg123.c
+++ b/src/codecs/music_mpg123.c
@@ -82,11 +82,11 @@ static mpg123_loader mpg123;
     if (mpg123.FUNC == NULL) { Mix_SetError("Missing mpg123.framework"); return -1; }
 #endif
 
-static int MPG123_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int MPG123_Load(void)
 {
     if (mpg123.loaded == 0) {
 #ifdef MPG123_DYNAMIC

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -73,11 +73,11 @@ static vorbis_loader vorbis;
     if (vorbis.FUNC == NULL) { Mix_SetError("Missing vorbis.framework or tremor.framework"); return -1; }
 #endif
 
-static int OGG_Load(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+static int OGG_Load(void)
 {
     if (vorbis.loaded == 0) {
 #ifdef OGG_DYNAMIC


### PR DESCRIPTION
@slouken Please review.

These were missed, because I did not need them for building 2.8.0 release in a config which MacPorts uses. I do not have SDL3 so cannot test the master, but the changes are identical, so should work the same way.

Credits to @sezero for pointing this out.
See: https://github.com/libsdl-org/SDL_mixer/pull/627#issuecomment-2287161791