### PR TITLE
Fix null-dereference warning in src/decoder_voc.c

### DIFF
--- a/src/decoder_voc.c
+++ b/src/decoder_voc.c
@@ -84,10 +84,12 @@ static VOC_Block *AddVocDataBlock(VOC_AudioData *adata, Sint64 iopos, const SDL_
     }
 
     VOC_Block *block = AddVocBlock(adata);
-    block->iopos = (Uint64) iopos;
-    block->loop_count = 0;
-    SDL_copyp(&block->spec, spec);
-    block->frames = frames;
+    if (block) {
+        block->iopos = (Uint64) iopos;
+        block->loop_count = 0;
+        SDL_copyp(&block->spec, spec);
+        block->frames = frames;
+    }
     return block;
 }
 


### PR DESCRIPTION
This commit adds a NULL check for the returned variable `block`
similar to the one in `AddVocLoopBlock()` directly below this function.

<details><summary>Warning</summary>
<p>

```c
[ 45%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_voc.c.o
/path/to/SDL_mixer/src/decoder_voc.c: In function ‘AddVocDataBlock’:
/path/to/SDL_mixer/src/decoder_voc.c:87:18: warning: dereference of NULL ‘block’ [CWE-476] [-Wanalyzer-null-dereference]
   87 |     block->iopos = (Uint64) iopos;
      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
  ‘ParseVocFile’: events 1-3
    │
    │  105 | static bool ParseVocFile(SDL_IOStream *io, VOC_AudioData *adata, SDL_PropertiesID props, SDL_AudioSpec *spec, Sint64 *duration_frames)
    │      |             ^~~~~~~~~~~~
    │      |             |
    │      |             (1) entry to ‘ParseVocFile’
    │......
    │  108 |     VOC_Block *loop_start = NULL;
    │      |                ~~~~~~~~~~
    │      |                |
    │      |                (2) ‘loop_start’ is NULL
    │......
    │  115 |     if (pos < 0) {
    │      |        ~     
    │      |        |
    │      |        (3) following ‘false’ branch (when ‘pos >= 0’)... ─>─┐
    │      |                                                             │
    │
  ‘ParseVocFile’: event 4
    │
    │/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:2483:21:
    │      |                                                             │
    │      |┌────────────────────────────────────────────────────────────┘
    │ 2483 |│#define SDL_memcpy  memcpy
    │      |│                    ^
    │      |│                    |
    │      |└───────────────────>(4) ...to here
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:2513:5: note: in expansion of macro ‘SDL_memcpy’
    │ 2513 |     SDL_memcpy((dst), (src), sizeof(*(src)))
    │      |     ^~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:119:5: note: in expansion of macro ‘SDL_copyp’
    │  119 |     SDL_copyp(&original_spec, spec);
    │      |     ^~~~~~~~~
    │
  ‘ParseVocFile’: event 5
    │
    │  126 |         if (SDL_ReadIO(io, &block, 1) != 1) {
    │      |            ^
    │      |            |
    │      |            (5) following ‘false’ branch... ─>─┐
    │      |                                               │
    │
  ‘ParseVocFile’: event 6
    │
    │      |                                               │
    │      |┌──────────────────────────────────────────────┘
    │  128 |│        } else if (block == VOC_TERM) {
    │      |│                         ^
    │      |│                         |
    │      |└────────────────────────>(6) ...to here
    │
  ‘ParseVocFile’: event 7
    │
    │  128 |         } else if (block == VOC_TERM) {
    │      |                   ^
    │      |                   |
    │      |                   (7) following ‘false’ branch... ─>─┐
    │      |                                                      │
    │
  ‘ParseVocFile’: events 8-9
    │
    │      |                                                      │
    │      |┌─────────────────────────────────────────────────────┘
    │  130 |│        } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
    │      |│                         ^
    │      |│                         |
    │      |└────────────────────────>(8) ...to here
    │......
    │  140 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
    │      |            ~              
    │      |            |
    │      |            (9) following ‘true’ branch... ─>─┐
    │      |                                              │
    │
  ‘ParseVocFile’: event 10
    │
    │      |                                              │
    │      |┌─────────────────────────────────────────────┘
    │  140 |│        if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
    │      |│                                   ~~~~~~~^~~~~~~~~~~~~~~
    │      |│                                          |
    │      |└─────────────────────────────────────────>(10) ...to here
    │
  ‘ParseVocFile’: events 11-13
    │
    │  140 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
    │      |             ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    │      |                                 |
    │      |                                 (11) following ‘false’ branch... ─>─┐
    │      |                                                                     │
    │......
    │      |                                                                     │
    │      |┌────────────────────────────────────────────────────────────────────┘
    │  144 |│        switch (block) {
    │      |│        ~~~~~~                   
    │      |│        |
    │      |└───────>(12) ...to here
    │......
    │  223 |                 if (spec->format == SDL_AUDIO_UNKNOWN) {
    │      |                    ~             
    │      |                    |
    │      |                    (13) following ‘false’ branch... ─>─┐
    │      |                                                        │
    │
  ‘ParseVocFile’: event 14
    │
    │/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_audio.h:425:55:
    │      |                                                        │
    │      |┌───────────────────────────────────────────────────────┘
    │  425 |│#define SDL_AUDIO_FRAMESIZE(x) (SDL_AUDIO_BYTESIZE((x).format) * (x).channels)
    │      |│                                                      ^
    │      |│                                                      |
    │      |└─────────────────────────────────────────────────────>(14) ...to here
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_audio.h:266:40: note: in definition of macro ‘SDL_AUDIO_BITSIZE’
    │  266 | #define SDL_AUDIO_BITSIZE(x)         ((x) & SDL_AUDIO_MASK_BITSIZE)
    │      |                                        ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_audio.h:425:33: note: in expansion of macro ‘SDL_AUDIO_BYTESIZE’
    │  425 | #define SDL_AUDIO_FRAMESIZE(x) (SDL_AUDIO_BYTESIZE((x).format) * (x).channels)
    │      |                                 ^~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:227:38: note: in expansion of macro ‘SDL_AUDIO_FRAMESIZE’
    │  227 |                 const int framelen = SDL_AUDIO_FRAMESIZE(current_spec);
    │      |                                      ^~~~~~~~~~~~~~~~~~~
    │
  ‘ParseVocFile’: event 15
    │
    │  229 |                 if (!AddVocDataBlock(adata, SDL_TellIO(io), &current_spec, frames)) {
    │      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │      |                      |
    │      |                      (15) calling ‘AddVocDataBlock’ from ‘ParseVocFile’
    │
    └──> ‘AddVocDataBlock’: events 16-19
           │
           │   80 | static VOC_Block *AddVocDataBlock(VOC_AudioData *adata, Sint64 iopos, const SDL_AudioSpec *spec, Uint64 frames)
           │      |                   ^~~~~~~~~~~~~~~
           │      |                   |
           │      |                   (16) entry to ‘AddVocDataBlock’
           │   81 | {
           │   82 |     if (iopos < 0) {  // SDL_TellIO failed?
           │      |        ~           
           │      |        |
           │      |        (17) following ‘false’ branch (when ‘iopos >= 0’)... ─>─┐
           │      |                                                                │
           │......
           │      |                                                                │
           │      |┌───────────────────────────────────────────────────────────────┘
           │   86 |│    VOC_Block *block = AddVocBlock(adata);
           │      |│                       ~~~~~~~~~~~~~~~~~~
           │      |│                       |
           │      |└──────────────────────>(18) ...to here
           │      |                        (19) calling ‘AddVocBlock’ from ‘AddVocDataBlock’
           │
           └──> ‘AddVocBlock’: events 20-21
                  │
                  │   66 | static VOC_Block *AddVocBlock(VOC_AudioData *adata)
                  │      |                   ^~~~~~~~~~~
                  │      |                   |
                  │      |                   (20) entry to ‘AddVocBlock’
                  │......
                  │   69 |     if (!ptr) {
                  │      |        ~           
                  │      |        |
                  │      |        (21) following ‘true’ branch (when ‘ptr’ is NULL)... ─>─┐
                  │      |                                                                │
                  │
                ‘AddVocBlock’: event 22
                  │
                  │      |                                                                │
                  │      |┌───────────────────────────────────────────────────────────────┘
                  │   70 |│        return NULL;
                  │      |│               ^~~~
                  │      |│               |
                  │      |└──────────────>(22) ...to here
                  │
                ‘AddVocBlock’: event 23
                  │
                  │   70 |         return NULL;
                  │      |                ^~~~
                  │      |                |
                  │      |                (23) ‘loop_start’ is NULL
                  │
           <──────┘
           │
         ‘AddVocDataBlock’: events 24-26
           │
           │   86 |     VOC_Block *block = AddVocBlock(adata);
           │      |                        ^~~~~~~~~~~~~~~~~~
           │      |                        |
           │      |                        (24) returning to ‘AddVocDataBlock’ from ‘AddVocBlock’
           │   87 |     block->iopos = (Uint64) iopos;
           │      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           │      |                  |
           │      |                  (26) ⚠️  dereference of NULL ‘block’
           │......
           │   91 |     return block;
           │      |            ~~~~~        
           │      |            |
           │      |            (25) ‘block’ is NULL
           │
```

</p>
</details>
