### PR TITLE
Fixed linker order so -lmingw32 comes before -lSDLmain (SDL 1.2)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -66,10 +66,10 @@ $(objects)/$(TARGET): $(OBJECTS) $(VERSION_OBJECTS)
 	$(LIBTOOL) --mode=link $(CC) -o $@ $(OBJECTS) $(VERSION_OBJECTS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
 
 $(objects)/playwave$(EXE): $(objects)/playwave.lo $(objects)/$(TARGET)
-	$(LIBTOOL) --mode=link $(CC) -o $@ $(objects)/playwave.lo $(SDL_CFLAGS) $(SDL_LIBS) $(LDFLAGS) $(objects)/$(TARGET)
+	$(LIBTOOL) --mode=link $(CC) -o $@ $(objects)/playwave.lo $(SDL_CFLAGS) $(objects)/$(TARGET) $(SDL_LIBS) $(LDFLAGS)
 
 $(objects)/playmus$(EXE): $(objects)/playmus.lo $(objects)/$(TARGET)
-	$(LIBTOOL) --mode=link $(CC) -o $@ $(objects)/playmus.lo $(SDL_CFLAGS) $(SDL_LIBS) $(LDFLAGS) $(objects)/$(TARGET)
+	$(LIBTOOL) --mode=link $(CC) -o $@ $(objects)/playmus.lo $(SDL_CFLAGS) $(objects)/$(TARGET) $(SDL_LIBS) $(LDFLAGS)
 
 install: all install-hdrs install-lib #install-bin
 install-hdrs:


### PR DESCRIPTION
Cherry-picked from SDL2 commit d55b3da936d24af2f44526807f9481b8e8205e86.