### PR TITLE
Make `mixer` optional in `MIX_LoadRawAudio_IO`

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -1168,7 +1168,7 @@ MIX_Audio *MIX_LoadAudio(MIX_Mixer *mixer, const char *path, bool predecode)
 
 MIX_Audio *MIX_LoadRawAudio_IO(MIX_Mixer *mixer, SDL_IOStream *io, const SDL_AudioSpec *spec, bool closeio)
 {
-    if (!CheckMixerParam(mixer)) {
+    if (!CheckInitialized()) {
         if (io && closeio) { SDL_CloseIO(io); }
         return NULL;
     } else if (!io) {


### PR DESCRIPTION
The docs state it's optional as in other `MIX_Load*` functions.