### PR TITLE
Fix: missing set free_precache

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -1070,6 +1070,7 @@ MIX_Audio *MIX_LoadAudioWithProperties(SDL_PropertiesID props)  // lets you spec
         if ((audio->precache = SDL_LoadFile_IO(io, &audio->precachelen, false)) == NULL) {
             goto failed;
         }
+        audio->free_precache = true;
         audio->clamp_offset = -1;   // precache is already clamped
         audio->clamp_length = -1;
     }


### PR DESCRIPTION
Simple call to `MIX_LoadAudio(mixer, filepath.c_str(), false)` then `MIX_DestroyAudio` was skipping `SDL_free` in `UnrefAudio`