### PR TITLE
Minor Optimization

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -2184,18 +2184,18 @@ bool MIX_PlayTrack(MIX_Track *track, SDL_PropertiesID options)
         loop_start = GetTrackOptionFramesOrTicks(track, options, MIX_PROP_PLAY_LOOP_START_FRAME_NUMBER, MIX_PROP_PLAY_LOOP_START_MILLISECOND_NUMBER, loop_start);
         fade_in = GetTrackOptionFramesOrTicks(track, options, MIX_PROP_PLAY_FADE_IN_FRAMES_NUMBER, MIX_PROP_PLAY_FADE_IN_MILLISECONDS_NUMBER, fade_in);
         append_silence_frames = GetTrackOptionFramesOrTicks(track, options, MIX_PROP_PLAY_APPEND_SILENCE_FRAMES_NUMBER, MIX_PROP_PLAY_APPEND_SILENCE_MILLISECONDS_NUMBER, append_silence_frames);
-    }
 
-    if (start_pos < 0) {
-        start_pos = 0;
-    }
+        if (start_pos < 0) {
+            start_pos = 0;
+        }
 
-    if (loop_start < 0) {
-        loop_start = 0;
-    }
+        if (loop_start < 0) {
+            loop_start = 0;
+        }
 
-    if (append_silence_frames < 0) {
-        append_silence_frames = 0;
+        if (append_silence_frames < 0) {
+            append_silence_frames = 0;
+        }
     }
 
     if (track->input_audio && (!track->input_audio->decoder->seek(track->decoder_userdata, start_pos))) {


### PR DESCRIPTION
Minor optimization for the common case of `options == 0`.

Lines https://github.com/libsdl-org/SDL_mixer/blob/3a1965b6e05a2d5b07dbbfcaacbcb3cca0c66d51/src/SDL_mixer.c#L2175-L2178

ensures that start_pos, loop_start, and append_silence_frames will be zero.

Negative values are only encountered on a non-zero option value.: https://github.com/libsdl-org/SDL_mixer/blob/3a1965b6e05a2d5b07dbbfcaacbcb3cca0c66d51/src/SDL_mixer.c#L2175-L2187