### PR TITLE
Freeing memory on error

### DIFF
--- a/src/decoder_opus.c
+++ b/src/decoder_opus.c
@@ -151,12 +151,14 @@ static bool SDLCALL OPUS_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SDL_P
     // now open the stream for serious processing.
     of = opus.op_open_callbacks(io, &OPUS_IoCallbacks, NULL, 0, &rc);
     if (!of) {
+        SDL_free(adata);
         return set_op_error("ov_open_callbacks", rc);
     }
 
     const OpusHead *info = opus.op_head(of, -1);
     if (!info) {
         opus.op_free(of);
+        SDL_free(adata);
         return SDL_SetError("Couldn't get Opus info; corrupt data?");
     }
 

--- a/src/decoder_stb_vorbis.c
+++ b/src/decoder_stb_vorbis.c
@@ -157,6 +157,7 @@ static bool SDLCALL STBVORBIS_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, 
     int error = 0;
     stb_vorbis *vorbis = stb_vorbis_open_io(io, 0, &error, NULL);
     if (!vorbis) {
+        SDL_free(adata);
         return SetStbVorbisError("stb_vorbis_open_memory", error);
     }
 

--- a/src/decoder_vorbis.c
+++ b/src/decoder_vorbis.c
@@ -171,12 +171,14 @@ static bool SDLCALL VORBIS_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SDL
     // now open the stream for serious processing.
     const int rc = vorbis.ov_open_callbacks(io, &vf, NULL, 0, VORBIS_IoCallbacks);
     if (rc < 0) {
+        SDL_free(adata);
         return SetOggVorbisError("ov_open_callbacks", rc);
     }
 
     const vorbis_info *vi = vorbis.ov_info(&vf, -1);
     if (!vi) {
         vorbis.ov_clear(&vf);
+        SDL_free(adata);
         return SDL_SetError("Couldn't get Ogg Vorbis info; corrupt data?");
     }
 


### PR DESCRIPTION
On error, some locally allocated memory isn't freed before returning from a function.
This commit adds those `SDL_free()` calls.

<details><summary>Warnings</summary>
<p>

```c
[ 38%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_opus.c.o
/path/to/SDL_mixer/src/decoder_opus.c:154:16: warning: Potential leak of memory pointed to by 'adata' [clang-analyzer-unix.Malloc]
  154 |         return set_op_error("ov_open_callbacks", rc);
      |                ^
/path/to/SDL_mixer/src/decoder_opus.c:136:9: note: Assuming 'of' is non-null
  136 |     if (!of) {
      |         ^~~
/path/to/SDL_mixer/src/decoder_opus.c:136:5: note: Taking false branch
  136 |     if (!of) {
      |     ^
/path/to/SDL_mixer/src/decoder_opus.c:142:9: note: Assuming the condition is false
  142 |     if (SDL_SeekIO(io, 0, SDL_IO_SEEK_SET) < 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_opus.c:142:5: note: Taking false branch
  142 |     if (SDL_SeekIO(io, 0, SDL_IO_SEEK_SET) < 0) {
      |     ^
/path/to/SDL_mixer/src/decoder_opus.c:146:48: note: Memory is allocated
  146 |     OPUS_AudioData *adata = (OPUS_AudioData *) SDL_calloc(1, sizeof (*adata));
      |                                                ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5990:20: note: expanded from macro 'SDL_calloc'
 5990 | #define SDL_calloc calloc
      |                    ^
/path/to/SDL_mixer/src/decoder_opus.c:147:9: note: Assuming 'adata' is non-null
  147 |     if (!adata) {
      |         ^~~~~~
/path/to/SDL_mixer/src/decoder_opus.c:147:5: note: Taking false branch
  147 |     if (!adata) {
      |     ^
/path/to/SDL_mixer/src/decoder_opus.c:153:9: note: Assuming 'of' is null
  153 |     if (!of) {
      |         ^~~
/path/to/SDL_mixer/src/decoder_opus.c:153:5: note: Taking true branch
  153 |     if (!of) {
      |     ^
/path/to/SDL_mixer/src/decoder_opus.c:154:16: note: Potential leak of memory pointed to by 'adata'
  154 |         return set_op_error("ov_open_callbacks", rc);
      |                ^


[ 48%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_stb_vorbis.c.o
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:160:16: warning: Potential leak of memory pointed to by 'adata' [clang-analyzer-unix.Malloc]
  160 |         return SetStbVorbisError("stb_vorbis_open_memory", error);
      |                ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:138:9: note: Assuming the condition is false
  138 |     if (SDL_ReadIO(io, buffer, sizeof (buffer)) != sizeof (buffer)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:138:5: note: Taking false branch
  138 |     if (SDL_ReadIO(io, buffer, sizeof (buffer)) != sizeof (buffer)) {
      |     ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:140:16: note: Assuming the condition is false
  140 |     } else if (SDL_memcmp(buffer, "OggS", 4) != 0) {
      |                ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:6002:20: note: expanded from macro 'SDL_memcmp'
 6002 | #define SDL_memcmp memcmp
      |                    ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:50:16: note: expanded from macro 'memcmp'
   50 | #define memcmp SDL_memcmp
      |                ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:140:12: note: Taking false branch
  140 |     } else if (SDL_memcmp(buffer, "OggS", 4) != 0) {
      |            ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:142:16: note: Assuming the condition is false
  142 |     } else if (SDL_memcmp(&buffer[29], "vorbis", 6) != 0) {
      |                ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:6002:20: note: expanded from macro 'SDL_memcmp'
 6002 | #define SDL_memcmp memcmp
      |                    ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:50:16: note: expanded from macro 'memcmp'
   50 | #define memcmp SDL_memcmp
      |                ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:142:12: note: Taking false branch
  142 |     } else if (SDL_memcmp(&buffer[29], "vorbis", 6) != 0) {
      |            ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:147:9: note: Assuming the condition is false
  147 |     if (SDL_SeekIO(io, 0, SDL_IO_SEEK_SET) < 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:147:5: note: Taking false branch
  147 |     if (SDL_SeekIO(io, 0, SDL_IO_SEEK_SET) < 0) {
      |     ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:151:58: note: Memory is allocated
  151 |     STBVORBIS_AudioData *adata = (STBVORBIS_AudioData *) SDL_calloc(1, sizeof (*adata));
      |                                                          ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5990:20: note: expanded from macro 'SDL_calloc'
 5990 | #define SDL_calloc calloc
      |                    ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:152:9: note: Assuming 'adata' is non-null
  152 |     if (!adata) {
      |         ^~~~~~
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:152:5: note: Taking false branch
  152 |     if (!adata) {
      |     ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:159:10: note: 'vorbis' is null
  159 |     if (!vorbis) {
      |          ^~~~~~
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:159:5: note: Taking true branch
  159 |     if (!vorbis) {
      |     ^
/path/to/SDL_mixer/src/decoder_stb_vorbis.c:160:16: note: Potential leak of memory pointed to by 'adata'
  160 |         return SetStbVorbisError("stb_vorbis_open_memory", error);
      |                ^


[ 58%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_vorbis.c.o
/path/to/SDL_mixer/src/decoder_vorbis.c:174:16: warning: Potential leak of memory pointed to by 'adata' [clang-analyzer-unix.Malloc]
  174 |         return SetOggVorbisError("ov_open_callbacks", rc);
      |                ^
/path/to/SDL_mixer/src/decoder_vorbis.c:156:9: note: Assuming the condition is false
  156 |     if (vorbis.ov_test_callbacks(io, &vf, NULL, 0, VORBIS_IoCallbacks) < 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_vorbis.c:156:5: note: Taking false branch
  156 |     if (vorbis.ov_test_callbacks(io, &vf, NULL, 0, VORBIS_IoCallbacks) < 0) {
      |     ^
/path/to/SDL_mixer/src/decoder_vorbis.c:162:9: note: Assuming the condition is false
  162 |     if (SDL_SeekIO(io, 0, SDL_IO_SEEK_SET) < 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_vorbis.c:162:5: note: Taking false branch
  162 |     if (SDL_SeekIO(io, 0, SDL_IO_SEEK_SET) < 0) {
      |     ^
/path/to/SDL_mixer/src/decoder_vorbis.c:166:52: note: Memory is allocated
  166 |     VORBIS_AudioData *adata = (VORBIS_AudioData *) SDL_calloc(1, sizeof (*adata));
      |                                                    ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5990:20: note: expanded from macro 'SDL_calloc'
 5990 | #define SDL_calloc calloc
      |                    ^
/path/to/SDL_mixer/src/decoder_vorbis.c:167:9: note: Assuming 'adata' is non-null
  167 |     if (!adata) {
      |         ^~~~~~
/path/to/SDL_mixer/src/decoder_vorbis.c:167:5: note: Taking false branch
  167 |     if (!adata) {
      |     ^
/path/to/SDL_mixer/src/decoder_vorbis.c:173:9: note: Assuming 'rc' is < 0
  173 |     if (rc < 0) {
      |         ^~~~~~
/path/to/SDL_mixer/src/decoder_vorbis.c:173:5: note: Taking true branch
  173 |     if (rc < 0) {
      |     ^
/path/to/SDL_mixer/src/decoder_vorbis.c:174:16: note: Potential leak of memory pointed to by 'adata'
  174 |         return SetOggVorbisError("ov_open_callbacks", rc);
      |                ^
```

</p>
</details> 