### PR TITLE
Fix a few `-Wextra` warnings

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -630,7 +630,7 @@ bool MIX_Generate(MIX_Mixer *mixer, void *buffer, int buflen)
 
 static void InitDecoders(void)
 {
-    for (int i = 0; i < SDL_arraysize(decoders); i++) {
+    for (size_t i = 0; i < SDL_arraysize(decoders); i++) {
         const MIX_Decoder *decoder = decoders[i];
         if (!decoder->init || decoder->init()) {
             available_decoders[num_available_decoders++] = decoder;

--- a/src/SDL_mixer_metadata_tags.c
+++ b/src/SDL_mixer_metadata_tags.c
@@ -199,7 +199,7 @@ static Sint32 get_id3v2_len(const Uint8 *data, size_t length)
     size += ID3v2_HEADER_SIZE; // header size
     // ID3v2 header[5] is flags (bits 4-7 only, 0-3 are zero).
     // bit 4 set: footer is present (a copy of the header but
-    // with "3DI" as ident.) 
+    // with "3DI" as ident.)
     if (data[5] & 0x10) {
         size += ID3v2_HEADER_SIZE; // footer size
     }

--- a/src/decoder_flac.c
+++ b/src/decoder_flac.c
@@ -209,7 +209,7 @@ static FLAC__StreamDecoderWriteStatus FLAC_IoWrite(const FLAC__StreamDecoder *de
 
     if (amount > 0) {
         void *channel_arrays[32];
-        SDL_assert(SDL_arraysize(channel_arrays) >= channels);
+        SDL_assert(SDL_arraysize(channel_arrays) >= (size_t)channels);
 
         // (If we padded out to 5.1 to get a front-center channel, the unnecessary channels happen
         //   to be at the end, so it'll assume those padded channels are silent.)
@@ -223,7 +223,7 @@ static FLAC__StreamDecoderWriteStatus FLAC_IoWrite(const FLAC__StreamDecoder *de
             for (int channel = 0; channel < channels; channel++) { \
                 const Sint32 *src = (const Sint32 *) buffer[channel]; \
                 typ *dst = (typ *) channel_arrays[channel]; \
-                for (int i = 0; i < amount; i++) { \
+                for (size_t i = 0; i < amount; i++) { \
                     dst[i] = (typ) (src[i] << shift); \
                 } \
             } \

--- a/src/decoder_opus.c
+++ b/src/decoder_opus.c
@@ -234,7 +234,7 @@ static bool SDLCALL OPUS_decode(void *track_userdata, SDL_AudioStream *stream)
         return false;  // EOF
     }
 
-    SDL_assert((amount * channels) <= SDL_arraysize(samples));
+    SDL_assert((amount * channels) <= (int)SDL_arraysize(samples));
 
     if (bitstream != tdata->current_bitstream) {
         const OpusHead *info = opus.op_head(tdata->of, -1);

--- a/src/decoder_sinewave.c
+++ b/src/decoder_sinewave.c
@@ -100,7 +100,7 @@ static bool SDLCALL SINEWAVE_decode(void *track_userdata, SDL_AudioStream *strea
     int current_sine_sample = tdata->current_sine_sample;
     float samples[256];
 
-    for (int i = 0; i < SDL_arraysize(samples); i++) {
+    for (size_t i = 0; i < SDL_arraysize(samples); i++) {
         const float phase = current_sine_sample * hz / fsample_rate;
         samples[i] = SDL_sinf(phase * 2.0f * SDL_PI_F) * amplitude;
         current_sine_sample++;

--- a/src/decoder_stb_vorbis.c
+++ b/src/decoder_stb_vorbis.c
@@ -237,7 +237,7 @@ static bool SDLCALL STBVORBIS_decode(void *track_userdata, SDL_AudioStream *stre
             tdata->skip_samples -= amount;
             return true;  // throw this all away; just try again next iteration.
         }
-        SDL_assert(num_channels <= SDL_arraysize(outputs));
+        SDL_assert(num_channels <= (int)SDL_arraysize(outputs));
         for (int i = 0; i < num_channels; i++) {
             outputs[i] = pcm_channels[i] + skip;
         }

--- a/src/decoder_wavpack.c
+++ b/src/decoder_wavpack.c
@@ -410,7 +410,7 @@ static bool SDLCALL WAVPACK_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SD
 
     adata->wvcdata = wvcdata;
     adata->wvcdatalen = wvcdatalen;
-    adata->numsamples = 
+    adata->numsamples =
     #if !defined(WAVPACK4_OR_OLDER) || defined(WAVPACK_DYNAMIC)
       wavpack.WavpackGetNumSamples64 ? wavpack.WavpackGetNumSamples64(ctx) :
     #endif


### PR DESCRIPTION
SDL_mixer currently does not compile its sources with `-Wextra`, where the other satellite libraries do.
When adding this flag, I see warnings about unused arguments and sized/unsized comparison.

This PR fixes the warnings about unused arguments, and straighforward signed/unsigned comparisons.

It might be worthwhile to look at the remaining warnings.
<details>

<summary>Remaining `-Wextra` warnings</summary>

```
/home/maarten/projects/SDL_mixer/src/decoder_vorbis.c: In function ‘VORBIS_seek’:
/home/maarten/projects/SDL_mixer/src/decoder_vorbis.c:346:32: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  346 |     if (loop->active && (frame >= loop->start)) {
      |                                ^~
/home/maarten/projects/SDL_mixer/src/decoder_vorbis.c:348:41: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  348 |         if ((loop->count < 0) || (frame < (loop->len * loop->count))) {  // literally in the loop right now.
      |                                         ^

/home/maarten/projects/SDL_mixer/src/decoder_fluidsynth.c: In function ‘SoundFontRead’:
/home/maarten/projects/SDL_mixer/src/decoder_fluidsynth.c:202:61: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘fluid_long_long_t’ {aka ‘long long int’} [-Werror=sign-compare]
  202 |     return (SDL_ReadIO((SDL_IOStream *) handle, buf, count) == count) ? FLUID_OK : FLUID_FAILED;
      |                                                             ^~

/home/maarten/projects/SDL_mixer/src/decoder_flac.c: In function ‘FLAC_IoWrite’:
/home/maarten/projects/SDL_mixer/src/decoder_flac.c:180:73: error: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  180 |         if (loop->active && ((tdata->current_iteration_frames + amount) >= loop->start)) {
      |                                                                         ^~
/home/maarten/projects/SDL_mixer/src/decoder_flac.c:190:20: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  190 |         if (amount > available) {
      |                    ^
/home/maarten/projects/SDL_mixer/src/decoder_flac.c:195:56: error: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  195 |         if ((tdata->current_iteration_frames + amount) >= loop->len) {  // time to loop?
      |                                                        ^~
/home/maarten/projects/SDL_mixer/src/decoder_flac.c: In function ‘FLAC_seek’:
/home/maarten/projects/SDL_mixer/src/decoder_flac.c:469:32: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  469 |     if (loop->active && (frame >= loop->start)) {
      |                                ^~
/home/maarten/projects/SDL_mixer/src/decoder_flac.c:471:41: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  471 |         if ((loop->count < 0) || (frame < (loop->len * loop->count))) {  // literally in the loop right now.
      |                                         ^

/home/maarten/projects/SDL_mixer/src/decoder_voc.c: In function ‘VOC_decode’:
/home/maarten/projects/SDL_mixer/src/decoder_voc.c:444:74: error: comparison of integer expressions of different signedness: ‘Sint64’ {aka ‘long int’} and ‘Uint64’ {aka ‘long unsigned int’} [-Werror=sign-compare]
  444 |                 if (SDL_SeekIO(tdata->io, block->iopos, SDL_IO_SEEK_SET) != block->iopos) {
      |                                                                          ^~


In file included from /home/maarten/projects/SDL/include/SDL3/SDL.h:34,
                 from /home/maarten/projects/SDL_mixer/test/testaudiodecoder.c:2:
/home/maarten/projects/SDL_mixer/test/testaudiodecoder.c: In function ‘AudioDeviceCallback’:
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:2137:29: error: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘int’ [-Werror=sign-compare]
 2137 | #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
      |                             ^
/home/maarten/projects/SDL_mixer/test/testaudiodecoder.c:19:28: note: in expansion of macro ‘SDL_min’
   19 |         const int needed = SDL_min(sizeof (buffer), additional_amount);
      |                            ^~~~~~~
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:2137:44: error: operand of ‘?:’ changes signedness from ‘int’ to ‘long unsigned int’ due to unsignedness of other operand [-Werror=sign-compare]
 2137 | #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
      |                                            ^~~
/home/maarten/projects/SDL_mixer/test/testaudiodecoder.c:19:28: note: in expansion of macro ‘SDL_min’
   19 |         const int needed = SDL_min(sizeof (buffer), additional_amount);
      |                            ^~~~~~~


/home/maarten/projects/SDL_mixer/src/decoder_timidity.c: In function ‘TIMIDITY_init’:
/home/maarten/projects/SDL_mixer/src/decoder_timidity.c:54:23: error: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Werror=sign-compare]
   54 |     for (int i = 0; i < SDL_arraysize(timidity_cfgs); i++) {
      |                       ^


/home/maarten/projects/SDL_mixer/src/decoder_opus.c: In function ‘OPUS_seek’:
/home/maarten/projects/SDL_mixer/src/decoder_opus.c:310:32: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  310 |     if (loop->active && (frame >= loop->start)) {
      |                                ^~
/home/maarten/projects/SDL_mixer/src/decoder_opus.c:312:41: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  312 |         if ((loop->count < 0) || (frame < (loop->len * loop->count))) {  // literally in the loop right now.
      |                                         ^


/home/maarten/projects/SDL_mixer/src/SDL_mixer_metadata_tags.c: In function ‘ape_handle_tag’:
/home/maarten/projects/SDL_mixer/src/SDL_mixer_metadata_tags.c:601:29: error: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Werror=sign-compare]
  601 |         if ((rc > 0) && (rc < sizeof (generic_key))) {
      |                             ^


/home/maarten/projects/SDL_mixer/src/decoder_stb_vorbis.c: In function ‘STBVORBIS_decode’:
/home/maarten/projects/SDL_mixer/src/decoder_stb_vorbis.c:238:18: error: comparison of integer expressions of different signedness: ‘Uint32’ {aka ‘unsigned int’} and ‘int’ [-Werror=sign-compare]
  238 |         if (skip >= amount) {
      |                  ^~
/home/maarten/projects/SDL_mixer/src/decoder_stb_vorbis.c: In function ‘STBVORBIS_seek’:
/home/maarten/projects/SDL_mixer/src/decoder_stb_vorbis.c:309:32: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  309 |     if (loop->active && (frame >= loop->start)) {
      |                                ^~
/home/maarten/projects/SDL_mixer/src/decoder_stb_vorbis.c:311:41: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  311 |         if ((loop->count < 0) || (frame < (loop->len * loop->count))) {  // literally in the loop right now.
      |                                         ^


/home/maarten/projects/SDL_mixer/src/SDL_mixer.c: In function ‘TrackGetCallback’:
/home/maarten/projects/SDL_mixer/src/SDL_mixer.c:351:27: error: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
  351 |     if (additional_amount > track->input_buffer_len) {
      |                           ^
/home/maarten/projects/SDL_mixer/src/SDL_mixer.c: In function ‘MixerCallback’:
/home/maarten/projects/SDL_mixer/src/SDL_mixer.c:548:20: error: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
  548 |     if (alloc_size > mixer->mix_buffer_allocation) {
      |                    ^


/home/maarten/projects/SDL_mixer/src/decoder_wav.c: In function ‘BuildSeekBlocks’:
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1147:27: error: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Werror=sign-compare]
 1147 |         for (int i = 0; i < numloops; i++) {
      |                           ^
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1165:19: error: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Werror=sign-compare]
 1165 |             if (i < (numloops - 1)) {
      |                   ^
In file included from /home/maarten/projects/SDL/include/SDL3/SDL.h:34,
                 from /home/maarten/projects/SDL_mixer/src/SDL_mixer_internal.h:31,
                 from /home/maarten/projects/SDL_mixer/src/decoder_wav.c:24:
/home/maarten/projects/SDL_mixer/src/decoder_wav.c: In function ‘WAV_decode’:
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:2137:29: error: comparison of integer expressions of different signedness: ‘int’ and ‘Uint64’ {aka ‘long unsigned int’} [-Werror=sign-compare]
 2137 | #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
      |                             ^
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1464:14: note: in expansion of macro ‘SDL_min’
 1464 |     buflen = SDL_min(buflen, available_bytes);
      |              ^~~~~~~
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:2137:38: error: operand of ‘?:’ changes signedness from ‘int’ to ‘Uint64’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Werror=sign-compare]
 2137 | #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
      |                                      ^~~
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1464:14: note: in expansion of macro ‘SDL_min’
 1464 |     buflen = SDL_min(buflen, available_bytes);
      |              ^~~~~~~
/home/maarten/projects/SDL_mixer/src/decoder_wav.c: In function ‘FindWAVSeekBlock’:
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1487:32: error: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Werror=sign-compare]
 1487 |     for (unsigned int i = 0; i < num_seekblocks; i++) {
      |                                ^
In file included from /home/maarten/projects/SDL/include/SDL3/SDL.h:35:
/home/maarten/projects/SDL_mixer/src/decoder_wav.c: In function ‘WAV_seek’:
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1523:66: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
 1523 |     SDL_assert((seekblock->iterations < 0) || (current_iteration < seekblock->iterations));
      |                                                                  ^
/home/maarten/projects/SDL/include/SDL3/SDL_assert.h:397:19: note: in definition of macro ‘SDL_enabled_assert’
  397 |         while ( !(condition) ) { \
      |                   ^~~~~~~~~
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1523:5: note: in expansion of macro ‘SDL_assert’
 1523 |     SDL_assert((seekblock->iterations < 0) || (current_iteration < seekblock->iterations));
      |     ^~~~~~~~~~
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:2137:29: error: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Werror=sign-compare]
 2137 | #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
      |                             ^
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1544:56: note: in expansion of macro ‘SDL_min’
 1544 |             const int br = adata->fetch(tdata, buffer, SDL_min(remainder, sizeof (buffer)));
      |                                                        ^~~~~~~
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:2137:38: error: operand of ‘?:’ changes signedness from ‘int’ to ‘long unsigned int’ due to unsignedness of other operand [-Werror=sign-compare]
 2137 | #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
      |                                      ^~~
/home/maarten/projects/SDL_mixer/src/decoder_wav.c:1544:56: note: in expansion of macro ‘SDL_min’
 1544 |             const int br = adata->fetch(tdata, buffer, SDL_min(remainder, sizeof (buffer)));
      |                                                        ^~~~~~~


/home/maarten/projects/SDL_mixer/src/decoder_drflac.c: In function ‘DRFLAC_init_audio’:
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:179:25: error: comparison of integer expressions of different signedness: ‘Sint64’ {aka ‘long int’} and ‘drflac_uint64’ {aka ‘long long unsigned int’} [-Werror=sign-compare]
  179 |     if (adata->loop.end > decoder->totalPCMFrameCount) {
      |                         ^
In file included from /home/maarten/projects/SDL_mixer/src/SDL_mixer_internal.h:58,
                 from /home/maarten/projects/SDL_mixer/src/decoder_drflac.c:24:
/home/maarten/projects/SDL_mixer/include/SDL3_mixer/SDL_mixer.h:898:31: error: operand of ‘?:’ changes signedness from ‘int’ to ‘long long unsigned int’ due to unsignedness of other operand [-Werror=sign-compare]
  898 | #define MIX_DURATION_INFINITE -2
      |                               ^~
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:186:54: note: in expansion of macro ‘MIX_DURATION_INFINITE’
  186 |         *duration_frames = (adata->loop.count < 0) ? MIX_DURATION_INFINITE : (decoder->totalPCMFrameCount * adata->loop.count);
      |                                                      ^~~~~~~~~~~~~~~~~~~~~
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c: In function ‘DRFLAC_decode’:
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:235:73: error: comparison of integer expressions of different signedness: ‘long long unsigned int’ and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  235 |         if (loop->active && ((tdata->current_iteration_frames + amount) >= loop->start)) {
      |                                                                         ^~
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:245:20: error: comparison of integer expressions of different signedness: ‘drflac_uint64’ {aka ‘long long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  245 |         if (amount > available) {
      |                    ^
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:250:56: error: comparison of integer expressions of different signedness: ‘long long unsigned int’ and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  250 |         if ((tdata->current_iteration_frames + amount) >= loop->len) {  // time to loop?
      |                                                        ^~
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c: In function ‘DRFLAC_seek’:
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:291:32: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  291 |     if (loop->active && (frame >= loop->start)) {
      |                                ^~
/home/maarten/projects/SDL_mixer/src/decoder_drflac.c:293:41: error: comparison of integer expressions of different signedness: ‘Uint64’ {aka ‘long unsigned int’} and ‘Sint64’ {aka ‘long int’} [-Werror=sign-compare]
  293 |         if ((loop->count < 0) || (frame < (loop->len * loop->count))) {  // literally in the loop right now.
      |                                         ^

```

</details>