### PR TITLE
Fix typo in 'spatialization'

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ endfunction()
 
 add_sdl_mixer_test_executable(testaudiodecoder testaudiodecoder.c)
 add_sdl_mixer_test_executable(testmixer testmixer.c)
-add_sdl_mixer_test_executable(testspacialization testspatialization.c)
+add_sdl_mixer_test_executable(testspatialization testspatialization.c)
 
 if(SDLMIXER_TESTS_INSTALL)
     install(


### PR DESCRIPTION
Fixes a typo in the test executable name. This is the only such typo.