### PR TITLE
decoder_voc: fix possible use-after-free again

### DIFF
--- a/src/decoder_voc.c
+++ b/src/decoder_voc.c
@@ -108,6 +108,7 @@ static bool ParseVocFile(SDL_IOStream *io, VOC_AudioData *adata, SDL_PropertiesI
 {
     Sint64 total_frames = 0;
     VOC_Block *loop_start = NULL;
+    int loop_start_loop_count = 0;
     Sint64 loop_frames = 0;
     SDL_AudioSpec original_spec;
     SDL_AudioSpec current_spec;
@@ -280,6 +281,7 @@ static bool ParseVocFile(SDL_IOStream *io, VOC_AudioData *adata, SDL_PropertiesI
                 if (!loop_start) {
                     return false;
                 }
+                loop_start_loop_count = loop_start->loop_count;
                 break;
             }
 
@@ -288,17 +290,17 @@ static bool ParseVocFile(SDL_IOStream *io, VOC_AudioData *adata, SDL_PropertiesI
                     return SDL_SetError("VOC has a LOOPEND without a matching LOOP");
                 }
 
-                const int loopcnt = loop_start->loop_count;
                 VOC_Block *block = AddVocLoopBlock(adata, -2);
                 if (!block) {
                     return false;
                 }
 
                 if (total_frames != -1) {
-                    total_frames += loop_frames * loopcnt;
+                    total_frames += loop_frames * loop_start_loop_count;
                 }
 
                 loop_start = NULL;
+                loop_start_loop_count = 0;
                 loop_frames = 0;
                 break;
             }


### PR DESCRIPTION
If any of these switch cases are trigger in between `VOC_LOOP` and `VOC_LOOPEND` the `adata->blocks` gets reallocated and `loop_start` is invalidated:
```c
VOC_DATA
VOC_DATA_16
VOC_CONT
VOC_SILENCE
```

The initial issue was https://github.com/libsdl-org/SDL_mixer/issues/726 and fixed the reallocation issue at the end of the loop in `VOC_LOOPEND`, but then others appeared.

This commit declares a variable outside the while loop and switch statement to preserve the variable `loop_start->loop_count` when it is first allocated. This variable is not affected when reallocations happen.

<details><summary>Warning</summary>
<p>

```c
[ 45%] Building C object CMakeFiles/SDL3_mixer-shared.dir/src/decoder_voc.c.o
/path/to/SDL_mixer/src/decoder_voc.c:291:37: warning: Use of memory after it is freed [clang-analyzer-unix.Malloc]
  291 |                 const int loopcnt = loop_start->loop_count;
      |                                     ^~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:117:9: note: Assuming 'pos' is >= 0
  117 |     if (pos < 0) {
      |         ^~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:117:5: note: Taking false branch
  117 |     if (pos < 0) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:125:5: note: Loop condition is true.  Entering loop body
  125 |     while (true) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:128:13: note: Assuming the condition is false
  128 |         if (SDL_ReadIO(io, &block, 1) != 1) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:128:9: note: Taking false branch
  128 |         if (SDL_ReadIO(io, &block, 1) != 1) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:130:20: note: Assuming 'block' is not equal to VOC_TERM
  130 |         } else if (block == VOC_TERM) {
      |                    ^~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:130:16: note: Taking false branch
  130 |         } else if (block == VOC_TERM) {
      |                ^
/path/to/SDL_mixer/src/decoder_voc.c:132:20: note: Assuming 'block' is not equal to VOC_LOOPEND
  132 |         } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
      |                    ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:132:16: note: Taking true branch
  132 |         } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
      |                ^
/path/to/SDL_mixer/src/decoder_voc.c:134:17: note: Assuming the condition is false
  134 |             if (SDL_ReadIO(io, bits24, sizeof(bits24)) != sizeof(bits24)) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:134:13: note: Taking false branch
  134 |             if (SDL_ReadIO(io, bits24, sizeof(bits24)) != sizeof(bits24)) {
      |             ^
/path/to/SDL_mixer/src/decoder_voc.c:142:14: note: 'block' is not equal to VOC_TERM
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |              ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:142:13: note: Left side of '&&' is true
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |             ^
/path/to/SDL_mixer/src/decoder_voc.c:142:37: note: 'block' is not equal to VOC_LOOPEND
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |                                     ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:142:9: note: Taking true branch
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:146:9: note: Control jumps to 'case 6:'  at line 256
  146 |         switch (block) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:260:21: note: 'loop_start' is null
  260 |                 if (loop_start) {
      |                     ^~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:260:17: note: Taking false branch
  260 |                 if (loop_start) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:262:28: note: Assuming the condition is false
  262 |                 } else if (!SDL_ReadU16LE(io, &iterations)) {
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:262:24: note: Taking false branch
  262 |                 } else if (!SDL_ReadU16LE(io, &iterations)) {
      |                        ^
/path/to/SDL_mixer/src/decoder_voc.c:267:21: note: Assuming 'iterations' is not equal to 65535
  267 |                 if (iterations == 0xFFFF) {
      |                     ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:267:17: note: Taking false branch
  267 |                 if (iterations == 0xFFFF) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:273:17: note: Taking true branch
  273 |                 if (total_frames != -1) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:279:30: note: Calling 'AddVocLoopBlock'
  279 |                 loop_start = AddVocLoopBlock(adata, loop_count);
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:98:24: note: Calling 'AddVocBlock'
   98 |     VOC_Block *block = AddVocBlock(adata);
      |                        ^~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:68:17: note: Memory is allocated
   68 |     void *ptr = SDL_realloc(adata->blocks, (adata->num_blocks + 1) * sizeof (*adata->blocks));
      |                 ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5991:21: note: expanded from macro 'SDL_realloc'
 5991 | #define SDL_realloc realloc
      |                     ^
/path/to/SDL_mixer/src/decoder_voc.c:69:9: note: Assuming 'ptr' is non-null
   69 |     if (!ptr) {
      |         ^~~~
/path/to/SDL_mixer/src/decoder_voc.c:69:5: note: Taking false branch
   69 |     if (!ptr) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:98:24: note: Returned allocated memory
   98 |     VOC_Block *block = AddVocBlock(adata);
      |                        ^~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:99:9: note: 'block' is non-null
   99 |     if (block) {
      |         ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:99:5: note: Taking true branch
   99 |     if (block) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:279:30: note: Returned allocated memory
  279 |                 loop_start = AddVocLoopBlock(adata, loop_count);
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:280:22: note: 'loop_start' is non-null
  280 |                 if (!loop_start) {
      |                      ^~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:280:17: note: Taking false branch
  280 |                 if (!loop_start) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:283:17: note:  Execution continues on line 356
  283 |                 break;
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:357:13: note: Assuming the condition is false
  357 |         if (SDL_SeekIO(io, pos, SDL_IO_SEEK_SET) < 0) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:357:9: note: Taking false branch
  357 |         if (SDL_SeekIO(io, pos, SDL_IO_SEEK_SET) < 0) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:125:5: note: Loop condition is true.  Entering loop body
  125 |     while (true) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:128:13: note: Assuming the condition is false
  128 |         if (SDL_ReadIO(io, &block, 1) != 1) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:128:9: note: Taking false branch
  128 |         if (SDL_ReadIO(io, &block, 1) != 1) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:130:20: note: Assuming 'block' is not equal to VOC_TERM
  130 |         } else if (block == VOC_TERM) {
      |                    ^~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:130:16: note: Taking false branch
  130 |         } else if (block == VOC_TERM) {
      |                ^
/path/to/SDL_mixer/src/decoder_voc.c:132:20: note: Assuming 'block' is not equal to VOC_LOOPEND
  132 |         } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
      |                    ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:132:16: note: Taking true branch
  132 |         } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
      |                ^
/path/to/SDL_mixer/src/decoder_voc.c:134:17: note: Assuming the condition is false
  134 |             if (SDL_ReadIO(io, bits24, sizeof(bits24)) != sizeof(bits24)) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:134:13: note: Taking false branch
  134 |             if (SDL_ReadIO(io, bits24, sizeof(bits24)) != sizeof(bits24)) {
      |             ^
/path/to/SDL_mixer/src/decoder_voc.c:142:14: note: 'block' is not equal to VOC_TERM
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |              ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:142:13: note: Left side of '&&' is true
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |             ^
/path/to/SDL_mixer/src/decoder_voc.c:142:37: note: 'block' is not equal to VOC_LOOPEND
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |                                     ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:142:9: note: Taking true branch
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:146:9: note: Control jumps to 'case 3:'  at line 241
  146 |         switch (block) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:244:21: note: Assuming the condition is false
  244 |                 if (!SDL_ReadU16LE(io, &frames)) {
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:244:17: note: Taking false branch
  244 |                 if (!SDL_ReadU16LE(io, &frames)) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:246:29: note: Calling 'AddVocDataBlock'
  246 |                 } else if (!AddVocDataBlock(adata, 0, &current_spec, frames + 1)) {
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:82:9: note: 'iopos' is >= 0
   82 |     if (iopos < 0) {  // SDL_TellIO failed?
      |         ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:82:5: note: Taking false branch
   82 |     if (iopos < 0) {  // SDL_TellIO failed?
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:86:24: note: Calling 'AddVocBlock'
   86 |     VOC_Block *block = AddVocBlock(adata);
      |                        ^~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:68:17: note: Memory is released
   68 |     void *ptr = SDL_realloc(adata->blocks, (adata->num_blocks + 1) * sizeof (*adata->blocks));
      |                 ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5991:21: note: expanded from macro 'SDL_realloc'
 5991 | #define SDL_realloc realloc
      |                     ^
/path/to/SDL_mixer/src/decoder_voc.c:69:9: note: Assuming 'ptr' is non-null
   69 |     if (!ptr) {
      |         ^~~~
/path/to/SDL_mixer/src/decoder_voc.c:69:5: note: Taking false branch
   69 |     if (!ptr) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:86:24: note: Returning; memory was released
   86 |     VOC_Block *block = AddVocBlock(adata);
      |                        ^~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:87:9: note: 'block' is non-null
   87 |     if (block) {
      |         ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:87:5: note: Taking true branch
   87 |     if (block) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:246:29: note: Returning; memory was released
  246 |                 } else if (!AddVocDataBlock(adata, 0, &current_spec, frames + 1)) {
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:246:24: note: Taking false branch
  246 |                 } else if (!AddVocDataBlock(adata, 0, &current_spec, frames + 1)) {
      |                        ^
/path/to/SDL_mixer/src/decoder_voc.c:250:17: note: Taking true branch
  250 |                 if (total_frames != -1) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:253:17: note:  Execution continues on line 356
  253 |                 break;
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:357:13: note: Assuming the condition is false
  357 |         if (SDL_SeekIO(io, pos, SDL_IO_SEEK_SET) < 0) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:357:9: note: Taking false branch
  357 |         if (SDL_SeekIO(io, pos, SDL_IO_SEEK_SET) < 0) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:125:5: note: Loop condition is true.  Entering loop body
  125 |     while (true) {
      |     ^
/path/to/SDL_mixer/src/decoder_voc.c:128:13: note: Assuming the condition is false
  128 |         if (SDL_ReadIO(io, &block, 1) != 1) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:128:9: note: Taking false branch
  128 |         if (SDL_ReadIO(io, &block, 1) != 1) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:130:20: note: Assuming 'block' is not equal to VOC_TERM
  130 |         } else if (block == VOC_TERM) {
      |                    ^~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:130:16: note: Taking false branch
  130 |         } else if (block == VOC_TERM) {
      |                ^
/path/to/SDL_mixer/src/decoder_voc.c:132:20: note: Assuming 'block' is equal to VOC_LOOPEND
  132 |         } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
      |                    ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:132:16: note: Taking false branch
  132 |         } else if (block != VOC_LOOPEND) {  // TERM and LOOPEND don't have a size field.
      |                ^
/path/to/SDL_mixer/src/decoder_voc.c:142:14: note: 'block' is not equal to VOC_TERM
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |              ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:142:13: note: Left side of '&&' is true
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |             ^
/path/to/SDL_mixer/src/decoder_voc.c:142:37: note: 'block' is equal to VOC_LOOPEND
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |                                     ^~~~~
/path/to/SDL_mixer/src/decoder_voc.c:142:9: note: Taking false branch
  142 |         if ((block != VOC_TERM) && (block != VOC_LOOPEND)) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:146:9: note: Control jumps to 'case 7:'  at line 286
  146 |         switch (block) {
      |         ^
/path/to/SDL_mixer/src/decoder_voc.c:287:22: note: 'loop_start' is non-null
  287 |                 if (!loop_start) {
      |                      ^~~~~~~~~~
/path/to/SDL_mixer/src/decoder_voc.c:287:17: note: Taking false branch
  287 |                 if (!loop_start) {
      |                 ^
/path/to/SDL_mixer/src/decoder_voc.c:291:37: note: Use of memory after it is freed
  291 |                 const int loopcnt = loop_start->loop_count;
      |                                     ^~~~~~~~~~~~~~~~~~~~~~
```

</p>
</details> 