### PR TITLE
cmake: add SDLMIXER_LIBC option allowing to disable libc usage shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,8 @@ cmake_dependent_option(SDLMIXER_INSTALL "Enable SDL3mixer install target" ${SDLM
 cmake_dependent_option(SDLMIXER_INSTALL_CPACK "Create binary SDL3_mixer archive using CPack" ${SDLMIXER_ROOTPROJECT} "SDLMIXER_INSTALL" OFF)
 cmake_dependent_option(SDLMIXER_INSTALL_MAN "Install man pages for SDL3_mixer" OFF "SDLMIXER_INSTALL" OFF)
 cmake_dependent_option(SDLMIXER_DEPS_SHARED "Load dependencies dynamically" ON PLATFORM_SUPPORTS_SHARED OFF)
-cmake_dependent_option(SDLMIXER_RELOCATABLE "Create relocatable SDL_mixer package" "${MSVC}" SDLMIXER_INSTALL OFF)
+cmake_dependent_option(SDLMIXER_RELOCATABLE "Create relocatable SDL_mixer package" "${MSVC}" "SDLMIXER_INSTALL" OFF)
+cmake_dependent_option(SDLMIXER_LIBC "Use the system C library" ON "BUILD_SHARED_LIBS;SDLMIXER_DEPS_SHARED" ON)
 option(SDLMIXER_VENDORED "Use vendored third-party libraries" ${vendored_default})
 option(SDLMIXER_WERROR "Treat warnings as errors" OFF)
 
@@ -1065,6 +1066,12 @@ if(SDLMIXER_WAVPACK)
             target_link_libraries(${sdl3_mixer_target_name} PRIVATE WavPack::WavPack)
         endif()
     endif()
+endif()
+
+if(NOT SDLMIXER_LIBC)
+  list(APPEND SDLMIXER_BACKENDS LIBC)
+  list(APPEND SDLMIXER_LIBC_ENABLED FALSE)
+  SDL_disable_libc(${sdl3_mixer_target_name})
 endif()
 
 # Restore BUILD_SHARED_LIBS

--- a/VisualC/SDL_mixer.vcxproj
+++ b/VisualC/SDL_mixer.vcxproj
@@ -46,6 +46,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -116,7 +117,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src;$(ProjectDir)..\external\flac\include;$(ProjectDir)..\external\libxmp\include;$(ProjectDir)..\external\ogg\include;$(ProjectDir)..\external\vorbis\include;$(ProjectDir)..\external\libgme;$(ProjectDir)\external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DLL_EXPORT;_DEBUG;WIN32;_WINDOWS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_VORBISFILE;DECODER_OGGVORBIS_STB;VORBIS_DYNAMIC="libvorbisfile-3.dll";DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DLL_EXPORT;_DEBUG;WIN32;_WINDOWS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_STB;DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
@@ -144,7 +145,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src;$(ProjectDir)..\external\flac\include;$(ProjectDir)..\external\libxmp\include;$(ProjectDir)..\external\ogg\include;$(ProjectDir)..\external\vorbis\include;$(ProjectDir)..\external\libgme;$(ProjectDir)\external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DLL_EXPORT;_DEBUG;WIN32;_WINDOWS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_VORBISFILE;DECODER_OGGVORBIS_STB;VORBIS_DYNAMIC="libvorbisfile-3.dll";DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DLL_EXPORT;_DEBUG;WIN32;_WINDOWS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_STB;DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
@@ -170,7 +171,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src;$(ProjectDir)..\external\flac\include;$(ProjectDir)..\external\libxmp\include;$(ProjectDir)..\external\ogg\include;$(ProjectDir)..\external\vorbis\include;$(ProjectDir)..\external\libgme;$(ProjectDir)\external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_VORBISFILE;DECODER_OGGVORBIS_STB;VORBIS_DYNAMIC="libvorbisfile-3.dll";DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_STB;DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
@@ -197,7 +198,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src;$(ProjectDir)..\external\flac\include;$(ProjectDir)..\external\libxmp\include;$(ProjectDir)..\external\ogg\include;$(ProjectDir)..\external\vorbis\include;$(ProjectDir)..\external\libgme;$(ProjectDir)\external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_VORBISFILE;DECODER_OGGVORBIS_STB;VORBIS_DYNAMIC="libvorbisfile-3.dll";DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;DECODER_WAV;DECODER_AIFF;DECODER_VOC;DECODER_AU;DECODER_WAVPACK;DECODER_FLAC_DRFLAC;DECODER_MOD_XMP;XMP_DYNAMIC="libxmp.dll";DECODER_MP3_DRMP3;DECODER_OGGVORBIS_STB;DECODER_OPUS;OPUS_DYNAMIC="libopusfile-0.dll";WAVPACK_DYNAMIC="libwavpack-1.dll";DECODER_MIDI_TIMIDITY;DECODER_GME;GME_DYNAMIC="libgme.dll";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
@@ -443,6 +444,22 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\$(Platform)\$(Configuration)\%(Filename)%(Extension)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\$(Platform)\$(Configuration)\%(Filename)%(Extension)</Outputs>
     </CustomBuild>
+  </ItemGroup>
+  <ItemDefinitionGroup Condition="'$(BuildWithoutCLibrary)'!=''">
+    <ClCompile>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <PreprocessorDefinitions>SDL_SLOW_MEMCPY;SDL_SLOW_MEMMOVE;SDL_SLOW_MEMSET;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/Gs1048576 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup Condition="'$(BuildWithoutCLibrary)'!=''">
+    <ClCompile Include="..\src\nolibc\SDL_mslibc.c" />
+    <MASM Condition="'$(Platform)'=='x64'" Include="..\src\nolibc\SDL_mslibc_x64.masm">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </MASM>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\decoder_aiff.c" />

--- a/VisualC/timidity/timidity.vcxproj
+++ b/VisualC/timidity/timidity.vcxproj
@@ -21,6 +21,13 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemDefinitionGroup Condition="'$(BuildWithoutCLibrary)'!=''">
+    <ClCompile>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <PreprocessorDefinitions>SDL_SLOW_MEMCPY;SDL_SLOW_MEMMOVE;SDL_SLOW_MEMSET;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/Gs1048576 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\timidity\common.c" />
     <ClCompile Include="..\..\src\timidity\instrum.c" />

--- a/build-scripts/build-release.py
+++ b/build-scripts/build-release.py
@@ -175,11 +175,12 @@ class VisualStudio:
         assert msbuild_path.is_file(), "MSBuild.exe does not exist"
         return msbuild_path
 
-    def build(self, arch_platform: VsArchPlatformConfig, projects: list[Path]):
+    def build(self, arch_platform: VsArchPlatformConfig, projects: list[Path], args: list[str]):
         assert projects, "Need at least one project to build"
+        joined_args = shlex.join(args)
 
         vsdev_cmd_str = f"\"{self.vsdevcmd}\" -arch={arch_platform.arch}"
-        msbuild_cmd_str = " && ".join([f"\"{self.msbuild}\" \"{project}\" /m /p:BuildInParallel=true /p:Platform={arch_platform.platform} /p:Configuration={arch_platform.configuration}" for project in projects])
+        msbuild_cmd_str = " && ".join([f"\"{self.msbuild}\" \"{project}\" /m /p:BuildInParallel=true /p:Platform={arch_platform.platform} /p:Configuration={arch_platform.configuration} {joined_args}" for project in projects])
         bat_contents = f"{vsdev_cmd_str} && {msbuild_cmd_str}\n"
         bat_path = Path(tempfile.gettempdir()) / "cmd.bat"
         with bat_path.open("w") as f:
@@ -1238,7 +1239,8 @@ class Releaser:
                 shutil.copy(src=src, dst=dir_b_props)
 
         with self.section_printer.group(f"Build {arch_platform.arch} VS binary"):
-            vs.build(arch_platform=arch_platform, projects=projects)
+            extra_msbuild_args = self.release_info["msvc"]["msbuild"].get("msbuild-arguments", [])
+            vs.build(arch_platform=arch_platform, projects=projects, args=extra_msbuild_args)
 
         if self.dry:
             for b in built_paths:

--- a/build-scripts/release-info.json
+++ b/build-scripts/release-info.json
@@ -57,6 +57,7 @@
         "-DSDLMIXER_RELOCATABLE=ON",
         "-DSDLMIXER_TESTS=OFF",
         "-DSDLMIXER_VENDORED=OFF",
+        "-DSDLMIXER_LIBC=OFF",
         "-DCMAKE_C_FLAGS=-I@<@PROJECT_ROOT@>@/VisualC/external/include",
         "-DSDLMIXER_DYNAMIC_GME=@<@PROJECT_ROOT@>@/VisualC/external/optional/@<@ARCH@>@/libgme.dll",
         "-DSDLMIXER_DYNAMIC_WAVPACK=@<@PROJECT_ROOT@>@/VisualC/external/optional/@<@ARCH@>@/libwavpack-1.dll",
@@ -89,6 +90,9 @@
       "archs": [
         "x86",
         "x64"
+      ],
+      "msbuild-arguments": [
+        "-p:BuildWithoutCLibrary=true"
       ],
       "projects": [
         "VisualC/SDL_mixer.vcxproj"
@@ -142,7 +146,6 @@
         "arm64"
       ],
       "args": [
-        "-DSDLMIXER_SNDFILE=ON",
         "-DSDLMIXER_FLAC=ON",
         "-DSDLMIXER_FLAC_DRFLAC=ON",
         "-DSDLMIXER_FLAC_LIBFLAC=OFF",
@@ -164,6 +167,7 @@
         "-DSDLMIXER_RELOCATABLE=ON",
         "-DSDLMIXER_TESTS=OFF",
         "-DSDLMIXER_DEPS_SHARED=ON",
+        "-DSDLMIXER_LIBC=OFF",
         "-DSDLMIXER_VENDORED=ON"
       ],
       "files-lib": {
@@ -249,7 +253,6 @@
     "cmake": {
       "args": [
         "-DBUILD_SHARED_LIBS=ON",
-        "-DSDLMIXER_SNDFILE=ON",
         "-DSDLMIXER_FLAC=ON",
         "-DSDLMIXER_FLAC_DRFLAC=ON",
         "-DSDLMIXER_FLAC_LIBFLAC=OFF",

--- a/cmake/PrivateSdlFunctions.cmake
+++ b/cmake/PrivateSdlFunctions.cmake
@@ -6,6 +6,7 @@ include(CMakePushCheckState)
 if(NOT CMAKE_VERSION VERSION_LESS "3.18")
   include(CheckLinkerFlag)
 endif()
+include("${CMAKE_CURRENT_LIST_DIR}/sdlcpu.cmake")
 
 macro(sdl_calculate_derived_version_variables MAJOR MINOR MICRO)
     set(SO_VERSION_MAJOR "0")
@@ -313,7 +314,7 @@ endfunction()
 function(sdl_add_warning_options TARGET)
     cmake_parse_arguments(ARGS "" "WARNING_AS_ERROR" "" ${ARGN})
     if(MSVC)
-        target_compile_options(${TARGET} PRIVATE /W2)
+        target_compile_options(${TARGET} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/W2>)
     else()
         target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wno-unused-parameter)
     endif()
@@ -375,3 +376,81 @@ function(SDL_install_pdb TARGET DIRECTORY)
         endif()
     endif()
 endfunction()
+
+macro(SDL_disable_libc TARGET)
+  SDL_DetectTargetCPUArchitectures(SDL_CPUS)
+  # Make sure /RTC1 is disabled, otherwise it will use functions from the CRT
+  foreach(flag_var
+          CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+          CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+          CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
+  endforeach(flag_var)
+  set_property(TARGET ${TARGET} PROPERTY MSVC_RUNTIME_CHECKS "")
+  target_sources(${TARGET} PRIVATE src/nolibc/SDL_mslibc.c)
+  target_compile_definitions(${TARGET} PRIVATE
+    SDL_SLOW_MEMCPY
+    SDL_SLOW_MEMMOVE
+    SDL_SLOW_MEMSET
+  )
+  if(MSVC)
+    if(SDL_CPU_X64)
+      enable_language(ASM_MASM)
+      set(asm_src "${PROJECT_SOURCE_DIR}/src/nolibc/SDL_mslibc_x64.masm")
+      target_compile_options(${TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:ASM_MASM>:/nologo>")
+      set_property(SOURCE "${asm_src}" PROPERTY LANGUAGE "ASM_MASM")
+      target_sources(${TARGET} PRIVATE "${asm_src}")
+    elseif(SDL_CPU_ARM64)
+      enable_language(ASM_MARMASM)
+      set(asm_src "${PROJECT_SOURCE_DIR}/src/nolibc/SDL_mslibc_arm64.masm")
+      target_compile_options(${TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:ASM_MARMASM>:/nologo>")
+      set_property(SOURCE "${asm_src}" PROPERTY LANGUAGE "ASM_MARMASM")
+      target_sources(${TARGET} PRIVATE "${asm_src}")
+    elseif(SDL_CPU_ARM32)
+      # FIXME
+    endif()
+
+    # for VS >= 17.14 targeting ARM64: inline the Interlocked funcs
+    if(MSVC_VERSION GREATER 1943 AND SDL_CPU_ARM64)
+      target_compile_options(${TARGET} PRIVATE "/forceInterlockedFunctions-")
+    endif()
+
+    # Prevent codegen that would use the VC runtime libraries.
+    target_compile_options(${TARGET} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/GS-> $<$<COMPILE_LANGUAGE:C,CXX>:/Gs1048576>)
+    if(SDL_CPU_X86)
+      target_compile_options(${TARGET} PRIVATE "/arch:SSE")
+    endif()
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang|IntelLLVM")
+      # Don't try to link with the default set of libraries.
+      # Note: The clang toolset for Visual Studio does not support /NODEFAULTLIB.
+      target_link_options(${TARGET} PRIVATE "/NODEFAULTLIB")
+      if(SDL_CPU_ARM32)
+        # linking to msvcrt.lib avoid unresolved external symbols
+        # (__rt_sdiv, __rt_udiv, __rt_sdiv64, _rt_udiv64, __dtou64, __u64tod, __i64tos)
+        target_link_libraries(${TARGET} PRIVATE msvcrt.lib)
+      endif()
+      find_library(HAVE_ONECORE_LIB NAMES "onecore.lib")
+      if(HAVE_ONECORE_LIB)
+        # SDL_malloc.c: __imp_MapViewOfFileNuma2 referenced in function MapViewOfFile2
+        target_link_libraries(${TARGET} PRIVATE onecore.lib)
+      endif()
+      find_library(HAVE_VOLATILEACCESSU_LIB NAMES "volatileaccessu.lib")
+      if(HAVE_VOLATILEACCESSU_LIB)
+        # SDL_malloc.c : RtlSetVolatileMemory referenced in function RtlFillVolatileMemory
+        # SDL_malloc.c : RtlFillDeviceMemory referenced in function RtlZeroDeviceMemory
+        target_link_libraries(${TARGET} PRIVATE volatileaccessu.lib)
+      endif()
+      check_c_compiler_flag("/Q_no-use-libirc" HAS_Q_NO_USE_LIBIRC)
+      if(HAS_Q_NO_USE_LIBIRC)
+        target_compile_options(${TARGET} PRIVATE /Q_no-use-libirc)
+      endif()
+    endif()
+  else()
+    target_link_options(${TARGET} PRIVATE -nostdlib)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+      target_link_options(${TARGET} PRIVATE -static-libgcc)
+      target_link_libraries(${TARGET} PRIVATE gcc)
+    endif()
+  endif()
+endmacro()

--- a/src/nolibc/SDL_mslibc.c
+++ b/src/nolibc/SDL_mslibc.c
@@ -1,0 +1,848 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2026 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+// This file contains SDL replacements for functions in the C library
+
+// These are some C runtime intrinsics that need to be defined
+
+#include <SDL3/SDL.h>
+
+#ifdef _MSC_VER
+
+#ifndef __FLTUSED__
+#define __FLTUSED__
+__declspec(selectany) int _fltused = 1;
+#endif
+
+#ifdef _M_IX86
+
+// Float to long
+void __declspec(naked) _ftol()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        ebp
+        mov         ebp,esp
+        sub         esp,20h
+        and         esp,0FFFFFFF0h
+        fld         st(0)
+        fst         dword ptr [esp+18h]
+        fistp       qword ptr [esp+10h]
+        fild        qword ptr [esp+10h]
+        mov         edx,dword ptr [esp+18h]
+        mov         eax,dword ptr [esp+10h]
+        test        eax,eax
+        je          integer_QnaN_or_zero
+arg_is_not_integer_QnaN:
+        fsubp       st(1),st
+        test        edx,edx
+        jns         positive
+        fstp        dword ptr [esp]
+        mov         ecx,dword ptr [esp]
+        xor         ecx,80000000h
+        add         ecx,7FFFFFFFh
+        adc         eax,0
+        mov         edx,dword ptr [esp+14h]
+        adc         edx,0
+        jmp         localexit
+positive:
+        fstp        dword ptr [esp]
+        mov         ecx,dword ptr [esp]
+        add         ecx,7FFFFFFFh
+        sbb         eax,0
+        mov         edx,dword ptr [esp+14h]
+        sbb         edx,0
+        jmp         localexit
+integer_QnaN_or_zero:
+        mov         edx,dword ptr [esp+14h]
+        test        edx,7FFFFFFFh
+        jne         arg_is_not_integer_QnaN
+        fstp        dword ptr [esp+18h]
+        fstp        dword ptr [esp+18h]
+localexit:
+        leave
+        ret
+    }
+    /* *INDENT-ON* */
+}
+
+void _ftol2_sse()
+{
+    _ftol();
+}
+
+void _ftol2()
+{
+    _ftol();
+}
+
+void __declspec(naked) _ftoul2_legacy()
+{
+    static const Uint64 LLONG_MAX_PLUS_ONE = 0x43e0000000000000ULL;
+    /* *INDENT-OFF* */
+    __asm {
+        fld qword ptr [LLONG_MAX_PLUS_ONE]
+        fcom
+        fnstsw ax
+        test ah, 41h
+        jnp greater_than_int64
+
+        fstp st(0)
+        jmp _ftol
+
+greater_than_int64:
+        fsub st(1), st(0)
+        fcomp
+        fnstsw ax
+        test ah, 41h
+        jnz greater_than_uint64
+
+        call _ftol
+        add edx, 80000000h
+        ret
+
+greater_than_uint64:
+        xor eax, eax
+        mov edx, 80000000h
+        ret
+    }
+    /* *INDENT-ON* */
+}
+
+// 64-bit math operators for 32-bit systems
+void __declspec(naked) _allmul()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        mov         eax, dword ptr[esp+8]
+        mov         ecx, dword ptr[esp+10h]
+        or          ecx, eax
+        mov         ecx, dword ptr[esp+0Ch]
+        jne         hard
+        mov         eax, dword ptr[esp+4]
+        mul         ecx
+        ret         10h
+hard:
+        push        ebx
+        mul         ecx
+        mov         ebx, eax
+        mov         eax, dword ptr[esp+8]
+        mul         dword ptr[esp+14h]
+        add         ebx, eax
+        mov         eax, dword ptr[esp+8]
+        mul         ecx
+        add         edx, ebx
+        pop         ebx
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _alldiv()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        edi
+        push        esi
+        push        ebx
+        xor         edi,edi
+        mov         eax,dword ptr [esp+14h]
+        or          eax,eax
+        jge         L1
+        inc         edi
+        mov         edx,dword ptr [esp+10h]
+        neg         eax
+        neg         edx
+        sbb         eax,0
+        mov         dword ptr [esp+14h],eax
+        mov         dword ptr [esp+10h],edx
+L1:
+        mov         eax,dword ptr [esp+1Ch]
+        or          eax,eax
+        jge         L2
+        inc         edi
+        mov         edx,dword ptr [esp+18h]
+        neg         eax
+        neg         edx
+        sbb         eax,0
+        mov         dword ptr [esp+1Ch],eax
+        mov         dword ptr [esp+18h],edx
+L2:
+        or          eax,eax
+        jne         L3
+        mov         ecx,dword ptr [esp+18h]
+        mov         eax,dword ptr [esp+14h]
+        xor         edx,edx
+        div         ecx
+        mov         ebx,eax
+        mov         eax,dword ptr [esp+10h]
+        div         ecx
+        mov         edx,ebx
+        jmp         L4
+L3:
+        mov         ebx,eax
+        mov         ecx,dword ptr [esp+18h]
+        mov         edx,dword ptr [esp+14h]
+        mov         eax,dword ptr [esp+10h]
+L5:
+        shr         ebx,1
+        rcr         ecx,1
+        shr         edx,1
+        rcr         eax,1
+        or          ebx,ebx
+        jne         L5
+        div         ecx
+        mov         esi,eax
+        mul         dword ptr [esp+1Ch]
+        mov         ecx,eax
+        mov         eax,dword ptr [esp+18h]
+        mul         esi
+        add         edx,ecx
+        jb          L6
+        cmp         edx,dword ptr [esp+14h]
+        ja          L6
+        jb          L7
+        cmp         eax,dword ptr [esp+10h]
+        jbe         L7
+L6:
+        dec         esi
+L7:
+        xor         edx,edx
+        mov         eax,esi
+L4:
+        dec         edi
+        jne         L8
+        neg         edx
+        neg         eax
+        sbb         edx,0
+L8:
+        pop         ebx
+        pop         esi
+        pop         edi
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _aulldiv()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        ebx
+        push        esi
+        mov         eax,dword ptr [esp+18h]
+        or          eax,eax
+        jne         L1
+        mov         ecx,dword ptr [esp+14h]
+        mov         eax,dword ptr [esp+10h]
+        xor         edx,edx
+        div         ecx
+        mov         ebx,eax
+        mov         eax,dword ptr [esp+0Ch]
+        div         ecx
+        mov         edx,ebx
+        jmp         L2
+L1:
+        mov         ecx,eax
+        mov         ebx,dword ptr [esp+14h]
+        mov         edx,dword ptr [esp+10h]
+        mov         eax,dword ptr [esp+0Ch]
+L3:
+        shr         ecx,1
+        rcr         ebx,1
+        shr         edx,1
+        rcr         eax,1
+        or          ecx,ecx
+        jne         L3
+        div         ebx
+        mov         esi,eax
+        mul         dword ptr [esp+18h]
+        mov         ecx,eax
+        mov         eax,dword ptr [esp+14h]
+        mul         esi
+        add         edx,ecx
+        jb          L4
+        cmp         edx,dword ptr [esp+10h]
+        ja          L4
+        jb          L5
+        cmp         eax,dword ptr [esp+0Ch]
+        jbe         L5
+L4:
+        dec         esi
+L5:
+        xor         edx,edx
+        mov         eax,esi
+L2:
+        pop         esi
+        pop         ebx
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _allrem()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        ebx
+        push        edi
+        xor         edi,edi
+        mov         eax,dword ptr [esp+10h]
+        or          eax,eax
+        jge         L1
+        inc         edi
+        mov         edx,dword ptr [esp+0Ch]
+        neg         eax
+        neg         edx
+        sbb         eax,0
+        mov         dword ptr [esp+10h],eax
+        mov         dword ptr [esp+0Ch],edx
+L1:
+        mov         eax,dword ptr [esp+18h]
+        or          eax,eax
+        jge         L2
+        mov         edx,dword ptr [esp+14h]
+        neg         eax
+        neg         edx
+        sbb         eax,0
+        mov         dword ptr [esp+18h],eax
+        mov         dword ptr [esp+14h],edx
+L2:
+        or          eax,eax
+        jne         L3
+        mov         ecx,dword ptr [esp+14h]
+        mov         eax,dword ptr [esp+10h]
+        xor         edx,edx
+        div         ecx
+        mov         eax,dword ptr [esp+0Ch]
+        div         ecx
+        mov         eax,edx
+        xor         edx,edx
+        dec         edi
+        jns         L4
+        jmp         L8
+L3:
+        mov         ebx,eax
+        mov         ecx,dword ptr [esp+14h]
+        mov         edx,dword ptr [esp+10h]
+        mov         eax,dword ptr [esp+0Ch]
+L5:
+        shr         ebx,1
+        rcr         ecx,1
+        shr         edx,1
+        rcr         eax,1
+        or          ebx,ebx
+        jne         L5
+        div         ecx
+        mov         ecx,eax
+        mul         dword ptr [esp+18h]
+        xchg        eax,ecx
+        mul         dword ptr [esp+14h]
+        add         edx,ecx
+        jb          L6
+        cmp         edx,dword ptr [esp+10h]
+        ja          L6
+        jb          L7
+        cmp         eax,dword ptr [esp+0Ch]
+        jbe         L7
+L6:
+        sub         eax,dword ptr [esp+14h]
+        sbb         edx,dword ptr [esp+18h]
+L7:
+        sub         eax,dword ptr [esp+0Ch]
+        sbb         edx,dword ptr [esp+10h]
+        dec         edi
+        jns         L8
+L4:
+        neg         edx
+        neg         eax
+        sbb         edx,0
+L8:
+        pop         edi
+        pop         ebx
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _aullrem()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        ebx
+        mov         eax,dword ptr [esp+14h]
+        or          eax,eax
+        jne         L1
+        mov         ecx,dword ptr [esp+10h]
+        mov         eax,dword ptr [esp+0Ch]
+        xor         edx,edx
+        div         ecx
+        mov         eax,dword ptr [esp+8]
+        div         ecx
+        mov         eax,edx
+        xor         edx,edx
+        jmp         L2
+L1:
+        mov         ecx,eax
+        mov         ebx,dword ptr [esp+10h]
+        mov         edx,dword ptr [esp+0Ch]
+        mov         eax,dword ptr [esp+8]
+L3:
+        shr         ecx,1
+        rcr         ebx,1
+        shr         edx,1
+        rcr         eax,1
+        or          ecx,ecx
+        jne         L3
+        div         ebx
+        mov         ecx,eax
+        mul         dword ptr [esp+14h]
+        xchg        eax,ecx
+        mul         dword ptr [esp+10h]
+        add         edx,ecx
+        jb          L4
+        cmp         edx,dword ptr [esp+0Ch]
+        ja          L4
+        jb          L5
+        cmp         eax,dword ptr [esp+8]
+        jbe         L5
+L4:
+        sub         eax,dword ptr [esp+10h]
+        sbb         edx,dword ptr [esp+14h]
+L5:
+        sub         eax,dword ptr [esp+8]
+        sbb         edx,dword ptr [esp+0Ch]
+        neg         edx
+        neg         eax
+        sbb         edx,0
+L2:
+        pop         ebx
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _alldvrm()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        edi
+        push        esi
+        push        ebp
+        xor         edi,edi
+        xor         ebp,ebp
+        mov         eax,dword ptr [esp+14h]
+        or          eax,eax
+        jge         L1
+        inc         edi
+        inc         ebp
+        mov         edx,dword ptr [esp+10h]
+        neg         eax
+        neg         edx
+        sbb         eax,0
+        mov         dword ptr [esp+14h],eax
+        mov         dword ptr [esp+10h],edx
+L1:
+        mov         eax,dword ptr [esp+1Ch]
+        or          eax,eax
+        jge         L2
+        inc         edi
+        mov         edx,dword ptr [esp+18h]
+        neg         eax
+        neg         edx
+        sbb         eax,0
+        mov         dword ptr [esp+1Ch],eax
+        mov         dword ptr [esp+18h],edx
+L2:
+        or          eax,eax
+        jne         L3
+        mov         ecx,dword ptr [esp+18h]
+        mov         eax,dword ptr [esp+14h]
+        xor         edx,edx
+        div         ecx
+        mov         ebx,eax
+        mov         eax,dword ptr [esp+10h]
+        div         ecx
+        mov         esi,eax
+        mov         eax,ebx
+        mul         dword ptr [esp+18h]
+        mov         ecx,eax
+        mov         eax,esi
+        mul         dword ptr [esp+18h]
+        add         edx,ecx
+        jmp         L4
+L3:
+        mov         ebx,eax
+        mov         ecx,dword ptr [esp+18h]
+        mov         edx,dword ptr [esp+14h]
+        mov         eax,dword ptr [esp+10h]
+L5:
+        shr         ebx,1
+        rcr         ecx,1
+        shr         edx,1
+        rcr         eax,1
+        or          ebx,ebx
+        jne         L5
+        div         ecx
+        mov         esi,eax
+        mul         dword ptr [esp+1Ch]
+        mov         ecx,eax
+        mov         eax,dword ptr [esp+18h]
+        mul         esi
+        add         edx,ecx
+        jb          L6
+        cmp         edx,dword ptr [esp+14h]
+        ja          L6
+        jb          L7
+        cmp         eax,dword ptr [esp+10h]
+        jbe         L7
+L6:
+        dec         esi
+        sub         eax,dword ptr [esp+18h]
+        sbb         edx,dword ptr [esp+1Ch]
+L7:
+        xor         ebx,ebx
+L4:
+        sub         eax,dword ptr [esp+10h]
+        sbb         edx,dword ptr [esp+14h]
+        dec         ebp
+        jns         L9
+        neg         edx
+        neg         eax
+        sbb         edx,0
+L9:
+        mov         ecx,edx
+        mov         edx,ebx
+        mov         ebx,ecx
+        mov         ecx,eax
+        mov         eax,esi
+        dec         edi
+        jne         L8
+        neg         edx
+        neg         eax
+        sbb         edx,0
+L8:
+        pop         ebp
+        pop         esi
+        pop         edi
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _aulldvrm()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        esi
+        mov         eax,dword ptr [esp+14h]
+        or          eax,eax
+        jne         L1
+        mov         ecx,dword ptr [esp+10h]
+        mov         eax,dword ptr [esp+0Ch]
+        xor         edx,edx
+        div         ecx
+        mov         ebx,eax
+        mov         eax,dword ptr [esp+8]
+        div         ecx
+        mov         esi,eax
+        mov         eax,ebx
+        mul         dword ptr [esp+10h]
+        mov         ecx,eax
+        mov         eax,esi
+        mul         dword ptr [esp+10h]
+        add         edx,ecx
+        jmp         L2
+L1:
+        mov         ecx,eax
+        mov         ebx,dword ptr [esp+10h]
+        mov         edx,dword ptr [esp+0Ch]
+        mov         eax,dword ptr [esp+8]
+L3:
+        shr         ecx,1
+        rcr         ebx,1
+        shr         edx,1
+        rcr         eax,1
+        or          ecx,ecx
+        jne         L3
+        div         ebx
+        mov         esi,eax
+        mul         dword ptr [esp+14h]
+        mov         ecx,eax
+        mov         eax,dword ptr [esp+10h]
+        mul         esi
+        add         edx,ecx
+        jb          L4
+        cmp         edx,dword ptr [esp+0Ch]
+        ja          L4
+        jb          L5
+        cmp         eax,dword ptr [esp+8]
+        jbe         L5
+L4:
+        dec         esi
+        sub         eax,dword ptr [esp+10h]
+        sbb         edx,dword ptr [esp+14h]
+L5:
+        xor         ebx,ebx
+L2:
+        sub         eax,dword ptr [esp+8]
+        sbb         edx,dword ptr [esp+0Ch]
+        neg         edx
+        neg         eax
+        sbb         edx,0
+        mov         ecx,edx
+        mov         edx,ebx
+        mov         ebx,ecx
+        mov         ecx,eax
+        mov         eax,esi
+        pop         esi
+        ret         10h
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _allshl()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        cmp         cl,40h
+        jae         RETZERO
+        cmp         cl,20h
+        jae         MORE32
+        shld        edx,eax,cl
+        shl         eax,cl
+        ret
+MORE32:
+        mov         edx,eax
+        xor         eax,eax
+        and         cl,1Fh
+        shl         edx,cl
+        ret
+RETZERO:
+        xor         eax,eax
+        xor         edx,edx
+        ret
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _allshr()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        cmp         cl,3Fh
+        jae         RETSIGN
+        cmp         cl,20h
+        jae         MORE32
+        shrd        eax,edx,cl
+        sar         edx,cl
+        ret
+MORE32:
+        mov         eax,edx
+        sar         edx,1Fh
+        and         cl,1Fh
+        sar         eax,cl
+        ret
+RETSIGN:
+        sar         edx,1Fh
+        mov         eax,edx
+        ret
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _aullshr()
+{
+    /* *INDENT-OFF* */
+    __asm {
+        cmp         cl,40h
+        jae         RETZERO
+        cmp         cl,20h
+        jae         MORE32
+        shrd        eax,edx,cl
+        shr         edx,cl
+        ret
+MORE32:
+        mov         eax,edx
+        xor         edx,edx
+        and         cl,1Fh
+        shr         eax,cl
+        ret
+RETZERO:
+        xor         eax,eax
+        xor         edx,edx
+        ret
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _chkstk(void)
+{
+    __asm {
+        push        ecx
+        mov         ecx,esp     ; lea         ecx,dword ptr [esp]+4
+        add         ecx,4
+        sub         ecx,eax
+        sbb         eax,eax
+        not         eax
+        and         ecx,eax
+        mov         eax,esp
+        and         eax,0xfffff000
+L1:
+        cmp         ecx,eax
+        jb          short L2
+        mov         eax,ecx
+        pop         ecx
+        xchg        esp,eax
+        mov         eax,dword ptr [eax]
+        mov         dword ptr [esp],eax
+        ret
+L2:
+        sub         eax,0x1000
+        test        dword ptr [eax],eax
+        jmp         short L1
+    }
+}
+
+void __declspec(naked) _alloca_probe_8(void)
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        ecx
+        mov         ecx,esp     ; lea         ecx,dword ptr [esp]+8
+        add         ecx,8
+        sub         ecx,eax
+        and         ecx,0x7
+        add         eax,ecx
+        sbb         ecx,ecx
+        or          eax,ecx
+        pop         ecx
+        jmp         _chkstk
+    }
+    /* *INDENT-ON* */
+}
+
+void __declspec(naked) _alloca_probe_16(void)
+{
+    /* *INDENT-OFF* */
+    __asm {
+        push        ecx
+        mov         ecx,esp     ; lea         ecx,dword ptr [esp]+8
+        add         ecx,8
+        sub         ecx,eax
+        and         ecx,0xf
+        add         eax,ecx
+        sbb         ecx,ecx
+        or          eax,ecx
+        pop         ecx
+        jmp         _chkstk
+    }
+    /* *INDENT-ON* */
+}
+
+#endif // _M_IX86
+
+#endif // MSC_VER
+
+#ifdef __ICL
+/* The classic Intel compiler generates calls to _intel_fast_memcpy
+ * and _intel_fast_memset when building an optimized SDL library */
+void *_intel_fast_memcpy(void *dst, const void *src, size_t len)
+{
+    return SDL_memcpy(dst, src, len);
+}
+void *_intel_fast_memset(void *dst, int c, size_t len)
+{
+    return SDL_memset(dst, c, len);
+}
+#endif
+
+#ifdef SDL_PLATFORM_WIN32
+
+#include <windows.h>
+
+// See https://github.com/libsdl-org/SDL/pull/7607
+// force_align_arg_pointer attribute requires gcc >= 4.2.x.
+#if defined(__clang__)
+#define HAVE_FORCE_ALIGN_ARG_POINTER
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
+#define HAVE_FORCE_ALIGN_ARG_POINTER
+#endif
+#if defined(__GNUC__) && defined(__i386__) && defined(HAVE_FORCE_ALIGN_ARG_POINTER)
+#define MINGW32_FORCEALIGN __attribute__((force_align_arg_pointer))
+#else
+#define MINGW32_FORCEALIGN
+#endif
+
+#ifdef _MSC_VER
+#define DLLMAINCRTSTARTUP _DllMainCRTStartup
+#else
+#define DLLMAINCRTSTARTUP DllMainCRTStartup
+#endif
+
+
+BOOL APIENTRY MINGW32_FORCEALIGN DLLMAINCRTSTARTUP(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+#endif // defined(SDL_PLATFORM_WIN32)
+
+extern void *memcpy(void *dst, const void *src, size_t len);
+#if defined(_MSC_VER) && !defined(__INTEL_LLVM_COMPILER)
+#pragma intrinsic(memcpy)
+#pragma intrinsic(memmove)
+#pragma intrinsic(memset)
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma function(memcpy)
+#endif
+// NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name)
+void *memcpy(void *dst, const void *src, size_t len)
+{
+    return SDL_memcpy(dst, src, len);
+}
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma function(memmove)
+#endif
+// NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name)
+void *memmove(void *dst, const void *src, size_t len)
+{
+    return SDL_memmove(dst, src, len);
+}
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma function(memset)
+#endif
+// NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name)
+void *memset(void *dst, int c, size_t len)
+{
+    return SDL_memset(dst, c, len);
+}

--- a/src/nolibc/SDL_mslibc_arm64.masm
+++ b/src/nolibc/SDL_mslibc_arm64.masm
@@ -1,0 +1,26 @@
+TeStackLimit EQU 0x00010
+PAGE_SIZE equ 0x1000
+
+    AREA CODE, READONLY
+
+    EXPORT __chkstk
+
+__chkstk PROC
+    ldr                          x17,[x18, #TeStackLimit]
+    subs                         x16,sp,x15, LSL  #0x4
+    csel                         x16,xzr,x16,cc
+    cmp                          x16,x17
+    b.cc                         chkstk_start_loop
+    ret
+chkstk_start_loop
+    and                          x16,x16,#-PAGE_SIZE
+chkstk_loop
+    sub                          x17,x17,#0x1, LSL #12
+    ldr                          xzr,[x17]
+    cmp                          x17,x16
+    b.ne                         chkstk_loop
+    ret
+
+    ENDP
+
+    END

--- a/src/nolibc/SDL_mslibc_x64.masm
+++ b/src/nolibc/SDL_mslibc_x64.masm
@@ -1,0 +1,29 @@
+include ksamd64.inc
+
+text        SEGMENT EXECUTE
+
+public      __chkstk
+
+__chkstk:
+    sub         rsp,010h
+    mov         QWORD PTR [rsp],r10
+    mov         QWORD PTR [rsp+08h],r11
+    xor         r11,r11
+    lea         r10,[rsp+018h]
+    sub         r10,rax
+    cmovb       r10,r11
+    mov         r11,QWORD PTR gs:[TeStackLimit]
+    cmp         r10,r11
+    jae         chkstk_finish
+    and         r10w,0f000h
+chkstk_loop:
+    lea         r11,[r11-PAGE_SIZE]
+    mov         BYTE PTR [r11],0h
+    cmp         r10,r11
+    jne         chkstk_loop
+chkstk_finish:
+    mov         r10,QWORD PTR [rsp]
+    mov         r11,QWORD PTR [rsp+08h]
+    add         rsp,010h
+    ret
+end


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

By configuring with `-DSDLMIXER_LIBC=OFF`, you can build a SDL3_mixer shared library that does not use the c library.
I tested it using a MSVC and gcc linux toolchain.

It does not work for mingw at the moment because of a missing implementation for: `__chkstk_ms`, `__umoddi3`, `__udivdi3`, `__divmoddi4` for i686 and x86_64 (and maybe additional symbols)