### PR TITLE
Convert volume API from integers [0-128] to floats [0-1]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
 3.0.0:
  * Updated for SDL 3.0
+ * Volume APIs now operate on floats, rather than integers between 0 and 128

--- a/examples/playmus.c
+++ b/examples/playmus.c
@@ -91,7 +91,7 @@ static void Menu(void)
             Mix_HaltMusic();
             break;
         case 'v': case 'V':
-            Mix_VolumeMusic(SDL_atoi(buf+1));
+            Mix_VolumeMusic((float)SDL_atof(buf+1));
             break;
         }
     }
@@ -112,7 +112,7 @@ static void IntHandler(int sig)
 
 int main(int argc, char *argv[])
 {
-    int audio_volume = MIX_MAX_VOLUME;
+    float audio_volume = 1.0f;
     int looping = 0;
     bool interactive = false;
     bool use_io = false;
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
         } else
         if ((SDL_strcmp(argv[i], "-v") == 0) && argv[i+1]) {
             ++i;
-            audio_volume = SDL_atoi(argv[i]);
+            audio_volume = (float)SDL_atof(argv[i]);
         } else
         if (SDL_strcmp(argv[i], "-l") == 0) {
             looping = -1;

--- a/include/SDL3_mixer/SDL_mixer.h
+++ b/include/SDL3_mixer/SDL_mixer.h
@@ -188,7 +188,6 @@ extern SDL_DECLSPEC void SDLCALL Mix_Quit(void);
 #define MIX_DEFAULT_FREQUENCY   44100
 #define MIX_DEFAULT_FORMAT      SDL_AUDIO_S16
 #define MIX_DEFAULT_CHANNELS    2
-#define MIX_MAX_VOLUME          128 /* Volume of a chunk */
 
 /**
  * The internal format for an audio chunk
@@ -197,7 +196,7 @@ typedef struct Mix_Chunk {
     int allocated;
     Uint8 *abuf;
     Uint32 alen;
-    Uint8 volume;       /* Per-sample volume, 0-128 */
+    float volume;       /* Per-sample volume */
 } Mix_Chunk;
 
 /**
@@ -1808,9 +1807,8 @@ extern SDL_DECLSPEC int SDLCALL Mix_FadeInChannelTimed(int channel, Mix_Chunk *c
 /**
  * Set the volume for a specific channel.
  *
- * The volume must be between 0 (silence) and MIX_MAX_VOLUME (full volume).
- * Note that MIX_MAX_VOLUME is 128. Values greater than MIX_MAX_VOLUME are
- * clamped to MIX_MAX_VOLUME.
+ * The volume must be between 0 (silence) and 1 (full volume).
+ * Values greater than 1 are clamped to 1.
  *
  * Specifying a negative volume will not change the current volume; as such,
  * this can be used to query the current volume without making changes, as
@@ -1820,18 +1818,18 @@ extern SDL_DECLSPEC int SDLCALL Mix_FadeInChannelTimed(int channel, Mix_Chunk *c
  * channels, and returns _the average_ of all channels' volumes prior to this
  * call.
  *
- * The default volume for a channel is MIX_MAX_VOLUME (no attenuation).
+ * The default volume for a channel is 1 (no attenuation).
  *
  * \param channel the channel on set/query the volume on, or -1 for all
  *                channels.
- * \param volume the new volume, between 0 and MIX_MAX_VOLUME, or -1 to query.
+ * \param volume the new volume, between 0 and 1, or -1 to query.
  * \returns the previous volume. If the specified volume is -1, this returns
  *          the current volume. If `channel` is -1, this returns the average
  *          of all channels.
  *
  * \since This function is available since SDL_mixer 3.0.0.
  */
-extern SDL_DECLSPEC int SDLCALL Mix_Volume(int channel, int volume);
+extern SDL_DECLSPEC float SDLCALL Mix_Volume(int channel, float volume);
 
 /**
  * Set the volume for a specific chunk.
@@ -1842,55 +1840,53 @@ extern SDL_DECLSPEC int SDLCALL Mix_Volume(int channel, int volume);
  * volume for all instances of a sound in addition to specific instances of
  * that sound.
  *
- * The volume must be between 0 (silence) and MIX_MAX_VOLUME (full volume).
- * Note that MIX_MAX_VOLUME is 128. Values greater than MIX_MAX_VOLUME are
- * clamped to MIX_MAX_VOLUME.
+ * The volume must be between 0 (silence) and 1 (full volume).
+ * Values greater than 1 are clamped to 1.
  *
  * Specifying a negative volume will not change the current volume; as such,
  * this can be used to query the current volume without making changes, as
  * this function returns the previous (in this case, still-current) value.
  *
- * The default volume for a chunk is MIX_MAX_VOLUME (no attenuation).
+ * The default volume for a chunk is 1 (no attenuation).
  *
  * \param chunk the chunk whose volume to adjust.
- * \param volume the new volume, between 0 and MIX_MAX_VOLUME, or -1 to query.
+ * \param volume the new volume, between 0 and 1, or -1 to query.
  * \returns the previous volume. If the specified volume is -1, this returns
  *          the current volume. If `chunk` is NULL, this returns -1.
  *
  * \since This function is available since SDL_mixer 3.0.0.
  */
-extern SDL_DECLSPEC int SDLCALL Mix_VolumeChunk(Mix_Chunk *chunk, int volume);
+extern SDL_DECLSPEC float SDLCALL Mix_VolumeChunk(Mix_Chunk *chunk, float volume);
 
 /**
  * Set the volume for the music channel.
  *
- * The volume must be between 0 (silence) and MIX_MAX_VOLUME (full volume).
- * Note that MIX_MAX_VOLUME is 128. Values greater than MIX_MAX_VOLUME are
- * clamped to MIX_MAX_VOLUME.
+ * The volume must be between 0 (silence) and 1 (full volume).
+ * Values greater than 1 are clamped to 1.
  *
  * Specifying a negative volume will not change the current volume; as such,
  * this can be used to query the current volume without making changes, as
  * this function returns the previous (in this case, still-current) value.
  *
- * The default volume for music is MIX_MAX_VOLUME (no attenuation).
+ * The default volume for music is 1 (no attenuation).
  *
- * \param volume the new volume, between 0 and MIX_MAX_VOLUME, or -1 to query.
+ * \param volume the new volume, between 0 and 1, or -1 to query.
  * \returns the previous volume. If the specified volume is -1, this returns
  *          the current volume.
  *
  * \since This function is available since SDL_mixer 3.0.0.
  */
-extern SDL_DECLSPEC int SDLCALL Mix_VolumeMusic(int volume);
+extern SDL_DECLSPEC float SDLCALL Mix_VolumeMusic(float volume);
 
 /**
  * Query the current volume value for a music object.
  *
  * \param music the music object to query.
- * \returns the music's current volume, between 0 and MIX_MAX_VOLUME (128).
+ * \returns the music's current volume, between 0 and 1.
  *
  * \since This function is available since SDL_mixer 3.0.0.
  */
-extern SDL_DECLSPEC int SDLCALL Mix_GetMusicVolume(Mix_Music *music);
+extern SDL_DECLSPEC float SDLCALL Mix_GetMusicVolume(Mix_Music *music);
 
 /**
  * Set the master volume for all channels.
@@ -1899,9 +1895,8 @@ extern SDL_DECLSPEC int SDLCALL Mix_GetMusicVolume(Mix_Music *music);
  * volume, and considers all three when mixing audio. This function sets the
  * master volume, which is applied to all playing channels when mixing.
  *
- * The volume must be between 0 (silence) and MIX_MAX_VOLUME (full volume).
- * Note that MIX_MAX_VOLUME is 128. Values greater than MIX_MAX_VOLUME are
- * clamped to MIX_MAX_VOLUME.
+ * The volume must be between 0 (silence) and 1 (full volume).
+ * Values greater than 1 are clamped to 1.
  *
  * Specifying a negative volume will not change the current volume; as such,
  * this can be used to query the current volume without making changes, as
@@ -1910,13 +1905,13 @@ extern SDL_DECLSPEC int SDLCALL Mix_GetMusicVolume(Mix_Music *music);
  * Note that the master volume does not affect any playing music; it is only
  * applied when mixing chunks. Use Mix_VolumeMusic() for that.\
  *
- * \param volume the new volume, between 0 and MIX_MAX_VOLUME, or -1 to query.
+ * \param volume the new volume, between 0 and 1, or -1 to query.
  * \returns the previous volume. If the specified volume is -1, this returns
  *          the current volume.
  *
  * \since This function is available since SDL_mixer 3.0.0.
  */
-extern SDL_DECLSPEC int SDLCALL Mix_MasterVolume(int volume);
+extern SDL_DECLSPEC float SDLCALL Mix_MasterVolume(float volume);
 
 /**
  * Halt playing of a particular channel.

--- a/src/codecs/music_drflac.c
+++ b/src/codecs/music_drflac.c
@@ -52,7 +52,7 @@ typedef struct {
     drflac *dec;
     int play_count;
     bool closeio;
-    int volume;
+    float volume;
     int status;
     int sample_rate;
     int channels;
@@ -167,7 +167,7 @@ static void *DRFLAC_CreateFromIO(SDL_IOStream *src, bool closeio)
     if (!music) {
         return NULL;
     }
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     if (MP3_IOinit(&music->file, src) < 0) {
         SDL_free(music);
@@ -215,13 +215,13 @@ static void *DRFLAC_CreateFromIO(SDL_IOStream *src, bool closeio)
     return music;
 }
 
-static void DRFLAC_SetVolume(void *context, int volume)
+static void DRFLAC_SetVolume(void *context, float volume)
 {
     DRFLAC_Music *music = (DRFLAC_Music *)context;
     music->volume = volume;
 }
 
-static int DRFLAC_GetVolume(void *context)
+static float DRFLAC_GetVolume(void *context)
 {
     DRFLAC_Music *music = (DRFLAC_Music *)context;
     return music->volume;

--- a/src/codecs/music_flac.c
+++ b/src/codecs/music_flac.c
@@ -163,7 +163,7 @@ static void FLAC_Unload(void)
 
 
 typedef struct {
-    int volume;
+    float volume;
     int play_count;
     FLAC__StreamDecoder *flac_decoder;
     unsigned sample_rate;
@@ -533,7 +533,7 @@ static void *FLAC_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
     music->src = src;
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     music->flac_decoder = flac.FLAC__stream_decoder_new();
     if (music->flac_decoder) {
@@ -609,14 +609,14 @@ static const char* FLAC_GetMetaTag(void *context, Mix_MusicMetaTag tag_type)
 
 
 /* Set the volume for an FLAC stream */
-static void FLAC_SetVolume(void *context, int volume)
+static void FLAC_SetVolume(void *context, float volume)
 {
     FLAC_Music *music = (FLAC_Music *)context;
     music->volume = volume;
 }
 
 /* Get the volume for an FLAC stream */
-static int FLAC_GetVolume(void *context)
+static float FLAC_GetVolume(void *context)
 {
     FLAC_Music *music = (FLAC_Music *)context;
     return music->volume;

--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -135,7 +135,7 @@ typedef struct {
     SDL_AudioStream *stream;
     void *buffer;
     int buffer_size;
-    int volume;
+    float volume;
     bool is_paused;
 } FLUIDSYNTH_Music;
 
@@ -187,7 +187,7 @@ static FLUIDSYNTH_Music *FLUIDSYNTH_LoadMusic(void *data)
         return NULL;
     }
 
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
     music->buffer_size = 4096/*music_spec.samples*/ * sizeof(Sint16) * channels;
     music->synth_write = fluidsynth.fluid_synth_write_s16;
     if (music_spec.format & 0x0020) { /* 32 bit. */
@@ -259,15 +259,15 @@ static void *FLUIDSYNTH_CreateFromIO(SDL_IOStream *src, bool closeio)
     return music;
 }
 
-static void FLUIDSYNTH_SetVolume(void *context, int volume)
+static void FLUIDSYNTH_SetVolume(void *context, float volume)
 {
     FLUIDSYNTH_Music *music = (FLUIDSYNTH_Music *)context;
     /* FluidSynth's default gain is 0.2. Make 1.0 the maximum gain value to avoid sound overload. */
     music->volume = volume;
-    fluidsynth.fluid_synth_set_gain(music->synth, volume * 1.0f / MIX_MAX_VOLUME);
+    fluidsynth.fluid_synth_set_gain(music->synth, volume);
 }
 
-static int FLUIDSYNTH_GetVolume(void *context)
+static float FLUIDSYNTH_GetVolume(void *context)
 {
     FLUIDSYNTH_Music *music = (FLUIDSYNTH_Music *)context;
     return music->volume;
@@ -321,7 +321,7 @@ static int FLUIDSYNTH_GetSome(void *context, void *data, int bytes, bool *done)
 }
 static int FLUIDSYNTH_GetAudio(void *context, void *data, int bytes)
 {
-    return music_pcm_getaudio(context, data, bytes, MIX_MAX_VOLUME, FLUIDSYNTH_GetSome);
+    return music_pcm_getaudio(context, data, bytes, 1.0f, FLUIDSYNTH_GetSome);
 }
 
 static void FLUIDSYNTH_Stop(void *context)

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -126,7 +126,7 @@ typedef struct
     int track_length;
     int intro_length;
     int loop_length;
-    int volume;
+    float volume;
     double tempo;
     double gain;
     SDL_AudioStream *stream;
@@ -138,19 +138,17 @@ typedef struct
 static void GME_Delete(void *context);
 
 /* Set the volume for a GME stream */
-static void GME_SetVolume(void *music_p, int volume)
+static void GME_SetVolume(void *music_p, float volume)
 {
     GME_Music *music = (GME_Music*)music_p;
-    double v = SDL_floor(((double)volume * music->gain) + 0.5);
-    music->volume = (int)v;
+    music->volume = volume;
 }
 
 /* Get the volume for a GME stream */
-static int GME_GetVolume(void *music_p)
+static float GME_GetVolume(void *music_p)
 {
     GME_Music *music = (GME_Music*)music_p;
-    double v = SDL_floor(((double)(music->volume) / music->gain) + 0.5);
-    return (int)v;
+    return music->volume;
 }
 
 static int initialize_from_track_info(GME_Music *music, int track)
@@ -265,7 +263,7 @@ static void *GME_CreateFromIO(struct SDL_IOStream *src, bool closeio)
 
     gme.gme_set_tempo(music->game_emu, music->tempo);
 
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     meta_tags_init(&music->tags);
     if (initialize_from_track_info(music, 0) < 0) {
@@ -328,7 +326,7 @@ static int GME_GetSome(void *context, void *data, int bytes, bool *done)
 static int GME_PlayAudio(void *music_p, void *data, int bytes)
 {
     GME_Music *music = (GME_Music*)music_p;
-    return music_pcm_getaudio(music_p, data, bytes, music->volume, GME_GetSome);
+    return music_pcm_getaudio(music_p, data, bytes, (float)SDL_floor(music->volume * music->gain + 0.5), GME_GetSome);
 }
 
 /* Close the given Game Music Emulators stream */

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -326,7 +326,7 @@ static int GME_GetSome(void *context, void *data, int bytes, bool *done)
 static int GME_PlayAudio(void *music_p, void *data, int bytes)
 {
     GME_Music *music = (GME_Music*)music_p;
-    return music_pcm_getaudio(music_p, data, bytes, (float)SDL_floor(music->volume * music->gain + 0.5), GME_GetSome);
+    return music_pcm_getaudio(music_p, data, bytes, (float)(music->volume * music->gain), GME_GetSome);
 }
 
 /* Close the given Game Music Emulators stream */

--- a/src/codecs/music_minimp3.c
+++ b/src/codecs/music_minimp3.c
@@ -35,7 +35,7 @@ typedef struct {
     int closeio;
     mp3dec_ex_t dec;
     mp3dec_io_t io;
-    int volume;
+    float volume;
     int status;
     SDL_AudioStream *stream;
     mp3d_sample_t *buffer;
@@ -72,7 +72,7 @@ static void *MINIMP3_CreateFromIO(SDL_IOStream *src, bool closeio)
     if (!music) {
         return NULL;
     }
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     if (MP3_IOinit(&music->file, src) < 0) {
         SDL_free(music);
@@ -125,13 +125,13 @@ static void *MINIMP3_CreateFromIO(SDL_IOStream *src, bool closeio)
     return music;
 }
 
-static void MINIMP3_SetVolume(void *context, int volume)
+static void MINIMP3_SetVolume(void *context, float volume)
 {
     MiniMP3_Music *music = (MiniMP3_Music *)context;
     music->volume = volume;
 }
 
-static int MINIMP3_GetVolume(void *context)
+static float MINIMP3_GetVolume(void *context)
 {
     MiniMP3_Music *music = (MiniMP3_Music *)context;
     return music->volume;

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -117,7 +117,7 @@ static void MODPLUG_Unload(void)
 
 typedef struct
 {
-    int volume;
+    float volume;
     int play_count;
     ModPlugFile *file;
     SDL_AudioStream *stream;
@@ -177,7 +177,7 @@ void *MODPLUG_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
 
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     SDL_zero(srcspec);
     srcspec.format = (settings.mBits == 8) ? SDL_AUDIO_U8 : SDL_AUDIO_S16;
@@ -220,15 +220,15 @@ void *MODPLUG_CreateFromIO(SDL_IOStream *src, bool closeio)
 }
 
 /* Set the volume for a modplug stream */
-static void MODPLUG_SetVolume(void *context, int volume)
+static void MODPLUG_SetVolume(void *context, float volume)
 {
     MODPLUG_Music *music = (MODPLUG_Music *)context;
     music->volume = volume;
-    modplug.ModPlug_SetMasterVolume(music->file, (unsigned int)volume * 2); /* 0-512, reduced to 0-256 to prevent clipping */
+    modplug.ModPlug_SetMasterVolume(music->file, volume * 256); /* 0-512, reduced to 0-256 to prevent clipping */
 }
 
 /* Get the volume for a modplug stream */
-static int MODPLUG_GetVolume(void *context)
+static float MODPLUG_GetVolume(void *context)
 {
     MODPLUG_Music *music = (MODPLUG_Music *)context;
     return music->volume;
@@ -289,7 +289,7 @@ static int MODPLUG_GetSome(void *context, void *data, int bytes, bool *done)
 
 static int MODPLUG_GetAudio(void *context, void *data, int bytes)
 {
-    return music_pcm_getaudio(context, data, bytes, MIX_MAX_VOLUME, MODPLUG_GetSome);
+    return music_pcm_getaudio(context, data, bytes, 1.0f, MODPLUG_GetSome);
 }
 
 /* Jump to a given order */

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -224,7 +224,7 @@ static void MODPLUG_SetVolume(void *context, float volume)
 {
     MODPLUG_Music *music = (MODPLUG_Music *)context;
     music->volume = volume;
-    modplug.ModPlug_SetMasterVolume(music->file, volume * 256); /* 0-512, reduced to 0-256 to prevent clipping */
+    modplug.ModPlug_SetMasterVolume(music->file, (unsigned int)(volume * 256)); /* 0-512, reduced to 0-256 to prevent clipping */
 }
 
 /* Get the volume for a modplug stream */

--- a/src/codecs/music_mpg123.c
+++ b/src/codecs/music_mpg123.c
@@ -141,7 +141,7 @@ typedef struct
     struct mp3file_t mp3file;
     int play_count;
     bool closeio;
-    int volume;
+    float volume;
 
     mpg123_handle* handle;
     SDL_AudioStream *stream;
@@ -244,7 +244,7 @@ static void *MPG123_CreateFromIO(SDL_IOStream *src, bool closeio)
     if (!music) {
         return NULL;
     }
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     if (MP3_IOinit(&music->mp3file, src) < 0) {
         SDL_free(music);
@@ -339,13 +339,13 @@ static void *MPG123_CreateFromIO(SDL_IOStream *src, bool closeio)
     return music;
 }
 
-static void MPG123_SetVolume(void *context, int volume)
+static void MPG123_SetVolume(void *context, float volume)
 {
     MPG123_Music *music = (MPG123_Music *)context;
     music->volume = volume;
 }
 
-static int MPG123_GetVolume(void *context)
+static float MPG123_GetVolume(void *context)
 {
     MPG123_Music *music = (MPG123_Music *)context;
     return music->volume;

--- a/src/codecs/music_nativemidi.c
+++ b/src/codecs/music_nativemidi.c
@@ -47,7 +47,7 @@ static int NATIVEMIDI_Play(void *context, int play_count)
     return 0;
 }
 
-static void NATIVEMIDI_SetVolume(void *context, int volume)
+static void NATIVEMIDI_SetVolume(void *context, float volume)
 {
     (void)context;
     native_midi_setvolume(volume);

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -128,7 +128,7 @@ typedef struct {
     SDL_IOStream *src;
     bool closeio;
     int play_count;
-    int volume;
+    float volume;
     OggVorbis_File vf;
     vorbis_info vi;
     int section;
@@ -254,7 +254,7 @@ static void *OGG_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
     music->src = src;
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
     music->section = -1;
 
     callbacks.read_func = sdl_read_func;
@@ -343,14 +343,14 @@ static const char* OGG_GetMetaTag(void *context, Mix_MusicMetaTag tag_type)
 }
 
 /* Set the volume for an OGG stream */
-static void OGG_SetVolume(void *context, int volume)
+static void OGG_SetVolume(void *context, float volume)
 {
     OGG_music *music = (OGG_music *)context;
     music->volume = volume;
 }
 
 /* Get the volume for an OGG stream */
-static int OGG_GetVolume(void *context)
+static float OGG_GetVolume(void *context)
 {
     OGG_music *music = (OGG_music *)context;
     return music->volume;

--- a/src/codecs/music_ogg_stb.c
+++ b/src/codecs/music_ogg_stb.c
@@ -71,7 +71,7 @@ typedef struct {
     SDL_IOStream *src;
     bool closeio;
     int play_count;
-    int volume;
+    float volume;
     stb_vorbis *vf;
     stb_vorbis_info vi;
     int section;
@@ -177,7 +177,7 @@ static void *OGG_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
     music->src = src;
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
     music->section = -1;
 
     music->vf = stb_vorbis_open_io(src, 0, &error, NULL);
@@ -279,14 +279,14 @@ static const char* OGG_GetMetaTag(void *context, Mix_MusicMetaTag tag_type)
 }
 
 /* Set the volume for an OGG stream */
-static void OGG_SetVolume(void *context, int volume)
+static void OGG_SetVolume(void *context, float volume)
 {
     OGG_music *music = (OGG_music *)context;
     music->volume = volume;
 }
 
 /* Get the volume for an OGG stream */
-static int OGG_GetVolume(void *context)
+static float OGG_GetVolume(void *context)
 {
     OGG_music *music = (OGG_music *)context;
     return music->volume;

--- a/src/codecs/music_opus.c
+++ b/src/codecs/music_opus.c
@@ -106,7 +106,7 @@ typedef struct {
     SDL_IOStream *src;
     bool closeio;
     int play_count;
-    int volume;
+    float volume;
     OggOpusFile *of;
     const OpusHead *op_info;
     int section;
@@ -224,7 +224,7 @@ static void *OPUS_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
     music->src = src;
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
     music->section = -1;
 
     SDL_zero(callbacks);
@@ -321,14 +321,14 @@ static const char* OPUS_GetMetaTag(void *context, Mix_MusicMetaTag tag_type)
 }
 
 /* Set the volume for an Opus stream */
-static void OPUS_SetVolume(void *context, int volume)
+static void OPUS_SetVolume(void *context, float volume)
 {
     OPUS_music *music = (OPUS_music *)context;
     music->volume = volume;
 }
 
 /* Get the volume for an Opus stream */
-static int OPUS_GetVolume(void *context)
+static float OPUS_GetVolume(void *context)
 {
     OPUS_music *music = (OPUS_music *)context;
     return music->volume;

--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -35,7 +35,7 @@ typedef struct
     SDL_AudioStream *stream;
     void *buffer;
     Sint32 buffer_size;
-    int volume;
+    float volume;
 } TIMIDITY_Music;
 
 
@@ -94,7 +94,7 @@ void *TIMIDITY_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
 
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     SDL_memcpy(&spec, &music_spec, sizeof(spec));
     if (spec.channels > 2) {
@@ -128,14 +128,14 @@ void *TIMIDITY_CreateFromIO(SDL_IOStream *src, bool closeio)
     return music;
 }
 
-static void TIMIDITY_SetVolume(void *context, int volume)
+static void TIMIDITY_SetVolume(void *context, float volume)
 {
     TIMIDITY_Music *music = (TIMIDITY_Music *)context;
     music->volume = volume;
     Timidity_SetVolume(music->song, volume);
 }
 
-static int TIMIDITY_GetVolume(void *context)
+static float TIMIDITY_GetVolume(void *context)
 {
     TIMIDITY_Music *music = (TIMIDITY_Music *)context;
     return music->volume;
@@ -209,7 +209,7 @@ static int TIMIDITY_GetSome(void *context, void *data, int bytes, bool *done)
 
 static int TIMIDITY_GetAudio(void *context, void *data, int bytes)
 {
-    return music_pcm_getaudio(context, data, bytes, MIX_MAX_VOLUME, TIMIDITY_GetSome);
+    return music_pcm_getaudio(context, data, bytes, 1.0f, TIMIDITY_GetSome);
 }
 
 static int TIMIDITY_Seek(void *context, double position)

--- a/src/codecs/music_wav.c
+++ b/src/codecs/music_wav.c
@@ -80,7 +80,7 @@ typedef struct {
     SDL_IOStream *src;
     bool closeio;
     SDL_AudioSpec spec;
-    int volume;
+    float volume;
     int play_count;
     Sint64 start;
     Sint64 stop;
@@ -233,7 +233,7 @@ static void *WAV_CreateFromIO(SDL_IOStream *src, bool closeio)
         return NULL;
     }
     music->src = src;
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
     /* Default decoder is PCM */
     music->decode = fetch_pcm;
     music->encoding = PCM_CODE;
@@ -271,13 +271,13 @@ static void *WAV_CreateFromIO(SDL_IOStream *src, bool closeio)
     return music;
 }
 
-static void WAV_SetVolume(void *context, int volume)
+static void WAV_SetVolume(void *context, float volume)
 {
     WAV_Music *music = (WAV_Music *)context;
     music->volume = volume;
 }
 
-static int WAV_GetVolume(void *context)
+static float WAV_GetVolume(void *context)
 {
     WAV_Music *music = (WAV_Music *)context;
     return music->volume;

--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -182,7 +182,7 @@ typedef struct {
     SDL_IOStream *src2; /* correction file */
     bool closeio;
     int play_count;
-    int volume;
+    float volume;
 
     WavpackContext *ctx;
     int64_t numsamples;
@@ -364,7 +364,7 @@ static void *WAVPACK_CreateFromIO_internal(SDL_IOStream *src1, SDL_IOStream *src
     }
     music->src1 = src1;
     music->src2 = src2;
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
 
     music->ctx = (wvpk.WavpackOpenFileInputEx64 != NULL) ?
                   wvpk.WavpackOpenFileInputEx64(&sdl_reader64, src1, src2, err, OPEN_NORMALIZE|OPEN_TAGS|FLAGS_DSD, 0) :
@@ -477,13 +477,13 @@ static const char* WAVPACK_GetMetaTag(void *context, Mix_MusicMetaTag tag_type)
     return meta_tags_get(&music->tags, tag_type);
 }
 
-static void WAVPACK_SetVolume(void *context, int volume)
+static void WAVPACK_SetVolume(void *context, float volume)
 {
     WAVPACK_music *music = (WAVPACK_music *)context;
     music->volume = volume;
 }
 
-static int WAVPACK_GetVolume(void *context)
+static float WAVPACK_GetVolume(void *context)
 {
     WAVPACK_music *music = (WAVPACK_music *)context;
     return music->volume;

--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -135,7 +135,7 @@ typedef struct
 {
     SDL_IOStream *src;
     Sint64 src_offset;
-    int volume;
+    float volume;
     int play_count;
     struct xmp_module_info mi;
     struct xmp_frame_info fi;
@@ -259,7 +259,7 @@ void *XMP_CreateFromIO(SDL_IOStream *src, bool closeio)
         goto e2;
     }
 
-    music->volume = MIX_MAX_VOLUME;
+    music->volume = 1.0f;
     SDL_zero(srcspec);
     srcspec.format = SDL_AUDIO_S16;
     srcspec.channels = 2;
@@ -291,14 +291,14 @@ e0: SDL_free(music->buffer); SDL_free(music);
 }
 
 /* Set the volume for a libxmp stream */
-static void XMP_SetVolume(void *context, int volume)
+static void XMP_SetVolume(void *context, float volume)
 {
     XMP_Music *music = (XMP_Music *)context;
     music->volume = volume;
 }
 
 /* Get the volume for a libxmp stream */
-static int XMP_GetVolume(void *context)
+static float XMP_GetVolume(void *context)
 {
     XMP_Music *music = (XMP_Music *)context;
     return music->volume;

--- a/src/codecs/native_midi/native_midi.h
+++ b/src/codecs/native_midi/native_midi.h
@@ -34,7 +34,7 @@ void native_midi_pause(void);
 void native_midi_resume(void);
 void native_midi_stop(void);
 bool native_midi_active(void);
-void native_midi_setvolume(int volume);
+void native_midi_setvolume(float volume);
 const char *native_midi_error(void);
 
 #endif /* NATIVE_MIDI_H_ */

--- a/src/codecs/native_midi/native_midi_haiku.cpp
+++ b/src/codecs/native_midi/native_midi_haiku.cpp
@@ -212,11 +212,11 @@ bool native_midi_detect(void)
   return res == B_OK;
 }
 
-void native_midi_setvolume(int volume)
+void native_midi_setvolume(float volume)
 {
-  if (volume < 0) volume = 0;
-  if (volume > 128) volume = 128;
-  synth.SetVolume(volume / 128.0);
+  if (volume < 0.0f) volume = 0.0f;
+  if (volume > 1.0f) volume = 1.0f;
+  synth.SetVolume(volume);
 }
 
 NativeMidiSong *native_midi_loadsong_IO(SDL_IOStream *src, bool closeio)

--- a/src/codecs/native_midi/native_midi_macosx.c
+++ b/src/codecs/native_midi/native_midi_macosx.c
@@ -47,7 +47,7 @@ struct _NativeMidiSong
 };
 
 static NativeMidiSong *currentsong = NULL;
-static int latched_volume = MIX_MAX_VOLUME;
+static float latched_volume = 1.0f;
 
 static OSStatus
 GetSequenceLength(MusicSequence sequence, MusicTimeStamp *_sequenceLength)
@@ -278,7 +278,7 @@ void native_midi_freesong(NativeMidiSong *song)
 
 void native_midi_start(NativeMidiSong *song, int loops)
 {
-    int vol;
+    float vol;
 
     if (song == NULL)
         return;
@@ -337,16 +337,15 @@ bool native_midi_active(void)
     return false;
 }
 
-void native_midi_setvolume(int volume)
+void native_midi_setvolume(float volume)
 {
     if (latched_volume == volume)
         return;
 
     latched_volume = volume;
     if ((currentsong) && (currentsong->audiounit)) {
-        const float floatvol = ((float) volume) / ((float) MIX_MAX_VOLUME);
         AudioUnitSetParameter(currentsong->audiounit, kHALOutputParam_Volume,
-                              kAudioUnitScope_Global, 0, floatvol, 0);
+                              kAudioUnitScope_Global, 0, volume, 0);
     }
 }
 

--- a/src/codecs/native_midi/native_midi_macosx.c
+++ b/src/codecs/native_midi/native_midi_macosx.c
@@ -396,7 +396,7 @@ bool native_midi_active(void)
 {
 }
 
-void native_midi_setvolume(int volume)
+void native_midi_setvolume(float volume)
 {
 }
 

--- a/src/codecs/native_midi/native_midi_win32.c
+++ b/src/codecs/native_midi/native_midi_win32.c
@@ -320,15 +320,16 @@ bool native_midi_active(void)
   return currentsong->MusicPlaying;
 }
 
-void native_midi_setvolume(int volume)
+void native_midi_setvolume(float volume)
 {
   int calcVolume;
-  if (volume > 128)
-    volume = 128;
-  if (volume < 0)
-    volume = 0;
-  calcVolume = (65535 * volume / 128);
+  if (volume > 1.0f)
+    volume = 1.0f;
+  if (volume < 0.0f)
+    volume = 0.0f;
+  calcVolume = (int)(65535 * volume);
 
+  midiOutSetVolume((HMIDIOUT)hMidiStream, MAKELONG(calcVolume , calcVolume));
   midiOutSetVolume((HMIDIOUT)hMidiStream, MAKELONG(calcVolume , calcVolume));
 }
 

--- a/src/codecs/timidity/playmidi.c
+++ b/src/codecs/timidity/playmidi.c
@@ -785,7 +785,7 @@ int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len)
 void Timidity_SetVolume(MidiSong *song, float fvolume)
 {
   int i;
-  int volume = (int)(fvolume / 128);
+  int volume = (int)(fvolume * 128);
 
   if (volume > MAX_AMPLIFICATION)
     song->amplification = MAX_AMPLIFICATION;

--- a/src/codecs/timidity/playmidi.c
+++ b/src/codecs/timidity/playmidi.c
@@ -782,9 +782,11 @@ int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len)
   return samples * bytes_per_sample;
 }
 
-void Timidity_SetVolume(MidiSong *song, int volume)
+void Timidity_SetVolume(MidiSong *song, float fvolume)
 {
   int i;
+  int volume = (int)(fvolume / 128); // How should this be handled?
+
   if (volume > MAX_AMPLIFICATION)
     song->amplification = MAX_AMPLIFICATION;
   else

--- a/src/codecs/timidity/playmidi.c
+++ b/src/codecs/timidity/playmidi.c
@@ -785,7 +785,7 @@ int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len)
 void Timidity_SetVolume(MidiSong *song, float fvolume)
 {
   int i;
-  int volume = (int)(fvolume / 128); // How should this be handled?
+  int volume = (int)(fvolume / 128);
 
   if (volume > MAX_AMPLIFICATION)
     song->amplification = MAX_AMPLIFICATION;

--- a/src/codecs/timidity/timidity.h
+++ b/src/codecs/timidity/timidity.h
@@ -149,7 +149,7 @@ typedef struct {
 
 extern int Timidity_Init(const char *config_file);
 extern int Timidity_Init_NoConfig(void);
-extern void Timidity_SetVolume(MidiSong *song, int volume);
+extern void Timidity_SetVolume(MidiSong *song, float fvolume);
 extern int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len);
 extern MidiSong *Timidity_LoadSong(SDL_IOStream *io, SDL_AudioSpec *audio);
 extern void Timidity_Start(MidiSong *song);

--- a/src/music.h
+++ b/src/music.h
@@ -95,10 +95,10 @@ typedef struct
     void *(*CreateFromFile)(const char *file);
 
     /* Set the volume */
-    void (*SetVolume)(void *music, int volume);
+    void (*SetVolume)(void *music, float volume);
 
     /* Get the volume */
-    int (*GetVolume)(void *music);
+    float (*GetVolume)(void *music);
 
     /* Start playing music from the beginning with an optional loop count */
     int (*Play)(void *music, int play_count);
@@ -166,7 +166,7 @@ extern bool load_music_type(Mix_MusicType type);
 extern bool open_music_type(Mix_MusicType type);
 extern bool has_music(Mix_MusicType type);
 extern void open_music(const SDL_AudioSpec *spec);
-extern int music_pcm_getaudio(void *context, void *data, int bytes, int volume,
+extern int music_pcm_getaudio(void *context, void *data, int bytes, float volume,
                               int (*GetSome)(void *context, void *data, int bytes, bool *done));
 extern void SDLCALL music_mixer(void *udata, Uint8 *stream, int len);
 extern void pause_async_music(int pause_on);


### PR DESCRIPTION
In a lot of places this actually makes the code simpler. Volumes can be multiplied without then dividing by the integer range, the new SDL3 mixing API can be used without another divide into float-land, it makes one or two music codecs more straightforward.

Closes #652 

A couple things I wanted to highlight in review:
- The handling of gain in music_gme.c might not be 100% the same, I'm finding it difficult to think through the x * y vs floor(x * y + 0.5)/128.
- The Timidity_SetVolume function previously took in values between 0 and 128, but compares to a MAX AMPLIFICATION of 800, and checks if the value is at least 0. That is strange.
- Is my handling of master_volume in mixer.c okay? It previously was an SDL_AtomicInt, but there is no SDL_AtomicFloat so I gave it a spinlock instead.