### PR TITLE
Add vendored FluidSynth support to CMake 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = external/libgme
 	url = https://github.com/libsdl-org/game-music-emu.git
 	branch = v0.6.4-SDL
+[submodule "external/fluidsynth"]
+	path = external/fluidsynth
+	url = https://github.com/libsdl-org/fluidsynth.git
+	branch = v2.5.7-SDL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ cmake_dependent_option(SDLMIXER_MP3_MPG123_SHARED "Dynamically load mpg123" "${S
 
 option(SDLMIXER_MIDI "Enable MIDI audio" ON)
 
-cmake_dependent_option(SDLMIXER_MIDI_FLUIDSYNTH "Support FluidSynth MIDI output" ON "SDLMIXER_MIDI;NOT SDLMIXER_VENDORED" OFF)
+cmake_dependent_option(SDLMIXER_MIDI_FLUIDSYNTH "Support FluidSynth MIDI output" ON SDLMIXER_MIDI OFF)
 cmake_dependent_option(SDLMIXER_MIDI_FLUIDSYNTH_SHARED "Dynamically load libfluidsynth" "${SDLMIXER_DEPS_SHARED}" SDLMIXER_MIDI_FLUIDSYNTH OFF)
 
 cmake_dependent_option(SDLMIXER_MIDI_TIMIDITY "Support timidity MIDI output" ON SDLMIXER_MIDI OFF)
@@ -913,9 +913,31 @@ list(APPEND SDLMIXER_BACKENDS MIDI_FLUIDSYNTH)
 set(SDLMIXER_MIDI_FLUIDSYNTH_ENABLED FALSE)
 if(SDLMIXER_MIDI_FLUIDSYNTH)
     if(SDLMIXER_VENDORED)
-        message(STATUS "Using vendored FluidSynth")
-        message(${fatal_error} "FluidSynth is not vendored.")
-        set(SDLMIXER_MIDI_FLUIDSYNTH_ENABLED FALSE)
+        set(SDLMIXER_MIDI_FLUIDSYNTH_ENABLED TRUE)
+        message(STATUS "Using vendored fluidsynth")
+        sdl_check_project_in_subfolder(external/fluidsynth fluidsynth SDLMIXER_VENDORED)
+        set(disabled_opts enable-alsa  enable-aufile enable-dbus enable-ipv6 enable-jack enable-ladspa
+          enable-libinstpatch enable-libsndfile enable-midishare enable-opensles enable-oboe enable-network
+          enable-oss enable-dsound enable-wasapi enable-waveout enable-winmidi enable-sdl3 enable-pulseaudio
+          enable-pipewire enable-readline enable-threads enable-openmp enable-unicode enable-native enable-signalsmith
+          enable-framework enable-systemd enable-coreaudio enable-coremidi enable-dart enable-kai)
+        foreach(opt ${disabled_opts})
+          set(${opt} FALSE CACHE BOOL "FluidSynth ${opt} option")
+        endforeach()
+        enable_language(CXX)
+        set(osal "cpp11" CACHE STRING "FluidSynth OS Abstraction layer")
+        set(BUILD_SHARED_LIBS "${SDLMIXER_MIDI_FLUIDSYNTH_SHARED}")
+        add_subdirectory(external/fluidsynth external/fluidsynth-build EXCLUDE_FROM_ALL)
+        register_license(fluidsynth external/fluidsynth/LICENSE)
+        if(NOT TARGET FluidSynth::libfluidsynth)
+            add_library(FluidSynth::libfluidsynth ALIAS libfluidsynth)
+        endif()
+        if(SDLMIXER_MIDI_FLUIDSYNTH_SHARED OR NOT SDLMIXER_BUILD_SHARED_LIBS)
+            list(APPEND INSTALL_EXTRA_TARGETS libfluidsynth)
+        endif()
+        if(NOT SDLMIXER_MIDI_FLUIDSYNTH_SHARED)
+            list(APPEND PC_LIBS -l$<TARGET_FILE_BASE_NAME:FluidSynth::libfluidsynth>)
+        endif()
     elseif(SDLMIXER_MIDI_FLUIDSYNTH_SHARED AND DEFINED SDLMIXER_DYNAMIC_MIDI_FLUIDSYNTH AND EXISTS "${SDLMIXER_DYNAMIC_MIDI_FLUIDSYNTH}")
         message(STATUS "${PROJECT_NAME}: Using FluidSynth from CMake variable")
         set(SDLMIXER_MIDI_FLUIDSYNTH_ENABLED TRUE)
@@ -1173,10 +1195,11 @@ if(SDLMIXER_INSTALL)
 
     string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
     string(JOIN " " PC_LIBS ${PC_LIBS})
-    configure_file(cmake/sdl3-mixer.pc.in sdl3-mixer.pc @ONLY)
+    configure_file(cmake/sdl3-mixer.pc.in sdl3-mixer.pc.pre-config @ONLY)
+    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/sdl3-mixer-$<CONFIG>.pc" INPUT "${CMAKE_CURRENT_BINARY_DIR}/sdl3-mixer.pc.pre-config")
 
     # Always install sdl3-mixer.pc file: libraries might be different between config modes
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl3-mixer.pc"
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl3-mixer-$<CONFIG>.pc" RENAME "sdl3-mixer.pc"
         DESTINATION "${SDLMIXER_PKGCONFIG_INSTALLDIR}" COMPONENT devel)
 
     install(FILES "LICENSE.txt"

--- a/cmake/SDL3_mixerConfig.cmake.in
+++ b/cmake/SDL3_mixerConfig.cmake.in
@@ -53,7 +53,7 @@ set(SDL3_mixer_SDL3_mixer-static FALSE)
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_mixer-static-targets.cmake")
 
     if(SDLMIXER_VENDORED)
-        if(SDLMIXER_GME)
+        if(SDLMIXER_MIDI_FLUIDSYNTH OR SDLMIXER_GME)
             include(CheckLanguage)
             check_language(CXX)
             if(NOT CMAKE_CXX_COMPILER)


### PR DESCRIPTION
I'm using the latest FluidSynth release with one additional patch ([see pr](https://github.com/FluidSynth/fluidsynth/pull/1810)).

The libsdl-org vendored FluidSynth fork lives at https://github.com/libsdl-org/fluidsynth


- [x] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").


@sezero Can you set up periodical syncing between the FluidSynth/fluidsynth repo and our fork?

Addresses #878