### PR TITLE
Fix config typo

### DIFF
--- a/build-scripts/release-info.json
+++ b/build-scripts/release-info.json
@@ -222,7 +222,7 @@
       ],
       "cmake": [
         "build-scripts/pkg-support/msvc/cmake/SDL3_mixerConfig.cmake.in:SDL3_mixerConfig.cmake",
-        "build-scripts/pkg-support/msvc/cmake/SDL3_mixerConfigVersion.cmake.in:SDL3_mixerConvigVersion.cmake",
+        "build-scripts/pkg-support/msvc/cmake/SDL3_mixerConfigVersion.cmake.in:SDL3_mixerConfigVersion.cmake",
         "cmake/sdlcpu.cmake"
       ],
       "include/SDL3_mixer": [


### PR DESCRIPTION
Small typo in release-info.json caused my CMake build to fail with:

```
Could not find a configuration file for package "SDL3_mixer" that is
  compatible with requested version "3.1.2".

  The following configuration files were considered but not accepted:

    C:/Dev/protegon/external/windows/msvc/SDL3_mixer-3.1.2/cmake/SDL3_mixerConfig.cmake, version: unknown
```