### PR TITLE
using SDL_getenv_unsafe (renamed of SDL_getenv) until we decide if th…

### DIFF
--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -59,7 +59,7 @@ static int TIMIDITY_Open(const SDL_AudioSpec *spec)
 
     (void) spec;
 
-    cfg = SDL_getenv("TIMIDITY_CFG");
+    cfg = SDL_getenv_unsafe("TIMIDITY_CFG");
     if(!cfg) cfg = Mix_GetTimidityCfg();
     if (cfg) {
         return Timidity_Init(cfg); /* env or user override: no other tries */

--- a/src/effects_internal.c
+++ b/src/effects_internal.c
@@ -37,7 +37,7 @@ int _Mix_effects_max_speed = 0;
 
 void _Mix_InitEffects(void)
 {
-    _Mix_effects_max_speed = (SDL_getenv(MIX_EFFECTSMAXSPEED) != NULL);
+    _Mix_effects_max_speed = (SDL_getenv_unsafe(MIX_EFFECTSMAXSPEED) != NULL);
 }
 
 void _Mix_DeinitEffects(void)

--- a/src/music.c
+++ b/src/music.c
@@ -1495,7 +1495,7 @@ SDL_bool Mix_SetSoundFonts(const char *paths)
 
 const char* Mix_GetSoundFonts(void)
 {
-    const char *env_paths = SDL_getenv("SDL_SOUNDFONTS");
+    const char *env_paths = SDL_getenv_unsafe("SDL_SOUNDFONTS");
     SDL_bool force_env_paths = SDL_GetHintBoolean("SDL_FORCE_SOUNDFONTS", SDL_FALSE);
     if (force_env_paths && (!env_paths || !*env_paths)) {
         force_env_paths = SDL_FALSE;


### PR DESCRIPTION
This is a fix since `SDL_getenv` has been removed with the arrival of a new thread-safe API. For now I have thus replaced usages of the old name in the SDL_mixer extension by the new name `SDL_getenv_unsafe`. 

I am too unfamiliar with the library to implement the new multi-threaded API for now. I am slowly getting by bearings with this library.

Thank you,