### PR TITLE
timidity: fix S32 and F32 output:

### DIFF
--- a/src/timidity/output.c
+++ b/src/timidity/output.c
@@ -75,7 +75,7 @@ void timi_s32tof32(void *dp, Sint32 *lp, Sint32 c)
   float *sp=(float *)(dp);
   while (c--)
     {
-      *sp++ = (float)(*lp++) / 2147483647.0f;
+      *sp++ = (float)(*lp++) / (float)(1<<(32 - GUARD_BITS - 1));
     }
 }
 
@@ -84,7 +84,7 @@ void timi_s32tof32x(void* dp, Sint32* lp, Sint32 c)
     float* sp = (float*)(dp);
     while (c--)
     {
-        *sp++ = SDL_SwapFloat((float)(*lp++) / 2147483647.0f);
+        *sp++ = SDL_SwapFloat((float)(*lp++) / (float)(1<<(32 - GUARD_BITS - 1)));
     }
 }
 
@@ -93,7 +93,7 @@ void timi_s32tos32(void *dp, Sint32 *lp, Sint32 c)
   Sint32 *sp=(Sint32 *)(dp);
   while (c--)
     {
-      *sp++ = (*lp++);
+      *sp++ = (*lp++)<<GUARD_BITS;
     }
 }
 
@@ -102,6 +102,6 @@ void timi_s32tos32x(void *dp, Sint32 *lp, Sint32 c)
   Sint32 *sp=(Sint32 *)(dp);
   while (c--)
     {
-      *sp++ = SDL_Swap32(*lp++);
+      *sp++ = SDL_Swap32((*lp++)<<GUARD_BITS);
     }
 }


### PR DESCRIPTION
timidity internal output isn't full-width 32 bits: GUARD_BITS should be taken into account.

Reference issue: https://github.com/icculus/SDL_sound/issues/128 .

- [x] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

