### PR TITLE
Fixed warning: calloc-transposed-args

### DIFF
--- a/src/decoder_wav.c
+++ b/src/decoder_wav.c
@@ -1381,7 +1381,7 @@ static bool SDLCALL WAV_init_track(void *audio_userdata, SDL_IOStream *io, const
         }
 
         state->output.size = state->info->samplesperblock * state->info->channels;
-        state->output.data = (Sint16 *)SDL_calloc(sizeof(Sint16), state->output.size);
+        state->output.data = (Sint16 *)SDL_calloc(state->output.size, sizeof(Sint16));
         if (!state->output.data) {
             SDL_free(state->block.data);
             SDL_free(state->cstate);


### PR DESCRIPTION
```c
[ 61%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_wav.c.o
/path/to/SDL_mixer/src/decoder_wav.c: In function ‘WAV_init_track’:
/path/to/SDL_mixer/src/decoder_wav.c:1384:58: warning: ‘SDL_calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 1384 |         state->output.data = (Sint16 *)SDL_calloc(sizeof(Sint16), state->output.size);
      |                                                          ^~~~~~
/path/to/SDL_mixer/src/decoder_wav.c:1384:58: note: earlier argument should specify number of elements, later size of each element
```

Swapping the arguments gets rid of the warning.