### PR TITLE
stb_vorbis: zero-entry codebook support.

### DIFF
--- a/src/stb_vorbis/stb_vorbis.h
+++ b/src/stb_vorbis/stb_vorbis.h
@@ -35,7 +35,7 @@
 //    github:audinowho   Dougall Johnson     David Reid
 //    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
 //    AnthoFoxo          github:morlat       Gabriel Ravier
-//    Alice Rowan
+//    Alejandro González Alice Rowan
 //
 // Partial history:
 //    1.22    - 2021-07-11 - various small fixes
@@ -1042,7 +1042,7 @@ static void *setup_temp_malloc(vorb *f, uint64 siz)
       f->temp_offset -= sz;
       return (char *) f->alloc.alloc_buffer + f->temp_offset;
    }
-   return malloc(sz);
+   return sz ? malloc(sz) : NULL;
 }
 
 static void setup_temp_free(vorb *f, void **_p, uint64 sz)
@@ -3890,7 +3890,7 @@ static int start_decoder(vorb *f)
       uint32 *values;
       int ordered, sorted_count;
       int total=0;
-      uint8 *lengths;
+      uint8 *lengths=NULL;
       Codebook *c = f->codebooks+i;
       CHECK(f);
       x = get_bits(f, 8); if (x != 0x42)            return error(f, VORBIS_invalid_setup);
@@ -3907,13 +3907,15 @@ static int start_decoder(vorb *f)
       if (c->dimensions == 0 && c->entries != 0)    return error(f, VORBIS_invalid_setup);
       if (f->valid_bits < 0)                        return error(f, VORBIS_unexpected_eof);
 
-      if (c->sparse) {
-         lengths = (uint8 *) setup_temp_malloc(f, c->entries);
-         f->temp_lengths = lengths;
-      } else
-         lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+      if (c->entries > 0) {
+        if (c->sparse) {
+           lengths = (uint8 *) setup_temp_malloc(f, c->entries);
+           f->temp_lengths = lengths;
+        } else
+           lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
 
-      if (!lengths) return error(f, VORBIS_outofmem);
+        if (!lengths) return error(f, VORBIS_outofmem);
+      }
 
       if (ordered) {
          int current_entry = 0;
@@ -3947,11 +3949,13 @@ static int start_decoder(vorb *f)
          if (c->entries > (int) f->setup_temp_memory_required)
             f->setup_temp_memory_required = c->entries;
 
-         c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
-         if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
-         memcpy(c->codeword_lengths, lengths, c->entries);
-         setup_temp_free(f, &f->temp_lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
-         lengths = c->codeword_lengths;
+         if (c->entries > 0) {
+           c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+           if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
+           memcpy(c->codeword_lengths, lengths, c->entries);
+           setup_temp_free(f, &f->temp_lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
+           lengths = c->codeword_lengths;
+         }
          c->sparse = 0;
       }
 
@@ -3971,7 +3975,7 @@ static int start_decoder(vorb *f)
       values = NULL;
 
       CHECK(f);
-      if (!c->sparse) {
+      if (!c->sparse && c->entries > 0) {
          c->codewords = (uint32 *) setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
          if (!c->codewords)                  return error(f, VORBIS_outofmem);
       } else {


### PR DESCRIPTION
Mainstream pull request: https://github.com/nothings/stb/pull/1990

Authored by: Alejandro González

@icculus, @slouken: Please review. If this is good and if we do accept this,
then I'll cherry-pick to all branches and also apply to SDL_sound.

( /cc @AliceLR for an additional pair of eyes and pıssisble adoption into
libxmp. )

( /cc @AlexTMjugador as the original author. )

Relevant parts of original commit message by the author is as follows.

```
Vorbis I specification [1] defines how to read and use codebooks with
several entries encoded in the setup header, and it also describes the
expected decoder behavior for the edge case of single-entry codebooks.
However, codebooks without entries are not clearly addressed.

It is my interpretation of the specification that zero-entry codebooks
are not forbidden, and are therefore allowed, provided that no bound on
the codebook entry count is violated by its use for residue or vector
decoding and, obviously, that the codebook is not actually used in any
audio packet.

While no Vorbis encoder I know of generates streams with zero-entry
codebooks, my OptiVorbis project recently added unused codebook entry
truncation support [2], which I verified to work successfully with the
reference libvorbis decoder. However, after that change had circulated
for a while, people began encountering issues playing files containing
such codebooks with both stb_vorbis and JOrbis.

The changes proposed here skip the problematic allocations during setup
header decoding when there are no entries, which have been tested to
allow stb_vorbis to work with several files containing zero-entry
codebooks.

[1] https://xiph.org/vorbis/doc/Vorbis_I_spec.html
[2] https://github.com/OptiVorbis/OptiVorbis/pull/187
```

- [ ] I confirm that I am the author of this code and release it to the SDL_mixer project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

