### PR TITLE
MIX_CreateTrack(): Set MIX_Track alignment to 16 instead of SDL_GetSIMDAlignment()

### DIFF
--- a/src/SDL_mixer_internal.h
+++ b/src/SDL_mixer_internal.h
@@ -137,7 +137,7 @@ struct MIX_Audio
 
 struct MIX_Track
 {
-    float SDL_ALIGNED(16) position3d[4];   // we only need the X, Y, and Z coords, but the 4th element makes this SIMD-friendly.
+    float position3d[4];   // we only need the X, Y, and Z coords, but the 4th element makes this SIMD-friendly.
     MIX_SpatializationMode spatialization_mode;
     float spatialization_panning[2];
     int spatialization_speakers[2];

--- a/src/SDL_mixer_spatialization.c
+++ b/src/SDL_mixer_spatialization.c
@@ -410,7 +410,7 @@ void MIX_Spatialize(const MIX_VBAP2D *vbap2d, const float *position, float *pann
 {
     const int output_channels = vbap2d->speaker_count;
 
-    SDL_assert( (((size_t) position) % 16) == 0 );  // must be aligned for SIMD access.
+    SDL_assert( (((size_t) position) % SDL_GetSIMDAlignment()) == 0 );  // must be aligned for SIMD access.
     SDL_assert(output_channels > 0);
 
     float gain, radians;


### PR DESCRIPTION
Fixes #885

- [x] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

