### PR TITLE
[SDL2] cmake: Avoid misleading messages when smoke-testing library

### DIFF
--- a/cmake/test/main.c
+++ b/cmake/test/main.c
@@ -9,8 +9,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "SDL_Init: could not initialize SDL: %s\n", SDL_GetError());
         return 1;
     }
-    if (Mix_Init(0) == 0) {
-        fprintf(stderr, "Mix_Init: no sound/music loaders supported (%s)\n", Mix_GetError());
+    if (Mix_Init(MIX_INIT_OGG) & MIX_INIT_OGG) {
+        fprintf(stderr, "Mix_Init: Ogg Vorbis supported\n");
+    } else {
+        fprintf(stderr, "Mix_Init: Ogg Vorbis not supported (%s)\n", Mix_GetError());
     }
     Mix_Quit();
     SDL_Quit();


### PR DESCRIPTION
* cmake: Avoid misleading messages when smoke-testing library
    
    `Mix_Init(0)` doesn't attempt to initialize anything, so it's legitimate
    for it to return 0, and if it does, the error indicator won't be set,
    potentially leaving it with an unrelated (and benign) error message. Use
    a somewhat more realistic startup pattern: ask for an audio format that
    in practice is usually supported, and see whether it is.
    
    (If SDL_mixer is compiled without Ogg Vorbis support, that isn't an
    error, and this test will still succeed.)

---

Please cherry-pick to 2.8.x if accepted. This change is unnecessary for SDL3, which has an API change where `MIX_Init(void)` attempts to initialize all decoders that were supported at compile-time, without the user needing to specify which ones are potentially interesting.

- [x] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").