### PR TITLE
Fixed bug #733: build error on android with NEON intrinsics

### DIFF
--- a/src/SDL_mixer_spatialization.c
+++ b/src/SDL_mixer_spatialization.c
@@ -314,6 +314,12 @@ static void SDL_TARGETING("sse") calculate_distance_attenuation_and_angle_sse(co
 }
 #endif
 
+// FIXME: neon intrinsics "vcopyq_laneq_f32" is undeclared.
+// It is defined in <arm_neon.h>, but not activated because of __ARM_FP value.
+#if defined(SDL_PLATFORM_ANDROID) && defined(SDL_NEON_INTRINSICS)
+#undef SDL_NEON_INTRINSICS
+#endif
+
 #if defined(SDL_NEON_INTRINSICS)
 static float32x4_t xyzzy_neon(const float32x4_t a, const float32x4_t b)
 {


### PR DESCRIPTION
Neon intrinsics "vcopyq_laneq_f32" is undeclared.
It is defined in <arm_neon.h>, but not activated because of __ARM_FP value.

So, unactivate NEON intrinsics for spatialization on Android.