### PR TITLE
Fix wrong read position when decoding whole file

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -938,8 +938,10 @@ static void *DecodeWholeFile(MIX_Audio *audio, SDL_IOStream *io, size_t *decoded
         const MIX_Decoder *decoder = audio->decoder;
         void *track_userdata = NULL;
         if (decoder->init_track(audio->decoder_userdata, io, &audio->spec, audio->props, &track_userdata)) {
-            while (decoder->decode(track_userdata, stream)) {
-                // spin.
+            if (decoder->seek(track_userdata, 0)) {
+                while (decoder->decode(track_userdata, stream)) {
+                    // spin.
+                }
             }
             decoder->quit_track(track_userdata);
 


### PR DESCRIPTION
I've noticed exactly the same parasitic noise in the beginning of every WAV file being played with predecoding (`MIX_LoadAudio_IO(mixer, io, true, true)`). Exactly the same code works fine if I turn off predecoding.

Turned out there is a bug in the IO read position in `DecodeWholeFile`. By the time it is called, `io` is in the beginning of the file (after being reset in `MIX_LoadAudioWithProperties`). `init_track` does not do reading of its own, so PCM decoding starts at offset 0, which is a RIFF header in my case.

This PR fixes the bug by seeking to frame 0 before doing any decoding, effectively skipping RIFF header. This is the same approach that `MIX_PlayTrack` uses to fine-tune the starting position.