### PR TITLE
SDL_mixer_metadata_tags.c:parse_id3v1_ansi_string(): Fixed "always true" expression

### DIFF
--- a/src/SDL_mixer_metadata_tags.c
+++ b/src/SDL_mixer_metadata_tags.c
@@ -96,9 +96,17 @@ static char *parse_id3v1_ansi_string(const Uint8 *buffer, size_t src_len)
     src_buffer[src_len] = '\0';
 
     // trim whitespace from end (some id3v1 tags pad out with space instead of nulls).
-    for (size_t i = src_len - 1; (i >= 0) && (src_buffer[i] == ' '); i--) {
-        src_buffer[i] = '\0';
-        src_len--;
+    if (src_len > 0) {
+        size_t i = src_len;
+        do {
+            --i;
+            if (src_buffer[i] == ' ') {
+                src_buffer[i] = '\0';
+                --src_len;
+            } else {
+                break;
+            }
+        } while(i > 0);
     }
 
     char *ret = SDL_iconv_string("UTF-8", "ISO-8859-1", src_buffer, src_len + 1);


### PR DESCRIPTION
The comparison `i >= 0` is always true because `i` is an unsigned type.

```c
[  6%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/SDL_mixer_metadata_tags.c.o
/path/to/SDL_mixer/src/SDL_mixer_metadata_tags.c: In function ‘parse_id3v1_ansi_string’:
/path/to/SDL_mixer/src/SDL_mixer_metadata_tags.c:99:37: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
   99 |     for (size_t i = src_len - 1; (i >= 0) && (src_buffer[i] == ' '); i--) {
      |                                     ^~
```

This commit uses a do-while loop instead.

_Might be a bit more "chatty". :)_
_4 lines vs 12 lines_