### PR TITLE
autotools: set CMake libraries directly in configure.ac

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -116,6 +116,18 @@ install-hdrs:
 	$(SHELL) $(auxdir)/mkinstalldirs $(libdir)/cmake/SDL2_mixer/
 	$(INSTALL) -m 644 sdl2_mixer-config.cmake $(libdir)/cmake/SDL2_mixer
 	$(INSTALL) -m 644 sdl2_mixer-config-version.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/PkgConfigHelper.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/FindFLAC.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/FindFluidSynth.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findgme.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findlibxmp.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findlibxmp-lite.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findmodplug.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findmpg123.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/FindOpusFile.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findtremor.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/FindVorbis.cmake $(libdir)/cmake/SDL2_mixer
+	$(INSTALL) -m 644 $(srcdir)/cmake/Findwavpack.cmake $(libdir)/cmake/SDL2_mixer
 install-lib: $(objects)/$(TARGET)
 	$(SHELL) $(auxdir)/mkinstalldirs $(libdir)
 	$(LIBTOOL) --mode=install $(INSTALL) $(objects)/$(TARGET) $(libdir)/$(TARGET)
@@ -135,6 +147,18 @@ uninstall-hdrs:
 	-rmdir $(libdir)/pkgconfig
 	rm -f $(libdir)/cmake/SDL2_mixer/sdl2_mixer-config.cmake
 	rm -f $(libdir)/cmake/SDL2_mixer/sdl2_mixer-config-version.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/PkgConfigHelper.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/FindFLAC.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/FindFluidSynth.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/Findgme.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/Findlibxmp.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/Findlibxmp-lite
+	rm -f $(libdir)/cmake/SDL2_mixer/Findmodplug.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/Findmpg123.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/FindOpusFile.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/Findtremor.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/FindVorbis.cmake
+	rm -f $(libdir)/cmake/SDL2_mixer/Findwavpack.cmake
 	-rmdir $(libdir)/cmake/SDL2_mixer
 	-rmdir $(libdir)/cmake
 uninstall-lib:

--- a/configure
+++ b/configure
@@ -822,6 +822,7 @@ PC_LIBS
 PC_REQUIRES
 SDL_VERSION
 EXE
+CMAKE_LIBS
 MIXER_LIBS
 EXTRA_LDFLAGS
 BUILD_LDFLAGS
@@ -4965,13 +4966,13 @@ then :
 else $as_nop
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4968: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4969: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4971: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4972: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4974: output\"" >&5)
+  (eval echo "\"\$as_me:4975: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -6230,7 +6231,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6233 "configure"' > conftest.$ac_ext
+  echo '#line 6234 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7903,11 +7904,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7906: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7907: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7910: \$? = $ac_status" >&5
+   echo "$as_me:7911: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8253,11 +8254,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8256: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8257: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8260: \$? = $ac_status" >&5
+   echo "$as_me:8261: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8360,11 +8361,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8363: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8364: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8367: \$? = $ac_status" >&5
+   echo "$as_me:8368: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -8416,11 +8417,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8419: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8420: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8423: \$? = $ac_status" >&5
+   echo "$as_me:8424: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -10859,7 +10860,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10862 "configure"
+#line 10863 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10956,7 +10957,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10959 "configure"
+#line 10960 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -12266,11 +12267,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -12312,11 +12313,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -12636,11 +12637,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -12682,11 +12683,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -14655,11 +14656,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14658: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14659: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:14662: \$? = $ac_status" >&5
+   echo "$as_me:14663: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -14756,11 +14757,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14759: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14760: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:14763: \$? = $ac_status" >&5
+   echo "$as_me:14764: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -14809,11 +14810,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14812: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14813: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:14816: \$? = $ac_status" >&5
+   echo "$as_me:14817: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -16401,6 +16402,7 @@ EXTRA_CFLAGS="$INCLUDE $BASE_CFLAGS"
 BUILD_LDFLAGS="$LDFLAGS"
 EXTRA_LDFLAGS="$BASE_LDFLAGS"
 MIXER_LIBS=
+CMAKE_LIBS=
 ## These are common directories to find software packages
 #for path in /usr/freeware /usr/pkg /usr/local; do
 #    if test -d $path/include; then
@@ -17010,7 +17012,10 @@ fi
 printf "%s\n" "$ac_cv_lib_m_pow" >&6; }
 if test "x$ac_cv_lib_m_pow" = xyes
 then :
-  LIBM="-lm"
+
+    MIXER_LIBS="$MIXER_LIBS -lm"
+    CMAKE_LIBS="$CMAKE_LIBS;m"
+
 fi
 
 
@@ -17308,6 +17313,7 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMODPLUG_DYNAMIC=\\\"$modplug_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $MODPLUG_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;modplug::modplug"
             if test x$have_libmodplug_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmodplug"
             else
@@ -17544,6 +17550,11 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DXMP_DYNAMIC=\\\"$xmp_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $XMP_LIBS"
+            if test x$enable_music_mod_xmp_lite = xyes; then
+                CMAKE_LIBS="$CMAKE_LIBS;libxmp-lite::libxmp-lite"
+            else
+                CMAKE_LIBS="$CMAKE_LIBS;libxmp::libxmp"
+            fi
             if test x$have_libxmp_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES lib$xmplib"
             else
@@ -17616,16 +17627,19 @@ fi
             *-*-cygwin* | *-*-mingw*)
                 use_music_midi_native=yes
                 MIXER_LIBS="$MIXER_LIBS -lwinmm"
+                CMAKE_LIBS="$CMAKE_LIBS;winmm"
                 PC_LIBS="$PC_LIBS -lwinmm"
                 ;;
             *-*-darwin*)
                 use_music_midi_native=yes
                 MIXER_LIBS="$MIXER_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
+                CMAKE_LIBS="$CMAKE_LIBS;-Wl,-framework,AudioToolbox;-Wl,-framework,AudioUnit;-Wl,-framework,CoreServices"
                 PC_LIBS="$PC_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
                 ;;
             *-*-haiku*)
                 use_music_midi_native=yes_cpp
                 MIXER_LIBS="$MIXER_LIBS -lmidi"
+                CMAKE_LIBS="$CMAKE_LIBS;midi"
                 PC_LIBS="$PC_LIBS -lmidi"
                 ;;
         esac
@@ -17851,6 +17865,7 @@ fi
                 EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLUIDSYNTH_DYNAMIC=\\\"$fluidsynth_lib\\\""
             else
                 MIXER_LIBS="$MIXER_LIBS $FLUIDSYNTH_LIBS"
+                CMAKE_LIBS="$CMAKE_LIBS;FluidSynth::libfluidsynth"
                 if test x$have_fluidsynth_pc = xyes; then
                     PC_REQUIRES="$PC_REQUIRES fluidsynth"
                 else
@@ -18331,6 +18346,7 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $VORBIS_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;Vorbis::vorbisfile"
             if test x$have_ogg_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisfile"
             else
@@ -18559,6 +18575,7 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $TREMOR_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;tremor::tremor"
             if test x$have_tremor_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisidec"
             else
@@ -18848,6 +18865,7 @@ printf "%s\n" "$have_flac_ver" >&6; }
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLAC_DYNAMIC=\\\"$flac_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $FLAC_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;FLAC::FLAC"
             if test x$have_flac_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES flac"
             else
@@ -19097,6 +19115,7 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMPG123_DYNAMIC=\\\"$mpg123_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $MPG123_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;MPG123::libmpg123"
             if test x$have_mpg123_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmpg123"
             else
@@ -19327,6 +19346,7 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOPUS_DYNAMIC=\\\"$opusfile_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $OPUSFILE_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;OpusFile::opusfile"
             if test x$have_opusfile_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES opusfile"
             else
@@ -19594,6 +19614,7 @@ fi
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DWAVPACK_DYNAMIC=\\\"$wavpack_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $WAVPACK_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;WavPack::WavPack"
             if test x$have_wavpack_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES wavpack"
             else
@@ -19610,8 +19631,6 @@ printf "%s\n" "$as_me: WARNING: WavPack support disabled" >&2;}
 fi
 
 CheckNoUndef
-
-MIXER_LIBS="$MIXER_LIBS $LIBM"
 
 OBJECTS=`echo $SOURCES`
 DEPENDS=`echo $SOURCES`
@@ -19749,6 +19768,7 @@ case "$_lcl_notation" in
 esac
   eval $_lcl_result_var='$_lcl_result_tmp'
 done
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ EXTRA_CFLAGS="$INCLUDE $BASE_CFLAGS"
 BUILD_LDFLAGS="$LDFLAGS"
 EXTRA_LDFLAGS="$BASE_LDFLAGS"
 MIXER_LIBS=
+CMAKE_LIBS=
 ## These are common directories to find software packages
 #for path in /usr/freeware /usr/pkg /usr/local; do
 #    if test -d $path/include; then
@@ -306,7 +307,10 @@ dnl check for GCC visibility attributes
 CheckVisibilityHidden
 
 dnl Check for math library
-AC_CHECK_LIB(m, pow, [LIBM="-lm"])
+AC_CHECK_LIB(m, pow, [
+    MIXER_LIBS="$MIXER_LIBS -lm"
+    CMAKE_LIBS="$CMAKE_LIBS;m"
+])
 
 AC_CHECK_HEADERS([signal.h], [EXTRA_CFLAGS="$EXTRA_CFLAGS -DHAVE_SIGNAL_H"])
 AC_CHECK_FUNCS(setbuf, [EXTRA_CFLAGS="$EXTRA_CFLAGS -DHAVE_SETBUF"])
@@ -389,6 +393,7 @@ if test x$enable_music_mod = xyes -a x$enable_music_mod_modplug = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMODPLUG_DYNAMIC=\\\"$modplug_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $MODPLUG_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;modplug::modplug"
             if test x$have_libmodplug_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmodplug"
             else
@@ -451,6 +456,11 @@ if test x$enable_music_mod = xyes -a x$enable_music_mod_xmp = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DXMP_DYNAMIC=\\\"$xmp_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $XMP_LIBS"
+            if test x$enable_music_mod_xmp_lite = xyes; then
+                CMAKE_LIBS="$CMAKE_LIBS;libxmp-lite::libxmp-lite"
+            else
+                CMAKE_LIBS="$CMAKE_LIBS;libxmp::libxmp"
+            fi
             if test x$have_libxmp_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES lib$xmplib"
             else
@@ -501,16 +511,19 @@ if test x$enable_music_midi = xyes; then
             *-*-cygwin* | *-*-mingw*)
                 use_music_midi_native=yes
                 MIXER_LIBS="$MIXER_LIBS -lwinmm"
+                CMAKE_LIBS="$CMAKE_LIBS;winmm"
                 PC_LIBS="$PC_LIBS -lwinmm"
                 ;;
             *-*-darwin*)
                 use_music_midi_native=yes
                 MIXER_LIBS="$MIXER_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
+                CMAKE_LIBS="$CMAKE_LIBS;-Wl,-framework,AudioToolbox;-Wl,-framework,AudioUnit;-Wl,-framework,CoreServices"
                 PC_LIBS="$PC_LIBS -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,CoreServices"
                 ;;
             *-*-haiku*)
                 use_music_midi_native=yes_cpp
                 MIXER_LIBS="$MIXER_LIBS -lmidi"
+                CMAKE_LIBS="$CMAKE_LIBS;midi"
                 PC_LIBS="$PC_LIBS -lmidi"
                 ;;
         esac
@@ -568,6 +581,7 @@ if test x$enable_music_midi = xyes; then
                 EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLUIDSYNTH_DYNAMIC=\\\"$fluidsynth_lib\\\""
             else
                 MIXER_LIBS="$MIXER_LIBS $FLUIDSYNTH_LIBS"
+                CMAKE_LIBS="$CMAKE_LIBS;FluidSynth::libfluidsynth"
                 if test x$have_fluidsynth_pc = xyes; then
                     PC_REQUIRES="$PC_REQUIRES fluidsynth"
                 else
@@ -697,6 +711,7 @@ if test x$enable_music_ogg = xyes -a x$enable_music_ogg_vorbis = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $VORBIS_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;Vorbis::vorbisfile"
             if test x$have_ogg_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisfile"
             else
@@ -756,6 +771,7 @@ if test x$enable_music_ogg = xyes -a x$enable_music_ogg_tremor = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOGG_DYNAMIC=\\\"$ogg_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $TREMOR_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;tremor::tremor"
             if test x$have_tremor_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES vorbisidec"
             else
@@ -846,6 +862,7 @@ if test x$enable_music_flac = xyes -a x$enable_music_flac_libflac = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DFLAC_DYNAMIC=\\\"$flac_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $FLAC_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;FLAC::FLAC"
             if test x$have_flac_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES flac"
             else
@@ -915,6 +932,7 @@ if test x$enable_music_mp3 = xyes -a x$enable_music_mp3_mpg123 = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DMPG123_DYNAMIC=\\\"$mpg123_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $MPG123_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;MPG123::libmpg123"
             if test x$have_mpg123_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES libmpg123"
             else
@@ -975,6 +993,7 @@ if test x$enable_music_opus = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DOPUS_DYNAMIC=\\\"$opusfile_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $OPUSFILE_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;OpusFile::opusfile"
             if test x$have_opusfile_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES opusfile"
             else
@@ -1051,6 +1070,7 @@ if test x$enable_music_wavpack = xyes; then
             EXTRA_CFLAGS="$EXTRA_CFLAGS -DWAVPACK_DYNAMIC=\\\"$wavpack_lib\\\""
         else
             MIXER_LIBS="$MIXER_LIBS $WAVPACK_LIBS"
+            CMAKE_LIBS="$CMAKE_LIBS;WavPack::WavPack"
             if test x$have_wavpack_pc = xyes; then
                 PC_REQUIRES="$PC_REQUIRES wavpack"
             else
@@ -1066,8 +1086,6 @@ fi
 
 dnl check for LD --no-undefined option
 CheckNoUndef
-
-MIXER_LIBS="$MIXER_LIBS $LIBM"
 
 OBJECTS=`echo $SOURCES`
 DEPENDS=`echo $SOURCES`
@@ -1129,6 +1147,7 @@ AC_SUBST(EXTRA_CFLAGS)
 AC_SUBST(BUILD_LDFLAGS)
 AC_SUBST(EXTRA_LDFLAGS)
 AC_SUBST(MIXER_LIBS)
+AC_SUBST(CMAKE_LIBS)
 AC_SUBST(EXE)
 AC_SUBST(SDL_VERSION)
 AC_SUBST(SDL_CFLAGS)

--- a/sdl2_mixer-config.cmake.in
+++ b/sdl2_mixer-config.cmake.in
@@ -76,17 +76,62 @@ set(exec_prefix "@exec_prefix@")
 set(bindir "@bindir@")
 set(includedir "@includedir@")
 set(libdir "@libdir@")
-set(_sdl2mixer_extra_static_libraries "@MIXER_LIBS@ @PC_LIBS@")
-string(STRIP "${_sdl2mixer_extra_static_libraries}" _sdl2mixer_extra_static_libraries)
+set(_sdl2mixer_extra_static_libraries "@CMAKE_LIBS@")
+string(REGEX REPLACE "(^[;]+|[;]+$)" "" _sdl2mixer_extra_static_libraries "${_sdl2mixer_extra_static_libraries}")
 
 set(_sdl2mixer_bindir   "${bindir}")
 set(_sdl2mixer_libdir   "${libdir}")
 set(_sdl2mixer_incdir   "${includedir}/SDL2")
 
-# Convert _sdl2mixer_extra_static_libraries to list and keep only libraries
-string(REGEX MATCHALL "(-[lm]([-a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)" _sdl2mixer_extra_static_libraries "${_sdl2mixer_extra_static_libraries}")
-string(REGEX REPLACE "^-l" "" _sdl2mixer_extra_static_libraries "${_sdl2mixer_extra_static_libraries}")
-string(REGEX REPLACE ";-l" ";" _sdl2mixer_extra_static_libraries "${_sdl2mixer_extra_static_libraries}")
+include(CMakeFindDependencyMacro)
+
+set(_original_cmake_module_path "${CMAKE_MODULE_PATH}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PkgConfigHelper.cmake")
+
+if("modplug::modplug" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(modplug)
+endif()
+
+if("libxmp::libxmp" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(libxmp)
+endif()
+
+if("libxmp-lite::libxmp-lite" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(libxmp-lite)
+endif()
+
+if("FluidSynth::libfluidsynth" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(FluidSynth)
+endif()
+
+if("Vorbis::vorbisfile" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(Vorbis)
+endif()
+
+if("tremor::tremor" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(tremor)
+endif()
+
+if("FLAC::FLAC" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(FLAC)
+endif()
+
+if("MPG123::libmpg123" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(mpg123)
+endif()
+
+if("OpusFile::opusfile" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(OpusFile)
+endif()
+
+if("WavPack::WavPack" IN_LIST _sdl2mixer_extra_static_libraries)
+    find_dependency(wavpack)
+endif()
+
+set(CMAKE_MODULE_PATH "${_original_cmake_module_path}")
+unset(_original_cmake_module_path)
 
 unset(prefix)
 unset(exec_prefix)


### PR DESCRIPTION
Build CMake list containing CMake targets in configure.ac


I tested this with:
```cmd
mkdir build
cd build
../configure --prefix=$PWD/prefix --enable-music-mod-modplug-shared=no --enable-music-mod-xmp-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-gme-shared=no --enable-music-ogg-vorbis-shared=no --enable-music-ogg-tremor-shared=no --enable-music-flac-libflac-shared=no --enable-music-mp3-mpg123-shared=no --enable-music-opus-shared=no --enable-music-wavpack-shared=no
make
make install
cmake -S ../cmake/test -B /tmp/sdl2-mixer-autotools-cmake-test-build --fresh -DCMAKE_PREFIX_PATH=$PWD/prefix
cmake --build /tmp/sdl2-mixer-autotools-cmake-test-build
```


Fixes #655