### PR TITLE
Removed redundant casts

### DIFF
--- a/src/SDL_mixer_metadata_tags.c
+++ b/src/SDL_mixer_metadata_tags.c
@@ -372,7 +372,7 @@ static size_t id3v22_parse_frame(SDL_PropertiesID props, SDL_IOStream *io, Uint8
 
     handle_id3v2x2_string(props, key, buffer, read_size);
 
-    return (size_t)(size + ID3v2_2_FRAME_HEADER_SIZE); // data size + size of the header
+    return size + ID3v2_2_FRAME_HEADER_SIZE; // data size + size of the header
 }
 
 // Parse a frame in ID3v2.3 and ID3v2.4 formats
@@ -417,7 +417,7 @@ static size_t id3v2x_parse_frame(SDL_PropertiesID props, SDL_IOStream *io, Uint8
     buffer[read_size] = '\0';  // make sure it's definitely null-terminated.
     handle_id3v2_string(props, key, buffer, read_size);
 
-    return (size_t)(size + ID3v2_3_FRAME_HEADER_SIZE); // data size + size of the header
+    return size + ID3v2_3_FRAME_HEADER_SIZE; // data size + size of the header
 }
 
 // Parse content of ID3v2. This expects the stream to be seeked to the start of the potential header.
@@ -715,7 +715,7 @@ static Sint64 get_lyrics3v1_len(SDL_IOStream *io)
     if (flen < 20) {
         return -1;
     }
-    Sint64 len = (Sint64) SDL_min(flen, LYRICS3v1_SEARCH_BUFFER);
+    Sint64 len = SDL_min(flen, LYRICS3v1_SEARCH_BUFFER);
     if (SDL_SeekIO(io, -len, SDL_IO_SEEK_END) == -1) {
         return -1;
     }
@@ -1036,7 +1036,7 @@ static void ParseTrackNumString(const char *str, Sint64 *track, Sint64 *total_tr
     const char *trackstr = str;
     const char *totalstr = NULL;
     char *cpy = NULL;
-    char *ptr = (char *) SDL_strchr(str, '/');  // see if it has both track _and_ total tracks.
+    char *ptr = SDL_strchr(str, '/');  // see if it has both track _and_ total tracks.
 
     if (ptr) {
         cpy = SDL_strdup(str);

--- a/src/decoder_opus.c
+++ b/src/decoder_opus.c
@@ -227,7 +227,7 @@ static bool SDLCALL OPUS_decode(void *track_userdata, SDL_AudioStream *stream)
     float samples[256];
 
     const int channels = tdata->current_channels;
-    int amount = (int)opus.op_read_float(tdata->of, samples, SDL_arraysize(samples), &bitstream);
+    int amount = opus.op_read_float(tdata->of, samples, SDL_arraysize(samples), &bitstream);
     if (amount < 0) {
         return set_op_error("op_read_float", amount);
     } else if (amount == 0) {

--- a/src/decoder_voc.c
+++ b/src/decoder_voc.c
@@ -154,7 +154,7 @@ static bool ParseVocFile(SDL_IOStream *io, VOC_AudioData *adata, SDL_PropertiesI
                     return SDL_SetError("Unsupported VOC data format");
                 }
 
-                current_spec.freq = (int) (1000000 / (256 - rateu8));
+                current_spec.freq = 1000000 / (256 - rateu8);
                 current_spec.channels = 1;
                 current_spec.format = (codec == 0) ? SDL_AUDIO_U8 : SDL_AUDIO_S16LE;
 

--- a/src/decoder_wav.c
+++ b/src/decoder_wav.c
@@ -242,7 +242,7 @@ static bool MS_ADPCM_Init(ADPCM_DecoderInfo *info, const Uint8 *chunk_data, Uint
     Uint16 samplesperblock = SDL_Swap16LE(fmt->Samples.samplesperblock);
 
     // Number of coefficient pairs. A pair has two 16-bit integers.
-    size_t coeffcount = (size_t) (chunk_data[20] | ((size_t)chunk_data[21] << 8));
+    size_t coeffcount = (size_t)chunk_data[20] | ((size_t)chunk_data[21] << 8);
 
     // bPredictor, the integer offset into the coefficients array, is only
     // 8 bits. It can only address the first 256 coefficients. Let's limit
@@ -1094,7 +1094,7 @@ static void CalcSeekBlockSeek(const WAV_AudioData *adata, Uint32 actual_frame, W
     if (IsADPCM(adata->encoding)) {
         seekblock->seek_position = (Sint64) (adata->start + ((actual_frame / adata->adpcm_info.samplesperblock) * adata->adpcm_info.blocksize));
     } else {
-        seekblock->seek_position = (Sint64) (adata->start + (actual_frame * adata->framesize));
+        seekblock->seek_position = adata->start + (actual_frame * adata->framesize);
     }
 }
 
@@ -1169,7 +1169,7 @@ static bool BuildSeekBlocks(WAV_AudioData *adata)
                     const Sint64 stop_frame_block = loop_stop_frame / frames_per_block;
                     const Sint64 offset_into_stop_block = loop_stop_frame % frames_per_block;
                     const Sint64 frames_left_in_stop_block = frames_per_block - offset_into_stop_block;
-                    const Sint64 all_blocks_in_file = ((Sint64) (adata->stop - adata->start)) / frames_per_block;
+                    const Sint64 all_blocks_in_file = (adata->stop - adata->start) / frames_per_block;
                     const Sint64 blocks_left_after_stop_block = all_blocks_in_file - stop_frame_block;
                     seekblocks->num_frames = frames_left_in_stop_block + (blocks_left_after_stop_block * frames_per_block);
                 } else {

--- a/src/decoder_wavpack.c
+++ b/src/decoder_wavpack.c
@@ -417,7 +417,7 @@ static bool SDLCALL WAVPACK_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SD
       wavpack.WavpackGetNumSamples(ctx);
     adata->bps = wavpack.WavpackGetBytesPerSample(ctx) << 3;
     adata->mode = wavpack.WavpackGetMode(ctx);
-    adata->channels = (int) wavpack.WavpackGetNumChannels(ctx);
+    adata->channels = wavpack.WavpackGetNumChannels(ctx);
     adata->samplerate = wavpack.WavpackGetSampleRate(ctx);
     adata->decimation = 1;
 


### PR DESCRIPTION
```c
[  6%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/SDL_mixer_metadata_tags.c.o
/path/to/SDL_mixer/src/SDL_mixer_metadata_tags.c:1039:17: warning: redundant explicit casting to the same type 'char *' as the sub-expression, remove this casting [readability-redundant-casting]
 1039 |     char *ptr = (char *) SDL_strchr(str, '/');  // see if it has both track _and_ total tracks.
      |                 ^~~~~~~~
/usr/include/string.h:246:14: note: source type originates from the invocation of this function
  246 | extern char *strchr (const char *__s, int __c)
      |        ~~~~~~^

[ 38%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_opus.c.o
/path/to/SDL_mixer/src/decoder_opus.c:230:18: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
  230 |     int amount = (int)opus.op_read_float(tdata->of, samples, SDL_arraysize(samples), &bitstream);
      |                  ^~~~~
/path/to/SDL_mixer/src/SDL_mixer_loader.h:12:5: note: source type originates from referencing this member
   12 |     MIX_LOADER_FUNCTIONS
      |     ^
/path/to/SDL_mixer/src/decoder_opus.c:45:34: note: expanded from macro 'MIX_LOADER_FUNCTIONS'
   45 |     MIX_LOADER_FUNCTION(true,int,op_read_float,(OggOpusFile *, float *,int,int *)) \
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/SDL_mixer_loader.h:11:61: note: expanded from macro 'MIX_LOADER_FUNCTION'
   11 |     #define MIX_LOADER_FUNCTION(required,ret,fn,args) ret (*fn) args;
      |                                                       ~~~~~~^~~~~~~~

[ 54%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_voc.c.o
/path/to/SDL_mixer/src/decoder_voc.c:157:37: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
  157 |                 current_spec.freq = (int) (1000000 / (256 - rateu8));
      |                                     ^~~~~~~                        ~
      |                                     (                              )

[ 61%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_wav.c.o
/path/to/SDL_mixer/src/decoder_wav.c:1172:56: warning: redundant explicit casting to the same type 'Sint64' (aka 'long') as the sub-expression, remove this casting [readability-redundant-casting]
 1172 |                     const Sint64 all_blocks_in_file = ((Sint64) (adata->stop - adata->start)) / frames_per_block;
      |                                                        ^~~~~~~~~~                          ~
      |                                                        (                                   )

[ 64%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_wavpack.c.o
/path/to/SDL_mixer/src/decoder_wavpack.c:420:23: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
  420 |     adata->channels = (int) wavpack.WavpackGetNumChannels(ctx);
      |                       ^~~~~
/path/to/SDL_mixer/src/SDL_mixer_loader.h:12:5: note: source type originates from referencing this member
   12 |     MIX_LOADER_FUNCTIONS
      |     ^
/path/to/SDL_mixer/src/decoder_wavpack.c:87:5: note: expanded from macro 'MIX_LOADER_FUNCTIONS'
   87 |     MIX_LOADER_FUNCTIONS_wavpackbase \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_wavpack.c:75:34: note: expanded from macro 'MIX_LOADER_FUNCTIONS_wavpackbase'
   75 |     MIX_LOADER_FUNCTION(true,int,WavpackGetNumChannels,(WavpackContext*)) \
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/SDL_mixer_loader.h:11:61: note: expanded from macro 'MIX_LOADER_FUNCTION'
   11 |     #define MIX_LOADER_FUNCTION(required,ret,fn,args) ret (*fn) args;
      |                                                       ~~~~~~^~~~~~~~
```