### PR TITLE
Add ELF dlnotes

### DIFF
--- a/src/decoder_flac.c
+++ b/src/decoder_flac.c
@@ -25,6 +25,15 @@
 
 #include <FLAC/stream_decoder.h>
 
+#if defined(FLAC_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "flac",
+    "Support for FLAC audio using libFLAC",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    FLAC_DYNAMIC
+);
+#endif
+
 #ifdef FLAC_DYNAMIC
 #define MIX_LOADER_DYNAMIC FLAC_DYNAMIC
 #endif

--- a/src/decoder_fluidsynth.c
+++ b/src/decoder_fluidsynth.c
@@ -27,6 +27,15 @@
 
 #include <fluidsynth.h>
 
+#if defined(FLUIDSYNTH_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "midi-fluidsynth",
+    "Support for MIDI audio using FluidSynth",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    FLUIDSYNTH_DYNAMIC
+);
+#endif
+
 #ifdef FLUIDSYNTH_DYNAMIC
 #define MIX_LOADER_DYNAMIC FLUIDSYNTH_DYNAMIC
 #endif

--- a/src/decoder_gme.c
+++ b/src/decoder_gme.c
@@ -25,6 +25,15 @@
 
 #include <gme/gme.h>
 
+#if defined(FLUIDSYNTH_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "gme",
+    "Support for audio of classic video game consoles using game-music-emu",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    GME_DYNAMIC
+);
+#endif
+
 #ifdef GME_DYNAMIC
 #define MIX_LOADER_DYNAMIC GME_DYNAMIC
 #endif

--- a/src/decoder_mpg123.c
+++ b/src/decoder_mpg123.c
@@ -23,6 +23,15 @@
 
 #include "SDL_mixer_internal.h"
 
+#if defined(MPG123_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "mp3",
+    "Support for MP3 audio using mpg123",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    MPG123_DYNAMIC
+);
+#endif
+
 #define MPG123_ENUM_API /* for mpg123_param() */
 #include <stdio.h>  // SEEK_SET
 #include <mpg123.h>

--- a/src/decoder_opus.c
+++ b/src/decoder_opus.c
@@ -27,6 +27,15 @@
 
 #include <opusfile.h>
 
+#if defined(OPUS_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "opus",
+    "Support for OPUS audio using opusfile",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    OPUS_DYNAMIC
+);
+#endif
+
 #ifdef OPUS_DYNAMIC
 #define MIX_LOADER_DYNAMIC OPUS_DYNAMIC
 #endif

--- a/src/decoder_vorbis.c
+++ b/src/decoder_vorbis.c
@@ -34,6 +34,15 @@
 #include <vorbis/vorbisfile.h>
 #endif
 
+#if defined(MPG123_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "vorbis",
+    "Support for VORBIS audio", // vorbisfile or tremor
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    VORBIS_DYNAMIC
+);
+#endif
+
 #ifdef VORBIS_DYNAMIC
 #define MIX_LOADER_DYNAMIC VORBIS_DYNAMIC
 #endif

--- a/src/decoder_wavpack.c
+++ b/src/decoder_wavpack.c
@@ -25,6 +25,15 @@
 
 #include "SDL_mixer_internal.h"
 
+#if defined(WAVPACK_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "wavpack",
+    "Support for WAVPACK audio using WavPack",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    WAVPACK_DYNAMIC
+);
+#endif
+
 #define WAVPACK_DBG 0
 
 // This file supports WavPack music streams

--- a/src/decoder_xmp.c
+++ b/src/decoder_xmp.c
@@ -23,6 +23,15 @@
 
 #include "SDL_mixer_internal.h"
 
+#if defined(XMP_DYNAMIC) && defined(SDL_ELF_NOTE_DLOPEN)
+SDL_ELF_NOTE_DLOPEN(
+    "midi-xmp",
+    "Support for MIDI audio using libxmp",
+    SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+    XMP_DYNAMIC
+);
+#endif
+
 #ifdef LIBXMP_HEADER
 #include LIBXMP_HEADER
 #else


### PR DESCRIPTION
```
$ dlopen-notes.py libSDL3_mixer.so.0  
# libSDL3_mixer.so.0
[
  {
    "feature": "flac",
    "description": "Support for FLAC audio using libFLAC",
    "priority": "suggested",
    "soname": [
      "libFLAC.so.12"
    ]
  },
  {
    "feature": "midi-fluidsynth",
    "description": "Support for MIDI audio using FluidSynth",
    "priority": "suggested",
    "soname": [
      "libfluidsynth.so.3"
    ]
  },
  {
    "feature": "mp3",
    "description": "Support for MP3 audio using mpg123",
    "priority": "suggested",
    "soname": [
      "libmpg123.so.0"
    ]
  },
  {
    "feature": "opus",
    "description": "Support for OPUS audio using opusfile",
    "priority": "suggested",
    "soname": [
      "libopusfile.so.0"
    ]
  },
  {
    "feature": "vorbis",
    "description": "Support for VORBIS audio",
    "priority": "suggested",
    "soname": [
      "libvorbisfile.so.3"
    ]
  },
  {
    "feature": "wavpack",
    "description": "Support for WAVPACK audio using WavPack",
    "priority": "suggested",
    "soname": [
      "libwavpack.so.1"
    ]
  },
  {
    "feature": "midi-xmp",
    "description": "Support for MIDI audio using libxmp",
    "priority": "suggested",
    "soname": [
      "libxmp.so.4"
    ]
  }
]
```