### PR TITLE
Don't include alsa/asoundef.h directly

### DIFF
--- a/src/codecs/native_midi/native_midi_linux_alsa.c
+++ b/src/codecs/native_midi/native_midi_linux_alsa.c
@@ -36,7 +36,6 @@
 #include "native_midi.h"
 #include "native_midi_common.h"
 
-#include <alsa/asoundef.h>
 #include <alsa/asoundlib.h>
 
 #include <errno.h>


### PR DESCRIPTION
```c
In file included from /path/to/SDL_mixer-git/src/codecs/native_midi/native_midi_linux_alsa.c:39:
/usr/include/alsa/asoundef.h:30:2: warning: #warning "use #include <alsa/asoundlib.h>, <alsa/asoundef.h> should not be used directly" [-Wcpp]
   30 | #warning "use #include <alsa/asoundlib.h>, <alsa/asoundef.h> should not be used directly"
      |  ^~~~~~~
```

alsa 1.2.14

gcc 14.2.1
clang 19.1.7