### PR TITLE
Removing redundant assignment

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -2100,7 +2100,6 @@ static void StopTrack(MIX_Track *track, Sint64 fadeOut)
             TrackStopped(track);
         } else {
             track->total_fade_frames = fadeOut;
-            track->fade_frames = track->total_fade_frames;
             track->fade_frames = fadeOut;
             track->fade_direction = -1;
         }


### PR DESCRIPTION
Removing a redundant assignment

```c
src/SDL_mixer.c:2104:32: style: Variable 'track->fade_frames' is reassigned a value before the old one has been used. [redundantAssignment]
            track->fade_frames = fadeOut;
                               ^
```

Introduced in commit:
https://github.com/icculus/SDL_remixer/commit/76ec5d35e7cc70e397b984d382f95023d8580023#diff-66d27914364c2b11bd71a896ac07aca5d1b4cbb91cf4c61aa4ef2b1c093b583cL1131

```diff
@@ -1131,12 +1153,15 @@ bool Mix_PlayOnce(Mix_Audio *audio)
 static void HaltTrack(Mix_Track *track, Sint64 fadeOut)
 {
     LockTrack(track);
-    if (fadeOut <= 0) {  // stop immediately.
-        TrackFinished(track);
-    } else {
-        track->fade_frames = fadeOut;
-        track->fade_start_frame = track->position;
-        track->fade_direction = -1;
+    if (track->state != MIX_STATE_STOPPED) {
+        if (fadeOut <= 0) {  // stop immediately.
+            TrackFinished(track);
+        } else {
+            track->total_fade_frames = fadeOut;
+            track->fade_frames = track->total_fade_frames;
+            track->fade_frames = fadeOut;
+            track->fade_direction = -1;
+        }
     }
     UnlockTrack(track);
 }

```