### PR TITLE
Validate `mixer` in `MIX_PlayAudio`

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -2036,7 +2036,9 @@ bool MIX_PlayTag(MIX_Mixer *mixer, const char *tag, SDL_PropertiesID options)
 
 bool MIX_PlayAudio(MIX_Mixer *mixer, MIX_Audio *audio)
 {
-    if (!CheckAudioParam(audio)) {
+    if (!CheckMixerParam(mixer)) {
+        return false;
+    } else if (!CheckAudioParam(audio)) {
         return false;
     }
 


### PR DESCRIPTION
Causes segfault if `NULL` is being passed. Probably refers to #719, not sure.