### PR TITLE
Fix double clamping of precached data

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -1067,6 +1067,8 @@ MIX_Audio *MIX_LoadAudioWithProperties(SDL_PropertiesID props)  // lets you spec
         if ((audio->precache = SDL_LoadFile_IO(io, &audio->precachelen, false)) == NULL) {
             goto failed;
         }
+        audio->clamp_offset = -1;   // precache is already clamped
+        audio->clamp_length = -1;
     }
 
     if (ioclamp) {


### PR DESCRIPTION
Fixes #720, basically the same problem fixed in predecoding in cf4befdf42de2ffacd50ead3c4195d96a0d93123