### PR TITLE
Set MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN to true by default

### DIFF
--- a/include/SDL3_mixer/SDL_mixer.h
+++ b/include/SDL3_mixer/SDL_mixer.h
@@ -765,7 +765,7 @@ extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_LoadAudioNoCopy(MIX_Mixer *mixer, co
  *   the audio data specifying loop points. This will make a file decode from
  *   start to finish without looping, even if the file specified it should
  *   have. This audio can still be looped at playback time via MIX_Track loop
- *   settings, regardless of this setting. Default false.
+ *   settings, regardless of this setting. Default true.
  * - `MIX_PROP_AUDIO_DECODER_STRING`: the name of the decoder to use for this
  *   data. Optional. If not specified, SDL_mixer will examine the data and
  *   choose the best decoder. These names are the same returned from

--- a/src/decoder_drflac.c
+++ b/src/decoder_drflac.c
@@ -176,7 +176,7 @@ static bool SDLCALL DRFLAC_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SDL
 
     adata->framesize = SDL_AUDIO_FRAMESIZE(*spec);
 
-    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, false);
+    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, true);
     if (ignore_loops || (adata->loop.end > (Sint64)decoder->totalPCMFrameCount)) {
         adata->loop.active = false;
     }

--- a/src/decoder_flac.c
+++ b/src/decoder_flac.c
@@ -376,7 +376,7 @@ static bool SDLCALL FLAC_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SDL_P
 
     SDL_copyp(spec, &tdata.spec);
 
-    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, false);
+    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, true);
     if (ignore_loops || (adata->loop.end > total_frames)) {
         adata->loop.active = false;
     }

--- a/src/decoder_opus.c
+++ b/src/decoder_opus.c
@@ -179,7 +179,7 @@ static bool SDLCALL OPUS_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SDL_P
     opus.op_raw_seek(of, 0);  // !!! FIXME: it's not clear if this seek is necessary, but https://stackoverflow.com/a/72482773 suggests it might be, at least on older libvorbisfile releases...
     const Sint64 full_length = (Sint64) opus.op_pcm_total(of, -1);
 
-    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, false);
+    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, true);
     if (ignore_loops || (adata->loop.end > full_length)) {
         adata->loop.active = false;
     }

--- a/src/decoder_voc.c
+++ b/src/decoder_voc.c
@@ -106,7 +106,7 @@ static VOC_Block *AddVocLoopBlock(VOC_AudioData *adata, int loop_count)
 // this runs during VOC_audio_init to walk the whole .VOC for metadata and sanity checks.
 static bool ParseVocFile(SDL_IOStream *io, VOC_AudioData *adata, SDL_PropertiesID props, SDL_AudioSpec *spec, Sint64 *duration_frames)
 {
-    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, false);
+    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, true);
     Sint64 total_frames = 0;
     VOC_Block *loop_start = NULL;
     int loop_start_loop_count = 0;
@@ -477,7 +477,7 @@ static bool SDLCALL VOC_decode(void *userdata, SDL_AudioStream *stream)
             return true;  // try again on new block.
         }
     }
-            
+
     // still here? Feed data.
     SDL_assert(tdata->frame_pos <= block->frames);
     const Uint64 available = block->frames - tdata->frame_pos;

--- a/src/decoder_vorbis.c
+++ b/src/decoder_vorbis.c
@@ -217,7 +217,7 @@ static bool SDLCALL VORBIS_init_audio(SDL_IOStream *io, SDL_AudioSpec *spec, SDL
     vorbis.ov_raw_seek(&vf, 0);  // !!! FIXME: it's not clear if this seek is necessary, but https://stackoverflow.com/a/72482773 suggests it might be, at least on older libvorbisfile releases...
     const Sint64 full_length = (Sint64) vorbis.ov_pcm_total(&vf, -1);
 
-    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, false);
+    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, true);
     if (ignore_loops || (adata->loop.end > full_length)) {
         adata->loop.active = false;
     }

--- a/src/decoder_wav.c
+++ b/src/decoder_wav.c
@@ -1242,7 +1242,7 @@ static bool BuildSeekBlocks(WAV_AudioData *adata)
 
 static bool WAV_init_audio_internal(WAV_AudioData *adata, SDL_IOStream *io, SDL_AudioSpec *spec, SDL_PropertiesID props)
 {
-    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, false);
+    const bool ignore_loops = SDL_GetBooleanProperty(props, MIX_PROP_AUDIO_LOAD_IGNORE_LOOPS_BOOLEAN, true);
     Sint64 flen = SDL_GetIOSize(io);
     bool found_FMT = false;
     bool found_DATA = false;


### PR DESCRIPTION
I'm suggesting this change, because it recreates the old behavior that SDL2_mixer had. I doubt users will expect their audio to loop forever without telling SDL to do so. I also don't know of any media players that listen to this metadata and loops the audio. In short, I don't think the change made benefits users and this PR goes back to the old behavior.

- [x] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

